### PR TITLE
Display publication date below headline

### DIFF
--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -51,7 +51,7 @@ It can take the following context variables:
 			</h2>
 		{% endif %}
 		<div class='incident__date'>
-				{% include "incident/_incident_date.html" %}
+			{{ incident.first_published_at|date:"F j, Y" }}
 				{% if teaser and incident.recently_updated %}
 				<span
 					class="alert alert--green"


### PR DESCRIPTION
This pull request alters the Incident Page template to display the `first_published_at` (an internal wagtail Page field) as the date below the headline. Everything else, including the formatting, remains the same.

Fixes #679