### PR TITLE
Temporarily disables email notifications

### DIFF
--- a/pressfreedom/settings/production.py
+++ b/pressfreedom/settings/production.py
@@ -114,5 +114,10 @@ if os.environ.get('PIWIK_DOMAIN_PATH'):
     PIWIK_DOMAIN_PATH = os.environ.get('PIWIK_DOMAIN_PATH')
     PIWIK_SITE_ID = os.environ.get('PIWIK_SITE_ID', '5')
 
+# Mailgun integration
+#
+# Temporarily disabling email pending full Mailgun support
+EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.dummy.EmailBackend')
+
 # Ensure Django knows its being served over https
 SECURE_PROXY_SSL_HEADER = ('X-Forwarded-Proto', 'https')


### PR DESCRIPTION
Disabling email altogether using the dummy backend [0] as stopgap
measure pending full support for Mailgun integration. Will need to
generate API keys and flesh out the config for Mailgun, as we've done
with other Wagtail sites. That works will come in a separate PR.

[0] https://docs.djangoproject.com/en/1.11/topics/email/#dummy-backend