### PR TITLE
Fix missing missing variable error if footer menu exists

### DIFF
--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -157,7 +157,9 @@ class Command(BaseCommand):
                 ),
             ])
 
-        if not Menu.objects.filter(slug='footer').exists():
+        footer_menu, created = Menu.objects.get_or_create(
+            name='Footer Menu', slug='footer')
+        if created:
             footer_menu = Menu.objects.create(name='Footer Menu', slug='footer')
             MenuItem.objects.bulk_create([
                 MenuItem(


### PR DESCRIPTION
This command was erroring out when the footer menu was not found due
to a later reference to the variable `footer_menu`.  This patch
initializes it in the case that it didn't have to be created.