### PR TITLE
Corrected methodology rendering on category pages to work with incident filters

### DIFF
--- a/common/templates/common/category_page.html
+++ b/common/templates/common/category_page.html
@@ -117,5 +117,7 @@
 			{% include 'incident/_summary_table.html' with label="Results Summary" summary_table=summary_table %}
 		{% endif %}
 	</div>
-	{% include 'common/_category_methodology.html' with category=page %}
+	<div class="js-methodologies">
+		{% include 'common/_category_methodology.html' with category=page %}
+	</div>
 {% endblock %}


### PR DESCRIPTION
See #597. Category pages were not providing the expected wrapper for methodologies and thus were getting errors when incident filter form was submitted.