### PR TITLE
Allow PDB on Djano

### DIFF
--- a/molecule/dev/playbook.yml
+++ b/molecule/dev/playbook.yml
@@ -98,6 +98,8 @@
         published_ports:
           - 8000
         working_dir: /var/www/django
+        interactive: true
+        tty: true
         command: |
           /bin/bash -c "./manage.py migrate; ./manage.py runserver 0.0.0.0:8000"
         user: gcorn


### PR DESCRIPTION
This PR allows one to run PDB under Djano by toggling interactive + tty on the underlying django container during run-time. The only caveat is that once you connect to djano shell, I havent figured out how to detach without crashing django -- thats easy enough to fix by re-running `make dev-go`.

To test:

* Run `make dev-go`
* Add your relevant pdb section in django. I recommend like 14 of `search/views.py` and then add `import pdb; pdb.set_trace()`
* Navigate to the page in question in a browser to trigger
* Attach directly to the django console (dont use the `make` command) -- for example `docker attach pf_tracker_django`. You should see a (pdb) console prompt ;)