### PR TITLE
Include only live incidents in the category summary

### DIFF
--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -259,6 +259,10 @@ class CategoryPage(MetadataPageMixin, Page):
 
         context = super(CategoryPage, self).get_context(request)
 
+        context['total_incidents'] = self.incidents.filter(
+            incident_page__live=True,
+        ).count()
+
         data = request.GET.copy()
         data['categories'] = str(self.id)
         incident_filter = IncidentFilter(data)

--- a/common/templates/common/category_page.html
+++ b/common/templates/common/category_page.html
@@ -58,7 +58,7 @@
 				<th class="data-table__label data-table__label--light">
 					Total cases
 				</th>
-				<td class="data-table__value">{{ page.incidents.all.count }}</td>
+				<td class="data-table__value">{{ total_incidents }}</td>
 			</tr>
 			{% if data_items %}
 				{% for item in data_items %}


### PR DESCRIPTION
This pull request fixes the incident summary count to tally only incidents with `live=True`. Thus the number will now always match the number of search results, which are only displayed when live, also.

Refs #755 