### PR TITLE
Add optional "limit" to Autocomplete widget

### DIFF
--- a/autocomplete/edit_handlers.py
+++ b/autocomplete/edit_handlers.py
@@ -20,9 +20,10 @@ def _can_create(page_type):
 
 
 class AutocompleteFieldPanel:
-    def __init__(self, field_name, page_type='wagtailcore.Page'):
+    def __init__(self, field_name, page_type='wagtailcore.Page', limit=20):
         self.field_name = field_name
         self.page_type = page_type
+        self.limit = limit
 
     def bind_to_model(self, model):
         can_create = _can_create(self.page_type)
@@ -32,16 +33,17 @@ class AutocompleteFieldPanel:
             widget=type(
                 '_Autocomplete',
                 (Autocomplete,),
-                dict(page_type=self.page_type, can_create=can_create, is_single=False),
+                dict(page_type=self.page_type, can_create=can_create, is_single=False, limit=self.limit),
             ),
         )
         return type('_AutocompleteFieldPanel', (BaseFieldPanel,), base)
 
 
 class AutocompletePageChooserPanel:
-    def __init__(self, field_name, page_type='wagtailcore.Page'):
+    def __init__(self, field_name, page_type='wagtailcore.Page', limit=20):
         self.field_name = field_name
         self.page_type = page_type
+        self.limit = limit
 
     def bind_to_model(self, model):
         # TODO: support list of page types
@@ -56,7 +58,7 @@ class AutocompletePageChooserPanel:
             widget=type(
                 '_Autocomplete',
                 (Autocomplete,),
-                dict(page_type=self.page_type, can_create=can_create, is_single=True)
+                dict(page_type=self.page_type, can_create=can_create, is_single=True, limit=self.limit)
             )
         )
         return type('_AutocompletePageChooserPanel', (BaseChooserPanel,), base)

--- a/autocomplete/templates/autocomplete/autocomplete.html
+++ b/autocomplete/templates/autocomplete/autocomplete.html
@@ -7,5 +7,6 @@
 		'{{ widget.page_type }}',
 		'{{ widget.can_create }}' === 'True',
 		'{{ widget.is_single }}' === 'True',
+		'{{ widget.limit}}',
 	);
 </script>

--- a/autocomplete/views.py
+++ b/autocomplete/views.py
@@ -63,13 +63,14 @@ def search(request):
         queryset = queryset.live()
 
     exclude = request.GET.get('exclude', '')
+    limit = int(request.GET.get('limit', 20))
     try:
         exclusions = [int(item) for item in exclude.split(',')]
         queryset = queryset.exclude(pk__in=exclusions)
     except:  # noqa: #E722
         pass
 
-    results = map(render_page, queryset[:20])
+    results = map(render_page, queryset[:limit])
     return JsonResponse(dict(pages=list(results)))
 
 

--- a/autocomplete/widgets.py
+++ b/autocomplete/widgets.py
@@ -38,6 +38,7 @@ class Autocomplete(Widget):
         context['widget']['page_type'] = self.page_type
         context['widget']['can_create'] = self.can_create
         context['widget']['is_single'] = self.is_single
+        context['widget']['limit'] = self.limit
         return context
 
     def format_value(self, value):

--- a/client/autocomplete/js/autocomplete.js
+++ b/client/autocomplete/js/autocomplete.js
@@ -9,7 +9,7 @@ axios.defaults.xsrfCookieName = 'csrftoken'
 axios.defaults.xsrfHeaderName = 'X-CSRFToken'
 
 
-window.renderAutocompleteWidget = (id, name, value, type, canCreate, isSingle) => {
+window.renderAutocompleteWidget = (id, name, value, type, canCreate, isSingle, limit) => {
 	render(
 		<Autocomplete
 			name={name}
@@ -18,6 +18,7 @@ window.renderAutocompleteWidget = (id, name, value, type, canCreate, isSingle) =
 			canCreate={canCreate}
 			isSingle={isSingle}
 			apiBase="/admin/autocomplete/"
+			limit={limit}
 		/>,
 		document.getElementById(id)
 	)

--- a/client/autocomplete/js/components/Autocomplete.js
+++ b/client/autocomplete/js/components/Autocomplete.js
@@ -71,6 +71,7 @@ class Autocomplete extends PureComponent {
 		const params = {
 			query: value,
 			type: this.props.type,
+			limit: this.props.limit,
 			exclude: this.getExclusions(),
 		}
 		axios.get(this.props.apiBase + 'search/', { params })
@@ -108,6 +109,7 @@ class Autocomplete extends PureComponent {
 		const params = {
 			ids,
 			type: this.props.type,
+			limit: this.props.limit,
 		}
 		axios.get(this.props.apiBase + 'objects/', { params })
 			.then(res => {


### PR DESCRIPTION
This pull request: 

1. Adds an optional `limit` parameter to the Autocomplete API that sets the maximum number of results returned for an autocomplete request. There is no maximum value to the limit.

2. Changes the `FieldPanel` and `PageChooser` autocomplete widget definitions to allow defining a limit amount on a per-widget basis.

3. Changes the autocomplete JS widget itself to send a limit in its API requests, if one was given in its props.

This pull request does not change any of the currently in-use Autocomplete areas in the admin site to have a limit other than the default (20). This is potentially something that can happen in a future PR once there's a better defined set of limits that should be changed.

Fixes #717 