### PR TITLE
Repair breaking CI, set django_stack to master

### DIFF
--- a/devops/requirements.yml
+++ b/devops/requirements.yml
@@ -1,13 +1,3 @@
 ---
-- src: https://github.com/freedomofpress/ansible-role-openssl-node.git
-  name: freedomofpress.openssl_node
-
-- name: jdauphant.nginx
-
-- name: ANXS.postgresql
-
-- name: geerlingguy.nodejs
-
 - src: https://github.com/freedomofpress/django_stack.git
   name: freedomofpress.django_stack
-  version: 7d1081f5003d9650ea114c18a17d32530c1b961b


### PR DESCRIPTION
By default django_stack should be pulling `master`. The issue we ran into here
was that the commit we were pegging to got rebased and therefore doesnt exist on
github anylonger.

This commit also removes some other ansible roles that are no longer needed
thanks to some recent CI fixes :)