### PR TITLE
Reduce CI output text

### DIFF
--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -61,3 +61,5 @@
       - "--exclude=src"
     # The default packages are preinstalled on the base dockerimage
     django_stack_pkgs: []
+    django_stack_global_no_log: yes
+    django_stack_manage_no_log: no

--- a/devops/requirements.yml
+++ b/devops/requirements.yml
@@ -10,4 +10,4 @@
 
 - src: https://github.com/freedomofpress/django_stack.git
   name: freedomofpress.django_stack
-  version: 10acb7a7f81f831535ffe610d66b357eff1282dd
+  version: 7d1081f5003d9650ea114c18a17d32530c1b961b


### PR DESCRIPTION
This PR should dramatically reduce output text in CircleCI to make it easier to debug.
As a result, this will close #346 and close #212.

There is some remaining garbage output from the synchronize command that I couldn't kill because of an [upstream bug](https://github.com/ansible/ansible/issues/25681). Should be a huge improvement though with the removal of the npm and pip output ;)

Pending CI run *cross-fingers*