### PR TITLE
Exclude non-updated incidents from recently updated filter

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -4,8 +4,6 @@ from django import forms
 from django.db import models
 from django.db.models import (
     OuterRef,
-    F,
-    Q,
     Max,
     ExpressionWrapper,
     Subquery,
@@ -83,14 +81,11 @@ class IncidentQuerySet(PageQuerySet):
             updated_days_ago=ExtractDay(ExpressionWrapper(
                 CurrentDate() - Subquery(updates), output_field=models.DateField())
             ),
-            published_days_ago=ExtractDay(ExpressionWrapper(
-                CurrentDate() - F('first_published_at'), output_field=models.DateField())
-            ),
         )
 
     def updated_within_days(self, days):
         return self.with_most_recent_update().filter(
-            Q(updated_days_ago__lte=days) | Q(published_days_ago__lte=days)
+            updated_days_ago__lte=days
         )
 
 

--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -1294,12 +1294,12 @@ class RecentlyUpdatedFilterTest(TestCase):
         incidents = incident_filter.get_queryset()
         self.assertEqual(set(incidents), {incident_with_new_update})
 
-    def test_filters_recently_published_incidents(self):
+    def test_filters_recently_updated_excludes_nonupdated_incidents(self):
         IncidentPageFactory(
             first_published_at=timezone.now() - timedelta(days=90),
         )
 
-        incident_new = IncidentPageFactory(
+        IncidentPageFactory(
             first_published_at=timezone.now() - timedelta(days=3),
         )
 
@@ -1309,9 +1309,14 @@ class RecentlyUpdatedFilterTest(TestCase):
 
         incident_filter.clean()
         incidents = incident_filter.get_queryset()
-        self.assertEqual(set(incidents), {incident_new})
+        self.assertEqual(set(incidents), set())
 
     def test_filters_recently_published_or_updated_incidents(self):
+        """The recently_updated filter only includes incidents that have
+        associated updates, no matter how recently they were
+        published.
+
+        """
         IncidentPageFactory(
             first_published_at=timezone.now() - timedelta(days=90),
         )
@@ -1335,7 +1340,7 @@ class RecentlyUpdatedFilterTest(TestCase):
             date=timezone.now() - timedelta(days=12),
         )
 
-        incident_new = IncidentPageFactory(
+        IncidentPageFactory(
             first_published_at=timezone.now() - timedelta(days=3),
         )
 
@@ -1345,4 +1350,4 @@ class RecentlyUpdatedFilterTest(TestCase):
 
         incident_filter.clean()
         incidents = incident_filter.get_queryset()
-        self.assertEqual(set(incidents), {incident_new, incident_with_new_update})
+        self.assertEqual(set(incidents), {incident_with_new_update})


### PR DESCRIPTION
This pull request updates the logic of the recently updated filter to ignore the `first_published_at` field.

Formerly, the recently updated filter selected incidents that were published OR updated within the past N days.  Now it only selects incidents that were updated.  If an incident does not have any updates, it will no longer be included in any results from this filter.

Fixes #880 