### PR TITLE
Adjust footer CSS for more more nav items and small screens

### DIFF
--- a/client/common/sass/_info-footer.sass
+++ b/client/common/sass/_info-footer.sass
@@ -16,7 +16,7 @@ $white-link: rgba($white, 0.85)
 		padding: 0
 
 .info-footer__nav
-	max-width: 400px
+	max-width: 1024px
 
 
 /**
@@ -32,6 +32,9 @@ $white-link: rgba($white, 0.85)
 	flex-direction: row
 	justify-content: space-between
 
+@media(max-width: $mid-small-screen)
+	.info-footer__nav-list
+		flex-direction: column
 
 .info-footer__nav-item
 	flex-grow: 1


### PR DESCRIPTION
The gist: if we're on a large screen, give increase max-width to give
ourselves space for more items.  Also, add a media query to switch to
a vertical item layout if we're on a small screen.

Some screenshots with various numbers of menu items and sizes:

![screenshot from 2018-09-12 11-17-41](https://user-images.githubusercontent.com/561931/45435693-05404500-b67f-11e8-9ab2-54cd83bba5ee.png)

![screenshot from 2018-09-12 11-18-25](https://user-images.githubusercontent.com/561931/45435696-08d3cc00-b67f-11e8-8fb1-3fb51d37383a.png)

![screenshot from 2018-09-12 11-20-35](https://user-images.githubusercontent.com/561931/45435720-15f0bb00-b67f-11e8-9c1d-a9d3ab0e5a63.png)

![screenshot from 2018-09-12 11-20-21](https://user-images.githubusercontent.com/561931/45435723-18531500-b67f-11e8-9de4-01a6b41e2db0.png)

Fixes #672 