### PR TITLE
circle ci: Ensure test suite raises error when it does not pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ci-tests: ## Runs testinfra against a pre-running CI container (useful for debug
 
 .PHONY: dev-tests
 dev-tests: ## Run django tests against developer environment
-	docker-compose exec django /bin/bash -c \
+	docker-compose exec django /bin/bash -ec \
 		"coverage run --source='.' ./manage.py test --noinput --keepdb; \
 		coverage html --skip-empty --omit='*/migrations/*.py,*/tests/*.py'; \
 		coverage report -m --fail-under=85 --skip-empty --omit='*/migrations/*.py,*/tests/*.py'"


### PR DESCRIPTION
This pull request adds `-e` to the `make` command's `bash` call used to execute the test suite.

`bash -e` ensures that non-zero exit codes during any "intermediate"
command (e.g. in a sequence of semicolon separated commands, which we
have here) are propagated upwards and the entire call to `bash`
returns a non-zero code.  This is needed so that Circle CI becomes
aware that the test command failed.

## Testing and Acceptance

It's possible to see the effect of this in action locally but running the test suite where you know it will fail then inspecting the exit status with `echo $?`.

 If you modify a test so it will fail, e.g. with an `assert False` statement, then run 

```
make dev-tests
```

The exit code _with_ this change should be nonzero. Without this change, on master, should be zero.