### PR TITLE
Updates wagtail to 2.7.2 to fix CVEs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -364,9 +364,9 @@ wagtail-metadata==2.0.1 \
     --hash=sha256:1b710fcd6c96f2405db0d9f12ea3055a4532f3e4a43bcb2793700cde714841f1 \
     --hash=sha256:e3ef0776d3a429239dce4d164ac40c779f5d8ac958c630e0ab7442c25c54692e \
     # via -r requirements.txt
-wagtail==2.7.1 \
-    --hash=sha256:580a75944f805a3686dbec97a3479e631cee2dc29fdea3d916055b1db36ad475 \
-    --hash=sha256:69d1b5ca5fcac0812f923fa900040a15768961942f76e71c92f7043f172ea7a3 \
+wagtail==2.7.2 \
+    --hash=sha256:357cdb5733aeed18ae36c865eefd04484f545387331371d26a40b99affb1a327 \
+    --hash=sha256:e4d129ec3560cc4ee1fc9dae384c898938dded2bd7e7197376da8517be6b688b \
     # via -r requirements.txt, wagtail-autocomplete, wagtail-factories, wagtail-metadata
 wcwidth==0.1.7 \
     --hash=sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e \

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ python-json-logger
 pyparsing
 typing
 typogrify
-wagtail>=2.7,<2.8
+wagtail>=2.7.2,<2.8
 wagtail-autocomplete
 wagtail-factories
 wagtail-django-recaptcha

--- a/requirements.txt
+++ b/requirements.txt
@@ -259,9 +259,9 @@ wagtail-metadata==2.0.1 \
     --hash=sha256:1b710fcd6c96f2405db0d9f12ea3055a4532f3e4a43bcb2793700cde714841f1 \
     --hash=sha256:e3ef0776d3a429239dce4d164ac40c779f5d8ac958c630e0ab7442c25c54692e \
     # via -r requirements.in
-wagtail==2.7.1 \
-    --hash=sha256:580a75944f805a3686dbec97a3479e631cee2dc29fdea3d916055b1db36ad475 \
-    --hash=sha256:69d1b5ca5fcac0812f923fa900040a15768961942f76e71c92f7043f172ea7a3 \
+wagtail==2.7.2 \
+    --hash=sha256:357cdb5733aeed18ae36c865eefd04484f545387331371d26a40b99affb1a327 \
+    --hash=sha256:e4d129ec3560cc4ee1fc9dae384c898938dded2bd7e7197376da8517be6b688b \
     # via -r requirements.in, wagtail-autocomplete, wagtail-factories, wagtail-metadata
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \


### PR DESCRIPTION
Updates to wagtail 2.7.2 to fix CVE-2020-11001 - prevent XSS attack via page revision comparison view (Vlad Gerasimenko, Matt Westcott) https://github.com/wagtail/wagtail/releases/tag/v2.7.2