### PR TITLE
Upgrade to Django 1.11.18

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,61 +2,61 @@
 backcall==0.1.0           # via ipython
 beautifulsoup4==4.6.0
 bleach==3.0.2
-certifi==2018.10.15
+certifi==2018.11.29
 chardet==3.0.4
 click==7.0
 decorator==4.3.0          # via ipython, traitlets
 dj-database-url==0.5.0
-django-analytical==2.4.0
+django-analytical==2.5.0
 django-anymail==5.0
-django-debug-toolbar==1.10.1
+django-debug-toolbar==1.11
 django-modelcluster==3.1
 django-recaptcha==1.4.0
 django-settings-export==1.2.1
 django-taggit==0.22.2
 django-treebeard==4.3
 django-webpack-loader==0.6.0
-django==1.11.16
+django==1.11.18
 djangorestframework==3.6.4
 docutils==0.14
 factory-boy==2.11.1
-faker==1.0.0
+faker==1.0.1
 flake8==3.6.0
 gunicorn==19.9.0
 html5lib==0.999999999
-idna==2.7
+idna==2.8
 ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.5.0            # via ipdb
-jedi==0.13.1              # via ipython
+jedi==0.13.2              # via ipython
 jinja2==2.10
 markupsafe==1.1.0
 mccabe==0.6.1             # via flake8
 parso==0.3.1              # via jedi
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pillow==5.3.0
-pip-tools==3.1.0
+pillow==5.4.0
+pip-tools==3.2.0
 prompt-toolkit==1.0.15    # via ipython
 psycopg2==2.7.6.1
 ptyprocess==0.6.0         # via pexpect
 pycodestyle==2.4.0        # via flake8
 pyflakes==2.0.0           # via flake8
-pygments==2.2.0
+pygments==2.3.1
 pyparsing==2.3.0
 python-dateutil==2.7.5
 python-json-logger==0.1.10
 pytz==2018.7
-requests==2.20.1
+requests==2.21.0
 simplegeneric==0.8.1      # via ipython
-six==1.11.0
+six==1.12.0
 smartypants==2.0.1
 sqlparse==0.2.4           # via django-debug-toolbar
 text-unidecode==1.2
 traitlets==4.3.2          # via ipython
 typing==3.6.6
 typogrify==2.0.7
-unidecode==1.0.22
+unidecode==1.0.23
 unittest-xml-reporting==2.2.0
 urllib3==1.24.1
 wagtail-django-recaptcha==1.0

--- a/devops/requirements.txt
+++ b/devops/requirements.txt
@@ -1,5 +1,5 @@
 ansible-lint==3.4.23      # via molecule
-ansible==2.6.7
+ansible==2.6.11
 anyconfig==0.9.7          # via molecule
 arrow==0.12.1             # via jinja2-time
 asn1crypto==0.24.0        # via cryptography
@@ -7,10 +7,10 @@ atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 backports.functools-lru-cache==1.5  # via arrow
 backports.ssl-match-hostname==3.5.0.1  # via docker
-bcrypt==3.1.4             # via paramiko
+bcrypt==3.1.5             # via paramiko
 binaryornot==0.4.4        # via cookiecutter
 cerberus==1.2             # via molecule
-certifi==2018.10.15       # via requests
+certifi==2018.11.29       # via requests
 cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via binaryornot, requests
 click-completion==0.3.1   # via molecule
@@ -18,8 +18,8 @@ click==6.7                # via click-completion, cookiecutter, molecule, pip-to
 colorama==0.3.9           # via molecule, python-gilt
 configparser==3.5.0       # via flake8
 cookiecutter==1.6.0       # via molecule
-cryptography==2.4.1       # via ansible, paramiko
-docker-pycreds==0.3.0     # via docker
+cryptography==2.4.2       # via ansible, paramiko
+docker-pycreds==0.4.0     # via docker
 docker==2.7.0
 dparse==0.4.1             # via safety
 enum34==1.1.6             # via cryptography, flake8
@@ -28,7 +28,7 @@ flake8==3.5.0             # via molecule
 funcsigs==1.0.2           # via pytest
 future==0.17.1            # via cookiecutter
 git-url-parse==1.1.0      # via python-gilt
-idna==2.7                 # via cryptography, requests
+idna==2.8                 # via cryptography, requests
 ipaddress==1.0.22         # via cryptography, docker
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.10              # via ansible, click-completion, cookiecutter, jinja2-time, molecule
@@ -37,30 +37,30 @@ markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8
 molecule==2.19.0
 monotonic==1.5            # via fasteners
-more-itertools==4.3.0     # via pytest
+more-itertools==5.0.0     # via pytest
 packaging==18.0           # via dparse, safety
 paramiko==2.4.2           # via ansible
-pathlib2==2.3.2           # via pytest
+pathlib2==2.3.3           # via pytest
 pathspec==0.5.9           # via yamllint
 pbr==4.1.0                # via git-url-parse, molecule, python-gilt
 pexpect==4.6.0            # via molecule
-pip-tools==3.1.0
+pip-tools==3.2.0
 pluggy==0.8.0             # via pytest
 poyo==0.4.2               # via cookiecutter
 psutil==5.4.6             # via molecule
 ptyprocess==0.6.0         # via pexpect
 py==1.7.0                 # via pytest
-pyasn1==0.4.4             # via paramiko
+pyasn1==0.4.5             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.19           # via cffi
 pyflakes==1.6.0           # via flake8
 pynacl==1.3.0             # via paramiko
 pyparsing==2.3.0          # via packaging
-pytest==4.0.0             # via testinfra
+pytest==4.0.2             # via testinfra
 python-dateutil==2.7.5    # via arrow
 python-gilt==1.2.1        # via molecule
 pyyaml==3.13              # via ansible, ansible-lint, dparse, molecule, python-gilt, yamllint
-requests==2.20.1          # via cookiecutter, docker, safety
+requests==2.21.0          # via cookiecutter, docker, safety
 safety==1.8.4
 scandir==1.9.0            # via pathlib2
 sh==1.12.14               # via molecule, python-gilt

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 bleach>=2.1
 dj-database-url
-Django>=1.11.15<2
+Django>=1.11.18<2
 -e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json
 django-analytical
 django-anymail

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 -e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json
 beautifulsoup4==4.6.0     # via wagtail
 bleach==3.0.2
-certifi==2018.10.15       # via requests
+certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 dj-database-url==0.5.0
-django-analytical==2.4.0
+django-analytical==2.5.0
 django-anymail==5.0
 django-modelcluster==3.1
 django-recaptcha==1.4.0
@@ -13,31 +13,31 @@ django-settings-export==1.2.1
 django-taggit==0.22.2     # via wagtail
 django-treebeard==4.3     # via wagtail
 django-webpack-loader==0.6.0
-django==1.11.16
+django==1.11.18
 djangorestframework==3.6.4  # via wagtail
 docutils==0.14
 factory-boy==2.11.1
-faker==1.0.0              # via factory-boy
+faker==1.0.1              # via factory-boy
 gunicorn==19.9.0
 html5lib==0.999999999     # via wagtail
-idna==2.7                 # via requests
+idna==2.8                 # via requests
 jinja2==2.10
 markupsafe==1.1.0         # via jinja2
-pillow==5.3.0             # via wagtail
-pip-tools==3.1.0
+pillow==5.4.0             # via wagtail
+pip-tools==3.2.0
 psycopg2==2.7.6.1
-pygments==2.2.0
+pygments==2.3.1
 pyparsing==2.3.0
 python-dateutil==2.7.5    # via faker
 python-json-logger==0.1.10
 pytz==2018.7              # via django, django-modelcluster
-requests==2.20.1          # via django-anymail, wagtail
-six==1.11.0               # via bleach, django-anymail, faker, html5lib, pip-tools, python-dateutil, unittest-xml-reporting
+requests==2.21.0          # via django-anymail, wagtail
+six==1.12.0               # via bleach, django-anymail, faker, html5lib, pip-tools, python-dateutil, unittest-xml-reporting
 smartypants==2.0.1        # via typogrify
 text-unidecode==1.2       # via faker
 typing==3.6.6
 typogrify==2.0.7
-unidecode==1.0.22         # via wagtail
+unidecode==1.0.23         # via wagtail
 unittest-xml-reporting==2.2.0
 urllib3==1.24.1           # via requests
 wagtail-django-recaptcha==1.0


### PR DESCRIPTION
Due to CVE-2019-3498 (see
https://www.djangoproject.com/weblog/2019/jan/04/security-releases/), towards https://github.com/freedomofpress/fpf-www-projects/issues/30
