### PR TITLE
Use _top_image template instead of _teaser_image

### DIFF
--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -25,7 +25,7 @@ It can take the following context variables:
 	{% elif incident.primary_video %}
 		{% include "incident/_incident_video.html" with page=incident %}
 	{% elif incident.teaser_image %}
-		{% include "common/_teaser_image.html" with page=incident %}
+		{% include "common/_top_image.html" with page=incident %}
 	{% endif %}
 
 	<div class="incident__body">


### PR DESCRIPTION
A previous feature change erroneously caused the _teaser_image
template to be used on incident detail pages. This meant that
incident detail templates would have lower resolution images, not
display in color without hover, and would unnecessarily self-referentially
link. This change restores the original template.