### PR TITLE
Remove "content" from logged response fields

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -229,7 +229,8 @@ DJANGO_LOGGING = {
     "PROPOGATE": False,
     "LOG_LEVEL": os.environ.get('DJANGO_LOG_LEVEL', 'info'),
     # Do not log the content of JSON responses by default--these might be quite big!
-    "CONTENT_JSON_ONLY": os.environ.get('LOG_CONTENT_JSON_ONLY', False)
+    "RESPONSE_FIELDS": ('status', 'reason', 'charset', 'headers'),
+    "ENCODING": "utf-8",
 }
 
 ## Ensure base log directory exists


### PR DESCRIPTION
This pull request updates the settings of the django-logging package to exclude the "content" field from the JSON object being logged. This was causing problems due to the large size of some responses.

Pull request #923 introduced the `CONTENT_JSON_ONLY = False` setting, which this PR returns to its default setting of `True`.   I believe the method in this PR is the correct way to achieve the goal of content-free request/response JSON logging. 

Also changes the default content encoding to UTF-8.  Even though we are not including the content, if that ever were to happen, it could cause an error if the default setting of `'ascii'` is used, since much of our content is not decodable into ASCII.