### PR TITLE
Upgrade django to 2.1.10

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ django-settings-export==1.2.1
 django-taggit==0.23.0
 django-treebeard==4.3
 django-webpack-loader==0.6.0
-django==2.1.7
+django==2.1.10
 djangorestframework==3.9.2
 docutils==0.14
 draftjs-exporter==2.1.5
@@ -68,3 +68,6 @@ wagtail==2.3
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1
 willow==1.1
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via ipdb, ipython

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 bleach>=2.1
 dj-database-url
-Django>=2.1,<2.2
+Django>=2.1.10,<2.2
 -e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json
 django-analytical
 django-anymail

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-settings-export==1.2.1
 django-taggit==0.23.0     # via wagtail
 django-treebeard==4.3     # via wagtail
 django-webpack-loader==0.6.0
-django==2.1.7
+django==2.1.10
 djangorestframework==3.9.2  # via wagtail
 docutils==0.14
 draftjs-exporter==2.1.5   # via wagtail


### PR DESCRIPTION
This upgrade fixes a few security vulnerabilities.

This change was generated by modifying requirements.in to require the version we want to upgrade to and running make update-pip-dependencies.

Refs freedomofpress/fpf-www-projects#58