### PR TITLE
Fix date picker when loading values from query string

### DIFF
--- a/client/common/js/filtering/IncidentFiltering.js
+++ b/client/common/js/filtering/IncidentFiltering.js
@@ -73,8 +73,8 @@ class IncidentFiltering extends PureComponent {
 				if (filter.type === 'date') {
 					const lowerDate = `${filter.name}_lower`
 					const upperDate = `${filter.name}_upper`
-					if (params[lowerDate]) newAcc[lowerDate] = moment(params[lowerDate])
-					if (params[upperDate]) newAcc[upperDate] = moment(params[upperDate])
+					if (params[lowerDate]) newAcc[lowerDate] = moment(params[lowerDate]).toDate()
+					if (params[upperDate]) newAcc[upperDate] = moment(params[upperDate]).toDate()
 				} else if (filter.type === 'autocomplete' && params[filter.name]) {
 					if (filter.many) {
 						newAcc[filter.name] = params[filter.name]

--- a/client/common/js/filtering/Inputs.js
+++ b/client/common/js/filtering/Inputs.js
@@ -207,7 +207,7 @@ export class DateRangeInput extends PureComponent {
 		const moment = Moment(value, DATE_TYPES, true)
 
 		if (moment.isValid()) {
-			this.props.handleFilterChange(filter_key, moment)
+			this.props.handleFilterChange(filter_key, moment.toDate())
 		}
 	}
 


### PR DESCRIPTION
This pull request alters the date filter code to convert moment values to JS date values before storing

Fixes a problem with logic introduced in 9382434a975a3dd1b8c3abd41678cfa8a1b019f1