### PR TITLE
Removes grayscale filter from teaser image in small screens

### DIFF
--- a/client/common/sass/_mixins.sass
+++ b/client/common/sass/_mixins.sass
@@ -203,3 +203,7 @@
 	+hover
 		filter: progid:DXImageTransform.Microsoft.BasicImage(grayScale=0)
 		filter: grayscale(0%)
+
+	@media(hover: none)
+		filter: progid:DXImageTransform.Microsoft.BasicImage(grayScale=0)
+		filter: grayscale(0%)


### PR DESCRIPTION
Fixes #790 

I have added the media check in the mixins itself because I reckon whenever I use the mixins of `gray-except-hover`, it takes into consideration the hovering capability of the media device. Also, since almost [all browser supports media interaction features](https://caniuse.com/#feat=css-media-interaction), I have user the `@media(hover: none)` instead of the width measurement.