### PR TITLE
Fix an error where a blank category filter caused an exception

### DIFF
--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -36,6 +36,11 @@ class TestPages(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_get_index_should_succeed_with_blank_category_filters(self):
+        """get index should succeed blank with a category filter."""
+        response = self.client.get('/incidents/?categories=')
+        self.assertEqual(response.status_code, 200)
+
     def test_get_index_should_succeed_with_illegal_date_range(self):
         """get index should succeed with malformed filters."""
         response = self.client.get(

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -421,7 +421,7 @@ class IncidentFilter(object):
         # If more than one category is included in this set, add a summary item
         # for each category of the form ("Total <Category Name>", <Count>)
         if self.categories is not None:
-            category_pks = [int(pk) for pk in self.categories.split(',')]
+            category_pks = validate_integer_list(self.categories.split(','))
             if len(category_pks) > 1:
                 categories = CategoryPage.objects.filter(
                     pk__in=category_pks


### PR DESCRIPTION
The problem was we were not taking into account what happens if
someone requests a category filter but the filter is empty,
i.e. `?categories=` with nothing else.  And it turns out we have a
handy function already written to convert potentially unsafe user
input into a nice list of integers.

This is in response to seeing this error happening in the logs:

Exception triggered @ 2017-08-07T19:28:03Z
*Loglevel*: ERROR
*Host*: tracker-prod
*Data*:
>{u'message': u"invalid literal for int() with base 10: ''", u'traceback': [{u'line': 185, u'method': u'_get_response', u'file': u'/home/gcorn/pressfreedom/lib/python3.4/site-packages/django/core/handlers/base.py'}, {u'line': 26, u'method': u'serve', u'file': u'/home/gcorn/pressfreedom/lib/python3.4/site-packages/wagtail/wagtailcore/views.py'}, {u'line': 93, u'method': u'serve', u'file': u'/var/www/django/incident/models/incident_index_page.py'}, {u'line': 102, u'method': u'serve', u'file': u'/home/gcorn/pressfreedom/lib/python3.4/site-packages/wagtail/contrib/wagtailroutablepage/models.py'}, {u'line': 758, u'method': u'serve', u'file': u'/home/gcorn/pressfreedom/lib/python3.4/site-packages/wagtail/wagtailcore/models.py'}, {u'line': 71, u'method': u'get_context', u'file': u'/var/www/django/incident/models/incident_index_page.py'}, {u'line': 360, u'method': u'fetch', u'file': u'/var/www/django/incident/utils/incident_filter.py'}, {u'line': 424, u'method': u'summarize', u'file': u'/var/www/django/incident/utils/incident_filter.py'}, {u'line': 424, u'method': u'<listcomp>', u'file': u'/var/www/django/incident/utils/incident_filter.py'}], u'type': u'ValueError'}