### PR TITLE
Treat non-integer values for RelationFilter as invalid

### DIFF
--- a/incident/tests/test_incident_filter.py
+++ b/incident/tests/test_incident_filter.py
@@ -229,3 +229,16 @@ class CleanTest(TestCase):
             [str(error) for error in cm.exception],
             ['Invalid parameter provided: not_a_parameter'],
         )
+
+    def test_invalid_data(self):
+        CategoryPage.objects.all().delete()
+        CategoryPageFactory(title='Category A', incident_filters=['state'])
+        incident_filter = IncidentFilter({'state': '???'})
+
+        with self.assertRaises(ValidationError) as cm:
+            incident_filter.clean(strict=True)
+
+        self.assertEqual(
+            [str(error) for error in cm.exception],
+            ['Expected integer for relationship "state", received "???"'],
+        )

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -49,6 +49,11 @@ class TestPages(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_get_index_should_succeed_with_invalid_foreign_key(self):
+        """get index should succeed with a noninteger foreign key reference."""
+        response = self.client.get('/incidents/?state=NONINTEGER_VALUE')
+        self.assertEqual(response.status_code, 200)
+
 
 class TestExportPage(TestCase):
     """CSV Exports"""

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -75,6 +75,19 @@ class BooleanFilter(Filter):
 class RelationFilter(Filter):
     serialized_type = 'autocomplete'
 
+    def clean(self, value, strict=False):
+        try:
+            return int(value)
+        except ValueError:
+            if strict:
+                raise ValidationError(
+                    'Expected integer for relationship "{}", received "{}"'.format(
+                        self.name,
+                        value,
+                    )
+                )
+            return None
+
     def serialize(self):
         serialized = super(RelationFilter, self).serialize()
         related_model = self.model_field.remote_field.model


### PR DESCRIPTION
This pull request updates `RelationFilter` to treat non-integer values as not valid. It's possible that a filter can receive invalid data if someone searching on the site directly enters values into the URL's query string, for example: `all-incidents/?state=not_a_valid_integer`. This change makes it so that if someone enters that URL, the state filter will be ignored. 

If strict mode is on, running `clean` on a `RelationFilter` with a non-integer value will raise a `ValidationError`.

It's possible that we could make this validity check even more stringent by only permitting values that are actually present as a primary key in the related table. E.g., `state=2` is only valid if there's a state in the database with id 2. But this PR does not do that.