### PR TITLE
Fix broken developer docker workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ devops/roles
 
 # Functional tests
 geckodriver.log
+
+# pip+docker install artifacts
+src/

--- a/devops/DockerConfigs/Dev-Python
+++ b/devops/DockerConfigs/Dev-Python
@@ -1,0 +1,9 @@
+FROM python:3.4-slim
+
+LABEL maintainer="Freedom of the Press Foundation"
+
+RUN apt-get update &&\
+    apt-get install --no-install-recommends git -y &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/* &&\
+    rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
+    rm -rf /usr/share/locale

--- a/devops/localdev/docker-config.yml
+++ b/devops/localdev/docker-config.yml
@@ -34,7 +34,7 @@
     - name: Start Django server
       docker_container:
         name: django
-        image: python:3.4-slim
+        image: quay.io/freedomofpress/ci-python
         volumes:
           - ../../:/var/www/django
         state: started
@@ -55,5 +55,5 @@
     - name: Display address for local development.
       debug:
         msg: >-
-          Development environment ready. You can browse to the website at
-          http://127.0.0.1:{{ dev_web_port_forward }}
+          Development environment spinning-up. You can browse to the web interface at
+          http://127.0.0.1:{{ dev_web_port_forward }} once containers finish running.


### PR DESCRIPTION
In a recent change, a git reference was added to the `requirements.txt` file
which causes the django container to bomb out during start. This happened
because it was missing the `git` binary and threw an error during the pip
install.

This PR adds `git` to a forked python container that is now available at our
quay.io repository. I also added the short dockerfile reference used to generate
this container.