### PR TITLE
Skip image downloads when testing createdevdata command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
             pipenv run docker-compose -f prod-docker-compose.yaml build
             pipenv run docker-compose -f prod-docker-compose.yaml up -d
             while ! curl --output /dev/null --silent --head --fail http://$(docker-compose -f prod-docker-compose.yaml port nginx 8080); do sleep 1; done;
-            pipenv run docker-compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py createdevdata"
+            pipenv run docker-compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py createdevdata --no-download"
             pipenv run pytest devops/tests/test_basic.py
           no_output_timeout: 5m
 


### PR DESCRIPTION
This pull request changes our CI test configuration to skip image downloading when testing the `createdevdata` command. Testing things in isolation is nice and more consistent, so let's do more of that!