### PR TITLE
Amend include path in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ var common = {
 					}
 				],
 				include: [
-					path.join(__dirname, '/core/static/js'),
+					path.join(__dirname, '/common/static/js'),
 				],
 			},
 			{


### PR DESCRIPTION
* The include path was "core" instead of "common", thus the slidingnav
  import wasn't being run through babel-loader, so its output was ES6+
  instead of ES5, which caused uglify to trip (uglify only supports ES5,
  post-babel transpilation).