### PR TITLE
Only render meta_tags if `self` is defined

### DIFF
--- a/pressfreedom/templates/super.html
+++ b/pressfreedom/templates/super.html
@@ -30,7 +30,9 @@
 			{% endblock %}
 
 			{% block meta %}
-				{% meta_tags %}
+				{% if self %}
+					{% meta_tags %}
+				{% endif %}
 				{% get_settings %}
 				{% with seo_settings=settings.common.SocialSharingSEOSettings %}
 					{% if seo_settings.twitter %}


### PR DESCRIPTION
I expected meta tags to fail silently in instances where `self`
was not defined, but apparently that's not its way. This is
critical to non-Page views, such as search. Otherwise they raise
an exception.