### PR TITLE
Make filter categories have different hover states.

### DIFF
--- a/common/static/css/_filters.sass
+++ b/common/static/css/_filters.sass
@@ -111,13 +111,14 @@
 			width: calc(50% - #{$padding-x})
 
 
-	&__category--active,
-	&__category:active,
-	&__category:hover,
-	&__category:focus
-		background-color: $white
-		color: $bg-medium
+		+hover
+			background-color: lighten($bg-light,8)
 
+		&--active,
+			background-color: $white
+			color: $bg-medium
+			+hover
+				background-color: lighten($bg-light,57)
 
 	&__accordion-category
 		border-bottom-width: 1px


### PR DESCRIPTION
There are now 4 colors:
- Inactive (dark)
- Inactive hover (slightly lighter)
- Active (white)
- Active hover (slightly darker)

This way, when you're hovering on a filter category and clicking it,
something happens even when your cursor doesn't move.

inactive, inactive hover, active hover, active
![image](https://user-images.githubusercontent.com/1051450/28467826-235b48e2-6dff-11e7-9072-5e9299842ccc.png)
