### PR TITLE
Adjust the transform origin for medium large screens

### DIFF
--- a/common/static/css/_header.sass
+++ b/common/static/css/_header.sass
@@ -61,6 +61,7 @@
 				// I don't understand quite why these numbers work
 				top: 25px
 				left: -25px
+				transform-origin: 1.5rem 0
 
 	&__logo:hover
 		.header__logo-svg path


### PR DESCRIPTION
I don't know why this works. :(
Hovering on the logo now covers the logo entirely.
**To review**: Change your screensize to max wide and max small. Observe the logo being entirely black. Open dev tools and click on "hover". Observe the logo being entirely white.
Close #297 