### PR TITLE
Replace VCS-based requirements with github-hosted archive files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ upgrade-pip: ## Uses pip-compile to update requirements.txt for upgrading a spec
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
 	docker run -v "$(DIR):/code" -w /code -it python:3.5-slim \
-		bash -c 'apt-get update && apt-get install git gcc -y && \
+		bash -c 'apt-get update && apt-get install gcc -y && \
 	pip install --require-hashes -r pip-tools-requirements.txt && \
 		pip-compile --generate-hashes --no-header --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
@@ -68,7 +68,7 @@ update-pip-dev: ## Uses pip-compile to update dev-requirements.txt for upgrading
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
 	docker run -v "$(DIR):/code" -w /code -it python:3.5-slim \
-		bash -c 'apt-get update && apt-get install git gcc -y && \
+		bash -c 'apt-get update && apt-get install gcc -y && \
 	pip install --require-hashes -r pip-tools-requirements.txt && \
 		pip-compile --require-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
 

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,6 @@ There are two Python requirements files:
 
 * ``requirements.in`` production application dependencies
 * ``dev-requirements.in`` local testing and CI requirements
-* ``requirements-github.txt`` contains URLs and commit hashes for GitHub-hosted dependencies.
 
 Add the desired dependency to the appropriate ``.in`` file, then run:
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -32,6 +32,8 @@ django-anymail==6.0 \
 django-debug-toolbar==1.11 \
     --hash=sha256:89d75b60c65db363fb24688d977e5fbf0e73386c67acf562d278402a10fc3736 \
     --hash=sha256:c2b0134119a624f4ac9398b44f8e28a01c7686ac350a12a74793f3dd57a9eea0
+https://github.com/freedomofpress/django-logging/zipball/b7d0b7b542db6ac088dbf3d2e7b249df333d3082 \
+    --hash=sha256:7a9857fff2988572ee03ae0ea2dc17e389095663ff72e2ea3fad904a4023b0f4
 django-modelcluster==5.0.1 \
     --hash=sha256:09e4242119f04e81bfab25c77b09cb6e9d469dc14b14e71f04cd358c7256bc2a \
     --hash=sha256:6f857bb0251c0982afeb35474aeedb3ec72260df81a0262188df8108067467ba

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -14,8 +14,6 @@ RUN  chmod +x /usr/local/bin/django-start.sh
 
 COPY dev-requirements.txt /requirements.txt
 RUN pip install --require-hashes -r /requirements.txt
-COPY requirements-github.txt /requirements-github.txt
-RUN pip install -r /requirements-github.txt
 
 ARG USERID
 RUN adduser --uid "${USERID}" --disabled-password --gecos "" gcorn || true

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -43,7 +43,6 @@ RUN find /django -path /django/node_modules -prune -o -print -exec chown gcorn: 
 
 WORKDIR /django
 RUN pip install --require-hashes -r /django/requirements.txt
-RUN pip install -r /django/requirements-github.txt
 
 
 # Really not used in production. Needed for mapped named volume

--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -1,1 +1,0 @@
--e git+https://github.com/freedomofpress/django-logging.git@b7d0b7b542db6ac088dbf3d2e7b249df333d3082#egg=django-logging-json

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+https://github.com/freedomofpress/django-logging/zipball/b7d0b7b542db6ac088dbf3d2e7b249df333d3082
 bleach>=2.1
 dj-database-url
 Django>=2.2,<2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ django-analytical==2.5.0 \
 django-anymail==6.0 \
     --hash=sha256:ab5cbfb280492c9cb2ef0497f8ebda4dcb3f99603dcf63c88ae623a66cad71f4 \
     --hash=sha256:f872089943f30283d485d121924598f4156f5bfa76a0885fd66df5205102be0b
+https://github.com/freedomofpress/django-logging/zipball/b7d0b7b542db6ac088dbf3d2e7b249df333d3082 \
+    --hash=sha256:7a9857fff2988572ee03ae0ea2dc17e389095663ff72e2ea3fad904a4023b0f4
 django-modelcluster==5.0.1 \
     --hash=sha256:09e4242119f04e81bfab25c77b09cb6e9d469dc14b14e71f04cd358c7256bc2a \
     --hash=sha256:6f857bb0251c0982afeb35474aeedb3ec72260df81a0262188df8108067467ba


### PR DESCRIPTION
This pull request unifies our package installation system to use a single installation method, with the added bonus of being able to require hashes for all the packages we use.  See commit for more details. We're doing this for our other websites, and we get increased security along with the simplicity of a single `.txt` file for all our production requirements.