### PR TITLE
Fix for stack overflow with debugtoolbar + Wagtail

### DIFF
--- a/pressfreedom/settings/dev.py
+++ b/pressfreedom/settings/dev.py
@@ -23,7 +23,8 @@ if settings.DEBUG:
         'SKIP_TEMPLATE_PREFIXES': (
             'django/forms/widgets/',
             'admin/widgets/',
-            'common/blocks/'
+            'common/blocks/',
+            'statistics/'
         ),
         'DISABLE_PANELS': {
             'debug_toolbar.panels.redirects.RedirectsPanel',


### PR DESCRIPTION
This issue is outlined in https://github.com/jazzband/django-debug-toolbar/issues/950 and seems to crop up when one has debug toolbar enabled and attempts to add an incident. Fixes #460 

To verify this resolves the issue:

* `make dev-go`
* navigate to `http://localhost:8000/admin/pages/add/incident/incidentpage/27/` 

If it loads - you are a-okay. If it crashes out you'll see an error in `docker logs pf_tracker_django`. I'm not entirely sure if my fix was necessary to blacklist each particular `common/blocks/` that was called in a StructBlock or if I could have just blacklisted that entire directory. @harrislapiroff any guidance on this?