### PR TITLE
Remove extraneous `section > h5` after incident update

### DIFF
--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -118,9 +118,6 @@ It can take the following context variables:
 						{% endfor %}
 					</div>
 				</div>
-				<section>
-					<h5></h5>
-				</section>
 			{% endfor %}
 			{% if incident.links.exists %}
 				<div class="related-links">


### PR DESCRIPTION
Confirmed that this does not harm visuals, no new padding needed.

Closes #229