### PR TITLE
Upgrade django from 2.1.10 to 2.1.11

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ django-settings-export==1.2.1
 django-taggit==0.23.0
 django-treebeard==4.3
 django-webpack-loader==0.6.0
-django==2.1.10
+django==2.1.11
 djangorestframework==3.9.2
 docutils==0.14
 draftjs-exporter==2.1.5

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 bleach>=2.1
 dj-database-url
-Django>=2.1.10,<2.2
+Django>=2.1.11,<2.2
 -e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json
 django-analytical
 django-anymail

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-settings-export==1.2.1
 django-taggit==0.23.0     # via wagtail
 django-treebeard==4.3     # via wagtail
 django-webpack-loader==0.6.0
-django==2.1.10
+django==2.1.11
 djangorestframework==3.9.2  # via wagtail
 docutils==0.14
 draftjs-exporter==2.1.5   # via wagtail


### PR DESCRIPTION
This upgrade fixes a few security vulnerabilities.  See https://docs.djangoproject.com/en/2.1/releases/2.1.11/ for more information.

This change was generated by modifying requirements.in to require the version we want to upgrade to and running `make update-pip-dependencies`.

Refs freedomofpress/fpf-www-projects#68