### PR TITLE
Adds Piwk/analytics requirements to dev env

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,8 +11,10 @@ certifi==2017.4.17
 chardet==3.0.4
 click==6.7
 dj-database-url==0.4.2
+django-analytical==2.2.2
 django-debug-toolbar==1.8
 django-modelcluster==3.1
+django-settings-export==1.2.1
 django-taggit==0.22.1
 django-treebeard==4.1.2
 django-webpack-loader==0.5.0


### PR DESCRIPTION
We have two requirements files:

  * requirements.txt # app, used in dev and prod
  * dev-requirements.txt # container-only, used in dev

During merge of #494 I overlooked the `dev-requirements.txt` file,
thereby breaking the container workflow created via `make dev-go`.
The solution was to run:

  pip-compile --output-file dev-requirements.txt dev-requirements.in

And commit the results. Now we're up to speed.

Closes #515.