### PR TITLE
Add check migrations command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
             pipenv run docker-compose up -d
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 1 && echo -n .; done;
             pipenv run make dev-tests
+            pipenv run make check-migrations
 
   prod:
     machine: true

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ flake8: ## Runs flake8 linting in Python3 container.
 			python:3.4-slim \
 			bash -c "pip install -q flake8 && flake8"
 
+.PHONY: check-migrations
+check-migrations: ## Check for ungenerated migrations
+	docker-compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"
+
 .PHONY: bandit
 bandit: ## Runs bandit static code analysis in Python3 container.
 	@docker run -it -v $(PWD):/code -w /code --name fpf_www_bandit --rm \


### PR DESCRIPTION
This pull request adds a make command to check for ungenerated migrations. I've also put the command into the CI config so it's run when building the site, so that we don't inadvertently merge any PRs without having included all necessary migrations.