### PR TITLE
Enforce unique slugs for OrganizationPageFactory

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -169,6 +169,7 @@ class OrganizationPageFactory(wagtail_factories.PageFactory):
         model = OrganizationPage
 
     title = factory.Faker('company')
+    slug = factory.Sequence(lambda n: 'organization-{n}'.format(n=n))
     website = factory.Faker('uri')
     description = factory.Faker('catch_phrase')
 


### PR DESCRIPTION
This pull request fixes a bug where sometimes the `createdevdata` command could fail due to a `ValidationError`.