### PR TITLE
Rework home page features query to be preview compatible

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -146,9 +146,9 @@ class HomePage(MetadataPageMixin, Page):
         search_page = SearchSettings.for_site(request.site).search_page
         context['export_path'] = getattr(search_page, 'url', None)
 
-        context['features'] = Page.objects.filter(
-            homepagefeature__home_page=self
-        ).live().order_by('homepagefeature__sort_order').specific()
+        context['features'] = [
+            f.page.specific for f in self.features.all().select_related('page')
+        ]
         return context
 
 


### PR DESCRIPTION
This pull request adjusts the home page features query to work properly with the preview feature of the wagtail admin. See commit for more detail on the tradeoffs (they're small but extant).

Fixes #832 