### PR TITLE
Shortens the IntInputs length to 5em instead of the normal 50% for text

### DIFF
--- a/client/common/js/filtering/Inputs.js
+++ b/client/common/js/filtering/Inputs.js
@@ -134,6 +134,7 @@ export function IntInput({ handleFilterChange, filterValues, label, filter, unit
 					onChange={handleFilterChange.bind(null, filter)}
 					value={value}
 					className={classNames(
+						'filter-int-input',
 						'filter-text-input',
 						{ 'filter-text-input--has-input': value.length > 0 }
 					)}

--- a/client/common/sass/filters/_text-input.sass
+++ b/client/common/sass/filters/_text-input.sass
@@ -8,3 +8,6 @@
 
 	&--has-input
 		background-color: $white
+
+	&.filter-int-input
+		width: 5em


### PR DESCRIPTION
Fixes #870 

![Screenshot_2020-04-06 Home](https://user-images.githubusercontent.com/9530293/78569001-93bb7f00-7840-11ea-872f-0aca2aa9528f.png)
