### PR TITLE
(Very minor) Amend the info footer styles

### DIFF
--- a/common/static/css/_info-footer.sass
+++ b/common/static/css/_info-footer.sass
@@ -1,6 +1,7 @@
 $white-link: rgba($white, 0.85)
 
 .info-footer
+	max-width: calc(1440px + 25%)
 	background-color: $black
 	color: $gray
 	padding: 40px


### PR DESCRIPTION
Apply the same max-width that .footer has so that it does not become
wider than the rest of the content on very wide screens.