### PR TITLE
Fix incident filter date picker

### DIFF
--- a/client/common/js/filtering/IncidentFiltering.js
+++ b/client/common/js/filtering/IncidentFiltering.js
@@ -320,7 +320,7 @@ class IncidentFiltering extends PureComponent {
 		let value
 		if (!event) {
 			value = null
-		} else if (isMoment(event)) {
+		} else if (isMoment(event) || event instanceof Date) {
 			value = event
 		} else if (event.target && event.target.hasOwnProperty('checked')) {
 			value = event.target.checked


### PR DESCRIPTION
This pull request updates the filter UI code to handle "native" JS date objects being emitted from the react-datepicker component. When we updated this component to be compatible with react 16, one thing it changed was to stop using Moment and instead use regular old JS dates. I've updated the filter change handling code to account for that. 

Note we must still account for moment objects being sent, as we are using Moment to parse manually input dates, i.e. those typed directly into the input box without using the date picker. I've tested both cases and they seem to work as expected.

Fixes #924