### PR TITLE
Strip unserializable characters from incident feeds

### DIFF
--- a/incident/feeds.py
+++ b/incident/feeds.py
@@ -24,13 +24,13 @@ class IncidentIndexPageFeed(Feed):
         return [inline.category for inline in categories]
 
     def _get_complete_url(self, path):
-        # Strip control characters that return error from Django
         return urljoin(
             self.incident_index_page.get_site().root_url,
             path
         )
     
     def _get_cleaned_feed(self, text):
+        # Strip control characters that return error from Django
         return re.sub(
             r'[\x00-\x08\x0B-\x0C\x0E-\x1F]',
             '',


### PR DESCRIPTION
Fixes #753 

- Removes control characters `[\x00-\x08\x0B-\x0C\x0E-\x1F]` from incident title and description preventing xml parsing error in feed.
- Adds test for feeds.