### PR TITLE
Fix fuzzy date filtering

### DIFF
--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -1,5 +1,4 @@
 from datetime import date, timedelta
-import unittest
 
 from django.test import TestCase
 from django.utils import timezone
@@ -340,7 +339,6 @@ excludes all dates from the same month"""
         )).get_queryset()
         self.assertEqual(len(incidents), 0)
 
-    @unittest.skip('Test currently fails on master as well; leaving for another ticket')
     def test_should_not_include_inexactly_dated_incidents_from_other_months__above(self):
         """should not include inexactly dated incidents if filter date range
 excludes all dates from the same month"""

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -7,14 +7,13 @@ from django.db.models import (
     CharField,
     DateField,
     DurationField,
-    F,
     ForeignKey,
     ManyToManyField,
     Q,
     TextField,
     Value,
 )
-from django.db.models.functions import Trunc, Cast
+from django.db.models.functions import Trunc, TruncMonth, Cast
 from django.db.models.fields.related import ManyToOneRel
 from django.utils.text import capfirst
 from psycopg2.extras import DateRange
@@ -137,7 +136,7 @@ class DateFilter(Filter):
             queryset = queryset.annotate(
                 fuzzy_date=MakeDateRange(
                     Cast(Trunc('date', 'month'), DateField()),
-                    Cast(F('date') + Cast(Value('1 month'), DurationField()), DateField()),
+                    Cast(TruncMonth('date') + Cast(Value('1 month'), DurationField()), DateField()),
                 ),
             )
             target_range = DateRange(


### PR DESCRIPTION
This pull request changes the query logic for finding the "fuzzy date" of an incident whose date is not exactly known. It fixes a bug where the fuzzy date range could extend outside the month it is supposed to be constrained to. 

We expect an incident with its exact date unknown to match a fuzzy date search on any date within the month specified by the `date` field.  So a date of 2018-10-23 should match any date in the range 2018-10-01 to 2018-10-31. When creating this fuzzy date range, we need to use the truncated date (the date with the "day part" set to 1) as the basis for both the lower and upper bounds of the range. Previously, we were only using the truncated date for the lower bound.

There was already a test for this, but we were skipping it. So now we're not (and it passes :smile:).

Fixes #617