### PR TITLE
Fixes flex alignments for nav header

### DIFF
--- a/client/common/sass/_header.sass
+++ b/client/common/sass/_header.sass
@@ -72,6 +72,7 @@
 	&__logo-svg
 		position: relative
 		z-index: 1
+		max-width: 100%
 
 		path
 			fill: #fff


### PR DESCRIPTION
Fixes #864 

Seems like the main problem was that the `header__nav` was assigned fixed height values based on media screen causing things to clutter. Since the header navigation has customisable number of items, I don't think this is a good approach. So instead I removed the heights so that the flexbox can take up the height of the content and then stretched the parent flexbox instead of aligning it center (since previously also technically it was stretched because the parent flexbox and the header__nav had same height).

@harrislapiroff @chigby do check in different widths and let me know if everything looks okay.