### PR TITLE
Bump cryptography

### DIFF
--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -1,5 +1,5 @@
 ansible-lint==3.4.23      # via molecule
-ansible==2.6.1
+ansible==2.6.2
 anyconfig==0.9.4          # via molecule
 arrow==0.12.1             # via jinja2-time
 asn1crypto==0.24.0        # via cryptography
@@ -18,7 +18,7 @@ click==6.7                # via click-completion, cookiecutter, molecule, pip-to
 colorama==0.3.9           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
 cookiecutter==1.6.0       # via molecule
-cryptography==2.2.2       # via ansible, paramiko
+cryptography==2.3         # via ansible, paramiko
 docker-pycreds==0.3.0     # via docker
 docker==2.7.0
 dparse==0.4.1             # via safety
@@ -38,32 +38,34 @@ markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 molecule==2.16.0
 monotonic==1.5            # via fasteners
-more-itertools==4.2.0     # via pytest
+more-itertools==4.3.0     # via pytest
 packaging==17.1           # via dparse, safety
 paramiko==2.4.1           # via ansible
+pathlib2==2.3.2           # via pytest
 pathspec==0.5.6           # via yamllint
 pbr==4.0.4                # via git-url-parse, molecule, python-gilt
 pexpect==4.6.0            # via molecule
 pip-tools==2.0.2
-pluggy==0.6.0             # via pytest
+pluggy==0.7.1             # via pytest
 poyo==0.4.1               # via cookiecutter
 psutil==5.4.6             # via molecule
 ptyprocess==0.6.0         # via pexpect
 py==1.5.4                 # via pytest
-pyasn1==0.4.3             # via paramiko
+pyasn1==0.4.4             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.18           # via cffi
 pyflakes==1.6.0           # via flake8
 pynacl==1.2.1             # via paramiko
 pyparsing==2.2.0          # via packaging
-pytest==3.6.3             # via testinfra
+pytest==3.7.1             # via testinfra
 python-dateutil==2.7.3    # via arrow
 python-gilt==1.2.1        # via molecule
 pyyaml==3.12              # via ansible, ansible-lint, dparse, molecule, python-gilt, yamllint
 requests==2.19.1          # via cookiecutter, docker, safety
-safety==1.8.2
+safety==1.8.4
+scandir==1.8              # via pathlib2
 sh==1.12.14               # via molecule, python-gilt
-six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, dparse, fasteners, junit-xml, molecule, more-itertools, packaging, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
+six==1.11.0               # via ansible-lint, bcrypt, click-completion, cryptography, docker, docker-pycreds, dparse, fasteners, junit-xml, molecule, more-itertools, packaging, pathlib2, pip-tools, pynacl, pytest, python-dateutil, testinfra, websocket-client
 tabulate==0.8.2           # via molecule
 testinfra==1.14.0         # via molecule
 tree-format==0.1.2        # via molecule


### PR DESCRIPTION
`safety` marks the `cryptography` library under 2.3 as vulnerable. Let's
bump to version >= 2.3.