### PR TITLE
Skip filtering if daterange would be illegal

### DIFF
--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -36,6 +36,13 @@ class TestPages(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_get_index_should_succeed_with_illegal_date_range(self):
+        """get index should succeed with malformed filters."""
+        response = self.client.get(
+            '/incidents/?upper_date=2011-01-01&lower_date=2012-01-01'
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 class TestExportPage(TestCase):
     """CSV Exports"""

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -238,6 +238,8 @@ class IncidentFilter(object):
                             field_name: lower_date
                         }
                         incidents = incidents.filter(**kw)
+                    elif lower_date and upper_date and lower_date > upper_date:
+                        pass
                     else:
                         kw = {
                             '{0}__contained_by'.format(field_name): DateRange(
@@ -371,6 +373,8 @@ class IncidentFilter(object):
     def by_date_range(self, incidents):
         if self.lower_date == self.upper_date:
             return incidents.filter(date=self.lower_date)
+        if self.lower_date and self.upper_date and self.lower_date > self.upper_date:
+            return incidents
 
         return incidents.filter(date__contained_by=DateRange(
             lower=self.lower_date,


### PR DESCRIPTION
If the lower bound exceeds the upper bound, then skip filtering by
dates altogether.  It's possible we want some kind of client-side
helper for the date picker to prevent people from doing this (e.g. an
explicit date range picker, rather than two date pickers) or at least
some kind of validation.

But for now this is the simplest path to preventing code 500 errors
and is in line with how we skip filtering for other kinds of invalid
dates.

Refs #324