### PR TITLE
Use longer auto-grabbed teaser text when there is no teaser image.

### DIFF
--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -66,8 +66,10 @@ It can take the following context variables:
 				<section>
 					{% if incident.teaser %}
 						{{ incident.teaser|typogrify }}
-					{% else %}
+					{% elif incident.teaser_image %}
 						{% include_block incident.body.0|striptags|truncatewords:20|typogrify %}
+					{% else %}
+						{% include_block incident.body.0|striptags|truncatewords:80|typogrify %}
 					{% endif %}
 				</section>
 			{% else %}


### PR DESCRIPTION
Closes #497 

Looks like:

![image](https://user-images.githubusercontent.com/1051450/37106583-2bb2f26e-2200-11e8-8beb-339f135bc643.png)