### PR TITLE
Fix webpack sass config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,6 @@ var common = {
 						}
 					}
 				],
-				include: path.resolve(__dirname, 'app/')
 			},
 			{
 				test: /\.css$/,


### PR DESCRIPTION
* The sass rule had an include option with a path not existing in this
  repo. I believe we want to include from the root, so I removed the
  qualifier entirely.