### PR TITLE
Gracefully handle noninteger page/endpage values

### DIFF
--- a/common/utils/paginate.py
+++ b/common/utils/paginate.py
@@ -5,8 +5,13 @@ DEFAULT_PAGE_KEY = 'page'
 
 
 def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20, orphans=10):
-    page_number = int(request.GET.get(page_key, 1))
-    endpage = int(request.GET.get('endpage', 1))
+    try:
+        page_number = int(request.GET.get(page_key, 1))
+        endpage = int(request.GET.get('endpage', 1))
+    except ValueError:
+        page_number = 1
+        endpage = 1
+
     # See https://docs.djangoproject.com/en/1.10/topics/pagination/#using-paginator-in-a-view
     paginator = Paginator(items, per_page)
     try:

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -64,6 +64,16 @@ class TestPages(TestCase):
         response = self.client.get('/incidents/?state=NONINTEGER_VALUE')
         self.assertEqual(response.status_code, 200)
 
+    def test_get_index_should_succeed_with_noninteger_page_number(self):
+        """get index should succeed with a noninteger foreign key reference."""
+        response = self.client.get('/incidents/?page=abc')
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_index_should_succeed_with_noninteger_endpage_number(self):
+        """get index should succeed with a noninteger foreign key reference."""
+        response = self.client.get('/incidents/?endpage=abc')
+        self.assertEqual(response.status_code, 200)
+
 
 class TestExportPage(TestCase):
     """CSV Exports"""


### PR DESCRIPTION
This pull request adds error handling during pagination for when the requested `page` and `endpage` values are not valid integers. If we get invalid page numbers, instead of raising an exception, we will fall back to returning page 1 by default.

Fixes #871 