### PR TITLE
Fix footer link colour

### DIFF
--- a/common/static/css/_info-footer.sass
+++ b/common/static/css/_info-footer.sass
@@ -18,7 +18,8 @@ $white-link: rgba($white, 0.85)
 		padding: 0
 
 	a,
-	.rich-text > a
+	.rich-text > a,
+	.rich-text p > a
 		color: $white-link
 		text-decoration: none
 


### PR DESCRIPTION
Closes #306

The staging site has the contents of the footer in a paragraph tag, thus
`rich-text a` was preferred over `info-footer__body a`.