### PR TITLE
Corrected get_related_incidents behavior to work with modelclusters

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -598,10 +598,8 @@ class IncidentPage(MetadataPageMixin, Page):
         """
         Returns related incidents and/or other incidents in the same category.
         """
-
         # If there are one or fewer related incidents, we will append more incidents from the same category, up to a maximum number
-        related_to_incident_qs = self.related_incidents.all()
-        related_incidents = list(related_to_incident_qs)
+        related_incidents = list(self.related_incidents.all())
         main_category = self.get_main_category()
 
         # Maximum of related incidents to return, minimum of 2
@@ -613,14 +611,15 @@ class IncidentPage(MetadataPageMixin, Page):
         # only add up to two more incidents from the main category
         maximum += maximum % 2
 
+        exclude_ids = {incident.id for incident in related_incidents}
+        if self.id:
+            exclude_ids.add(self.id)
         related_incidents += list(
             IncidentPage.objects.filter(
                 live=True,
                 categories__category=main_category
             ).exclude(
-                id=self.id
-            ).difference(
-                related_to_incident_qs
+                id__in=exclude_ids
             )[:(maximum - len(related_incidents))]
         )
 

--- a/incident/tests/factories.py
+++ b/incident/tests/factories.py
@@ -271,6 +271,14 @@ class IncidentPageFactory(wagtail_factories.PageFactory):
                     category=category,
                 )
 
+    @factory.post_generation
+    def related_incidents(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted:
+            self.related_incidents.set(extracted)
+
 
 class InexactDateIncidentPageFactory(IncidentPageFactory):
     exact_date_unknown = True


### PR DESCRIPTION
Resolved #546 (or at least one case of it.) get_related_incidents is required for rendering an IncidentPage. However, for previews, `self.related_incidents.all()` is a FakeQuerySet instance. We can resolve the issue by excluding the ids from that queryset instead of using the queryset directly in a `.difference()` call.