### PR TITLE
Prevent pages without templates from raising server errors

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -178,7 +178,7 @@ class BlogPage(MetadataPageMixin, Page):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name='+',
+        related_name='blog_posts',
     )
 
     author = models.ForeignKey(


### PR DESCRIPTION
OrganizationIndexPage and OrganizationPage never got templates.
We're preserving them as Page subclasses both to avoid a
migration and in case we decide to use them as Pages in the
future, but in the absence of templates for now, this commit
creates fallback behavior that does not require the use of a
template.

OrganizationIndexPage: raise 404
OrganizationPage: redirect to a BlogIndexPage filtered to posts
   from that organization

Resolves #669 