### PR TITLE
Corrected merge behavior when target tag included in tags to merge

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -40,7 +40,7 @@ class MergeView(FormView):
             ))
             getattr(new_model, field['accessor']).add(*pages)
         new_model.save()
-        models_to_merge.delete()
+        models_to_merge.exclude(id=new_model.id).delete()
         messages.success(
             self.request,
             _("{0} successfully merged").format(


### PR DESCRIPTION
Resolved #661. Made sure that if the tag with the merge name is also included in the tags to merge, it does not get deleted when removing old tags.