### PR TITLE
Bind docker ports to localhost only

### DIFF
--- a/molecule/dev/playbook.yml
+++ b/molecule/dev/playbook.yml
@@ -48,10 +48,8 @@
       docker_container:
         name: pf_tracker_postgresql
         image: postgres:9.3
-        exposed_ports:
-          - 5432
-        published_ports:
-          - 5432
+        ports:
+          - "127.0.0.1:5432:5432"
         volumes:
           - ../../:/django
         state: started
@@ -113,10 +111,8 @@
         volumes:
           - ../../:/var/www/django
         state: started
-        exposed_ports:
-          - 8000
-        published_ports:
-          - "{{ django_port_publish | default('8000:8000') }}"
+        ports:
+          - "127.0.0.1:8000:8000"
         working_dir: /var/www/django
         interactive: true
         tty: true


### PR DESCRIPTION
This ensures that containers are not exposed or reachable to other hosts
on local networks or VPN.

How to test: 

* CI should pass
* Checkout master
* make dev
* open browser to `<IP_OF_HOST>:8000`
* observe web page
* checkout this branch
* make dev
* open browser to `<IP_OF_HOST>:8000`
* do not observe web page
