### PR TITLE
Fix incident filtering on category pages

### DIFF
--- a/client/common/js/filtering/IncidentFiltering.js
+++ b/client/common/js/filtering/IncidentFiltering.js
@@ -31,6 +31,9 @@ class IncidentFiltering extends PureComponent {
 			filtersTouched: false,
 			...this.getStateFromQueryParams(),
 		}
+		if (props.category) {
+			this.state.categoriesEnabled[props.category] = true
+		}
 	}
 
 	componentDidMount() {
@@ -271,6 +274,12 @@ class IncidentFiltering extends PureComponent {
 			filtersTouched: false,
 			categoriesEnabled: { [GENERAL_ID]: true },
 		})
+		if (this.props.category) {
+			this.setState({
+				categoriesEnabled: { [this.props.category]: true }
+			})
+		}
+
 		history.pushState(null, null, '?')
 		this.fetchPage({})
 	}


### PR DESCRIPTION
This pull request:

Ensures that if you're viewing a category page that the `IncidentFiltering` component is properly setting up its internal state to show category-specific filters. Previously, this would only work if the category was being set in the URL's GET parameters. This change makes it work even without those parameters (since it's also being set in `IncidentFilter`'s props, but the component wasn't checking there). See commit message for more specific info.

Fixes #677