### PR TITLE
Fix IncidentPage search_fields

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -439,7 +439,6 @@ class IncidentPage(Page):
     search_fields = Page.search_fields + [
         index.SearchField('body'),
         index.FilterField('date'),
-        index.FilterField('category_id'),
     ]
 
     def detention_duration(self):


### PR DESCRIPTION
* Closes #272
* Fixes warning runtime warning
* Amends category filter field introduced in a42f2000c0b2f2e4121f944c5bc5909ad7f41bf5
* This was not actually needed to filter by categories nor do I see any
  sort of warning when searching/filtering