### PR TITLE
Remove top border on methodology

### DIFF
--- a/common/static/css/_methodology.sass
+++ b/common/static/css/_methodology.sass
@@ -2,10 +2,6 @@
 	padding-top: 1rem
 	padding-bottom: 1rem
 
-	&:not(:first-child)
-		border-top: 1px solid darken($gray-light, 5%)
-
-
 .methodology__title
 	+section-heading
 


### PR DESCRIPTION
This gets rid of it on incident as well as category pages, but I think I'm OK with that. Open to other opinions.

![screen shot 2017-08-01 at 1 44 50 pm](https://user-images.githubusercontent.com/13922520/28838906-d7bd410a-76bf-11e7-81fa-2dc5d1463777.png)
