### PR TITLE
Activates frontend caching logic

### DIFF
--- a/pressfreedom/settings/production.py
+++ b/pressfreedom/settings/production.py
@@ -99,6 +99,7 @@ else:
 # Cloudflare caching
 #
 if os.environ.get('CLOUDFLARE_TOKEN') and os.environ.get('CLOUDFLARE_EMAIL'):
+    INSTALLED_APPS.append('wagtail.contrib.wagtailfrontendcache')  # noqa: F405
     WAGTAILFRONTENDCACHE = {
         'cloudflare': {
             'BACKEND': 'wagtail.contrib.wagtailfrontendcache.backends.CloudflareBackend',


### PR DESCRIPTION
We had all the necessary boilerplate in place for purging Cloudflare
cache by URL on page updates, but we never actually included
`wagtail.contrib.wagtailfrontendcache` in INSTALLED_APPS, so the logic
was never activated.

Closes #547.