### PR TITLE
Remove `block ajax` from all templates

### DIFF
--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -22,59 +22,57 @@
 {% endblock %}
 
 {% block main %}
-	{% block ajax %}
-		{% if author_filter %}
-			<div class="blog-filter">
-				You are looking at articles written by
-				{% if author_filter.website %}
-					<a href="{{ author_filter.website }}">{{ author_filter.title }}</a>
-				{% else %}
-					{{ author_filter.title }}
-				{% endif %}
-				<div class="blog-filter__clear">
-					<a href="{{ page.url }}">&times; See All Articles</a>
-				</div>
+	{% if author_filter %}
+		<div class="blog-filter">
+			You are looking at articles written by
+			{% if author_filter.website %}
+				<a href="{{ author_filter.website }}">{{ author_filter.title }}</a>
+			{% else %}
+				{{ author_filter.title }}
+			{% endif %}
+			<div class="blog-filter__clear">
+				<a href="{{ page.url }}">&times; See All Articles</a>
 			</div>
-		{% endif %}
-		{% if organization_filter %}
-			<div class="blog-filter">
-				You are looking at articles from
-				{% if organization_filter.website %}
-					<a href="{{ organization_filter.website }}">{{ organization_filter.title }}</a>
-				{% else %}
-					{{ organization_filter.title }}
-				{% endif %}
-				<div class="blog-filter__clear">
-					<a href="{{ page.url }}">&times; See All Articles</a>
-				</div>
-			</div>
-		{% endif %}
-		<div class="js-infinite-scrolling-parent">
-			{% for post in entries_page %}
-				<div class="js-infinite-scrolling-item">
-					{% include "blog/_blog_tease.html" with page=post.specific location="blog-index" single_column=True %}
-				</div>
-			{% endfor %}
 		</div>
+	{% endif %}
+	{% if organization_filter %}
+		<div class="blog-filter">
+			You are looking at articles from
+			{% if organization_filter.website %}
+				<a href="{{ organization_filter.website }}">{{ organization_filter.title }}</a>
+			{% else %}
+				{{ organization_filter.title }}
+			{% endif %}
+			<div class="blog-filter__clear">
+				<a href="{{ page.url }}">&times; See All Articles</a>
+			</div>
+		</div>
+	{% endif %}
+	<div class="js-infinite-scrolling-parent">
+		{% for post in entries_page %}
+			<div class="js-infinite-scrolling-item">
+				{% include "blog/_blog_tease.html" with page=post.specific location="blog-index" single_column=True %}
+			</div>
+		{% endfor %}
+	</div>
 
-		{% if entries_page.has_previous %}
-			<a
-				href="?{% query_transform request page=entries_page.previous_page_number %}"
-				class="js-infinite-scrolling-prev-link"
-			>
-				Previous Page
-			</a>
-		{% endif %}
+	{% if entries_page.has_previous %}
+		<a
+			href="?{% query_transform request page=entries_page.previous_page_number %}"
+				  class="js-infinite-scrolling-prev-link"
+		>
+			Previous Page
+		</a>
+	{% endif %}
 
-		{% if entries_page.has_next %}
-			<a
-				href="?{% query_transform request page=entries_page.next_page_number %}"
-				class="button button--outline button--center js-infinite-scrolling-next-link"
-			>
-				More Posts
-			</a>
-		{% endif %}
-	{% endblock ajax %}
+	{% if entries_page.has_next %}
+		<a
+			href="?{% query_transform request page=entries_page.next_page_number %}"
+				  class="button button--outline button--center js-infinite-scrolling-next-link"
+		>
+			More Posts
+		</a>
+	{% endif %}
 {% endblock main %}
 
 {% block top_sidebar_class %}

--- a/common/templates/common/category_page.html
+++ b/common/templates/common/category_page.html
@@ -82,26 +82,24 @@
 {% block main %}
 	{% include "incident/_filters.html" with no_category_filtering=True category=page.id %}
 
-	{% block ajax %}
-		<div class="grid-50 js-infinite-scrolling-parent">
-			{% for incident in entries_page %}
-				<div class="grid-50__item js-infinite-scrolling-item">
-					{% include "incident/_incident.html" with incident=incident teaser=True %}
-				</div>
-			{% empty %}
-				<p class="grid-50__item">There are no results for those filters.</p>
-			{% endfor %}
-		</div>
+	<div class="grid-50 js-infinite-scrolling-parent">
+		{% for incident in entries_page %}
+			<div class="grid-50__item js-infinite-scrolling-item">
+				{% include "incident/_incident.html" with incident=incident teaser=True %}
+			</div>
+		{% empty %}
+			<p class="grid-50__item">There are no results for those filters.</p>
+		{% endfor %}
+	</div>
 
-		{% if entries_page.has_next %}
-			<a
-				href="?{% query_transform request page=entries_page.next_page_number %}"
-				class="button button--outline button--center js-infinite-scrolling-next-link"
-			>
-				More Incidents
-			</a>
-		{% endif %}
-	{% endblock %}
+	{% if entries_page.has_next %}
+		<a
+			href="?{% query_transform request page=entries_page.next_page_number %}"
+				  class="button button--outline button--center js-infinite-scrolling-next-link"
+		>
+			More Incidents
+		</a>
+	{% endif %}
 {% endblock %}
 
 

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -19,33 +19,31 @@
 {% block main %}
 	{% include "incident/_filters.html" %}
 
-	{% block ajax %}
-		<div class="grid-50 js-infinite-scrolling-parent">
-			{% for incident in entries_page %}
-				<div class="grid-50__item js-infinite-scrolling-item">
-					{% include "incident/_incident.html" with incident=incident.specific teaser=True %}
-				</div>
-			{% endfor %}
-		</div>
+	<div class="grid-50 js-infinite-scrolling-parent">
+		{% for incident in entries_page %}
+			<div class="grid-50__item js-infinite-scrolling-item">
+				{% include "incident/_incident.html" with incident=incident.specific teaser=True %}
+			</div>
+		{% endfor %}
+	</div>
 
-		{% if entries_page.has_previous %}
-			<a
-				href="?{% query_transform request page=entries_page.previous_page_number %}"
-				class="js-infinite-scrolling-prev-link"
-			>
-				Previous Page
-			</a>
-		{% endif %}
+	{% if entries_page.has_previous %}
+		<a
+			href="?{% query_transform request page=entries_page.previous_page_number %}"
+				  class="js-infinite-scrolling-prev-link"
+		>
+			Previous Page
+		</a>
+	{% endif %}
 
-		{% if entries_page.has_next %}
-			<a
-				href="?{% query_transform request page=entries_page.next_page_number %}"
-				class="button button--outline button--center js-infinite-scrolling-next-link"
-			>
-				More Incidents
-			</a>
-		{% endif %}
-	{% endblock %}
+	{% if entries_page.has_next %}
+		<a
+			href="?{% query_transform request page=entries_page.next_page_number %}"
+				  class="button button--outline button--center js-infinite-scrolling-next-link"
+		>
+			More Incidents
+		</a>
+	{% endif %}
 {% endblock %}
 
 {% block sidebar_class %}


### PR DESCRIPTION
This block is not used anymore, so it's not helpful to define it
anywhere.

Refs #514 