### PR TITLE
Strip whitespace from email addresses before signing them up

### DIFF
--- a/emails/tests/test_views.py
+++ b/emails/tests/test_views.py
@@ -1,0 +1,41 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from emails.models import EmailSignup
+
+
+class EmailSignupTest(TestCase):
+    def test_successful_signup(self):
+        response = self.client.post(
+            reverse("email-signup-create"), {"email_address": "hello@example.com"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # should not raise error
+        EmailSignup.objects.get(email_address="hello@example.com")
+
+    def test_should_reject_posts_without_email(self):
+        response = self.client.post(reverse("email-signup-create"), {})
+        self.assertEqual(response.status_code, 400)
+
+    def test_should_reject_non_email_addresses(self):
+        response = self.client.post(
+            reverse("email-signup-create"), {"email_address": "example.com"}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_should_reject_already_taken_emails(self):
+        EmailSignup.objects.create(email_address="hello@example.com")
+        response = self.client.post(
+            reverse("email-signup-create"), {"email_address": "hello@example.com"}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_signup_should_permit_leading_or_trailing_whitespace(self):
+        response = self.client.post(
+            reverse("email-signup-create"), {"email_address": "  hello@example.com    "}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # should not raise error
+        EmailSignup.objects.get(email_address="hello@example.com")

--- a/emails/views.py
+++ b/emails/views.py
@@ -14,7 +14,7 @@ def email_signup_create(request):
     email_address = request.POST.get('email_address')
 
     try:
-        email = EmailSignup(email_address=email_address)
+        email = EmailSignup(email_address=email_address.strip())
         email.full_clean()
         email.save()
     except ValidationError as error:


### PR DESCRIPTION
This pull request undraconianizes our email validation code by removing leading and trailing whitespace from incoming email addresses.

Fixes #657 