### PR TITLE
Corrected date filter validation on frontend

### DIFF
--- a/client/common/js/filtering/IncidentFiltering.js
+++ b/client/common/js/filtering/IncidentFiltering.js
@@ -131,8 +131,8 @@ class IncidentFiltering extends PureComponent {
 		const filterValues = DATE_FILTERS.reduce((filters, date_field) => {
 			const upper_date = date_field.replace('_lower', '_upper')
 			const hasCompleteRange = (
-				filters.hasOwnProperty(date_field) &&
-				filters.hasOwnProperty(upper_date) &&
+				filters[date_field] &&
+				filters[upper_date] &&
 				upper_date !== date_field
 			)
 			const shouldSwap = (


### PR DESCRIPTION
.hasOwnProperty checks whether a property exists at all; deselecting
a date filter results in a property value of null existing, which
can't be used in date comparisons. Instead we now check whether
the date filter value is truthy. Resolved #589.