### PR TITLE
Ensure items in search button are vertically centered

### DIFF
--- a/client/common/sass/_search-bar.sass
+++ b/client/common/sass/_search-bar.sass
@@ -52,6 +52,7 @@ $search-bar-height: $search-bar-font-size * $search-bar-line-height
 	border-width: 0
 	display: flex
 	justify-content: center
+	align-items: center
 
 	background-color: $header-color
 	color: white


### PR DESCRIPTION
This pull request vertically centers the content inside the search button. I tested it in Firefox (where it previously was not centered) and in Chrome (where it previously was centered) and it works under both browsers on Ubuntu. This is probably worth testing on Mac OS as well, but I don't have access to that directly.

Fixes #813 