### PR TITLE
Checks the query string and throws 404 if string passed as parameter

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -72,9 +72,9 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
         post_filters = BlogFilter.from_querystring(request.GET)
         entry_qs = post_filters.filter(self.get_posts())
 
-        if post_filters.author:
+        if request.GET.get('author'):
             context['author_filter'] = get_object_or_404(PersonPage, pk=post_filters.author)
-        if post_filters.organization:
+        if request.GET.get('organization'):
             context['organization_filter'] = get_object_or_404(OrganizationPage, pk=post_filters.organization)
 
         paginator, entries = paginate(


### PR DESCRIPTION
Fixes #766 

Checks whether a querystring with author or organization is passed rather than if it's an integer value. Thus it can check and return 404 even when the value of author or organization query parameter is string instead of integer.