### PR TITLE
Add styles and HTML to better handle varied image sizes

### DIFF
--- a/client/common/sass/_incident.sass
+++ b/client/common/sass/_incident.sass
@@ -1,3 +1,6 @@
+$min-image-height: 400px
+$max-image-vh-ratio: 0.75
+
 .incident
 	font-family: $sans-serif
 	background: #fff
@@ -10,9 +13,26 @@
 .incident__body
 	padding: $incident-body-top-padding $incident-body-side-padding 5px
 
+.incident__top-image-container
+	background: #f5f5f5
+	position: relative
+	min-height: 400px
+	display: flex
+	align-items: center
+	justify-content: space-around
+
 .incident__top-image
+	max-width: 100%
+	// Before the min-image-height threshold is passed the image should be allowed
+	// to grow to that size (this will *not* scale up low resolution images, however)
+	max-height: $min-image-height
+	margin: 0 auto
 	display: block
-	width: 100%
+
+	// Make sure (once the min-image-height threshold is passed) that the image
+	// is never taller than a certain percentage of the window height
+	@media(min-height: ceil($min-image-height * 1/$max-image-vh-ratio))
+		max-height: $max-image-vh-ratio * 100vh
 
 .incident__category-name
 	+uppercase

--- a/common/templates/common/_top_image.html
+++ b/common/templates/common/_top_image.html
@@ -3,12 +3,14 @@
 
 {% image page.teaser_image width-1440 as x1 %}
 {% image page.teaser_image width-2880 as x2 %}
-<img
-	class="incident__top-image"
-	alt="{{ x1.alt }}"
-	src="{{ x1.url }}"
-	srcset="{{ x2.url }} 2x"
-/>
+<div class="incident__top-image-container">
+	<img
+		class="incident__top-image"
+		alt="{{ x1.alt }}"
+		src="{{ x1.url }}"
+		srcset="{{ x2.url }} 2x"
+	/>
+</div>
 {% if page.image_caption or page.teaser_image.attribution %}
 	<aside
 		class="caption {% if not page.image_caption %} caption--att-only {% endif %}"


### PR DESCRIPTION
* Scale portrait images so they are never too tall
* Never upscale low res images
* Center images that are narrower or shorter than the image container

Resolves #635 

Some screenshots of the new behavior (using MacBook screen dimensions and sample images from Unsplash):

Landscape image:
![screen shot 2018-04-16 at 17 02 26](https://user-images.githubusercontent.com/296631/38835171-b5dbb1a8-4198-11e8-98d0-7561d24ae013.png)

Portrait image:
![screen shot 2018-04-16 at 17 02 39](https://user-images.githubusercontent.com/296631/38835184-c60c91a0-4198-11e8-98b5-be7ae93af5d7.png)

Low res image:
![screen shot 2018-04-16 at 17 02 51](https://user-images.githubusercontent.com/296631/38835189-ca5e1c4c-4198-11e8-87c7-bc2302a4fe10.png)

These new styles may affect images already live on the site, changing the appearance of existing incidents! The new styles should not change anything about incident teaser appearance. Those images will continue to be cropped to landscape as usual.

