### PR TITLE
Fixes autocomplete suggestion

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,9 @@ module.exports = api => {
           '@babel/preset-env',
           {
             modules: false,
+            "targets": {
+              "node": "current"
+            },
           },
         ],
         '@babel/preset-react',

--- a/client/autocomplete/js/components/Autocomplete.js
+++ b/client/autocomplete/js/components/Autocomplete.js
@@ -33,6 +33,9 @@ class Autocomplete extends PureComponent {
 
 	get value() {
 		if (this.props.controlled) {
+			if (!!this.props.value && !this.props.value[0].title) {
+				this.fetchInitialValues(this.props.value)
+			}
 			return this.props.value
 		} else {
 			return this.state.value

--- a/client/common/js/tests/Inputs.test.js
+++ b/client/common/js/tests/Inputs.test.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import axios from 'axios';
+import { shallow, mount } from 'enzyme';
+import { AutocompleteInput } from '~/filtering/Inputs';
+import Autocomplete from 'WagtailAutocomplete/Autocomplete';
+import { TAG_FILTER_VALUES, EMPTY_FILTER_VALUES, TAG_MOCK_RESULTS } from '~/tests/factories/CategoriesFilterFactory';
+
+jest.mock('axios');
+
+// Allows me to ensure that all the promises are resolved.
+// setImmediate isn't to be used in production but should
+// be fine for testing and CI.
+const flushPromises = () => new Promise(setImmediate);
+
+describe('Inputs', () => {
+
+    it('should render AutocompleteInput without error in "debug" mode', () => {
+        const component = shallow(
+            <AutocompleteInput
+                handleFilterChange={jest.fn()}
+                filter={'tags'}
+                filterValues={EMPTY_FILTER_VALUES}
+                label={'Autocomplete'}
+                isSingle={false}
+                type={'common.CommonTag'}
+            />
+        );
+
+        expect(component.debug()).toMatchSnapshot();
+    });
+
+	it('should render Autocomplete correctly', async () => {
+        axios.get.mockImplementationOnce(() => Promise.resolve(
+            {
+                'data': TAG_MOCK_RESULTS,
+                'status': 200
+            }
+        ));
+		const component = mount(
+            <AutocompleteInput
+                handleFilterChange={jest.fn()}
+                filter={'tags'}
+                filterValues={EMPTY_FILTER_VALUES}
+                label={'Autocomplete'}
+                isSingle={false}
+                type={'common.CommonTag'}
+            />
+        )
+        await flushPromises();
+        component.update();
+        const autocompleteComponent = component.find('.autocomplete');
+        expect(autocompleteComponent.length).toEqual(1);
+        expect(autocompleteComponent.find('.suggestions .suggestions__item').length).toEqual(2);
+        component.find('.autocomplete__search').simulate('focus');
+        expect(component.find('.suggestions').prop('style')).toHaveProperty('display', 'block');
+    });
+
+    it('should render Autocomplete selection results correctly when clicked', async() => {
+        axios.get.mockImplementationOnce(() => Promise.resolve(
+            {
+                'data': TAG_MOCK_RESULTS,
+                'status': 200
+            }
+        ));
+		const component = mount(
+            <AutocompleteInput
+                handleFilterChange={jest.fn()}
+                filterValues={EMPTY_FILTER_VALUES}
+                label={'Autocomplete'}
+                filter={'tags'}
+                isSingle={false}
+                type={'common.CommonTag'}
+            />
+        );
+
+        // Mock function to update the props of the root component
+        const handleFilterChangeMock = jest.fn((label, event) => {
+            component.setProps({filterValues: {[label]: event.target.value}});
+        });
+        component.setProps({handleFilterChange: handleFilterChangeMock});
+
+        // Used to complete all the promises
+        await flushPromises();
+        component.update();
+
+        // Before clicking nothing exist
+        expect(component.find('.autocomplete-layout__item--padded span').text()).toEqual('Nothing selected.');
+        component.find('.autocomplete__search').simulate('focus');
+
+        // Simulate clicking the first option
+        const suggestions = component.find('.suggestions .suggestions__item');
+        suggestions.first().simulate('click');
+        component.update();
+
+        // Check clicking renders the selection
+        const selection = component.find('.autocomplete-layout__item--padded .selection');
+        expect(selection.length).toEqual(1);
+        expect(selection.find('.selection__label').text()).toEqual('Tag 1');
+
+        // Simulate clicking the apply filter button by setting props
+        const fetchResult = {
+            items: TAG_MOCK_RESULTS.items.filter(result => result.pk === TAG_FILTER_VALUES.tags[0].id),
+        }
+        axios.get.mockImplementation(() => Promise.resolve(
+            {
+                'data': fetchResult,
+                'status': 200
+            }
+        ));
+        component.setProps({filterValues: TAG_FILTER_VALUES});
+        // Used to complete all the promises
+        await flushPromises();
+        component.update();
+        // Check selection still has text
+        expect(component.find('.selection .selection__label').text()).toEqual('Tag 1');
+    });
+
+    it('should render Autocomplete correctly when filtervalues are there in URL', async () => {
+        const fetchResult = {
+            items: TAG_MOCK_RESULTS.items.filter(result => result.pk === TAG_FILTER_VALUES.tags[0].id),
+        }
+        axios.get.mockImplementation((url) => {
+            if (url.indexOf('/autocomplete/search/') !== -1) {
+                return Promise.resolve(
+                    {
+                        'data': TAG_MOCK_RESULTS,
+                        'status': 200
+                    }
+                )
+            } else if (url.indexOf('/autocomplete/objects/') !== -1) {
+                return Promise.resolve(
+                    {
+                        'data': fetchResult,
+                        'status': 200
+                    }
+                )
+            }
+        });
+		const component = mount(
+            <AutocompleteInput
+                handleFilterChange={jest.fn()}
+                filter={'tags'}
+                filterValues={TAG_FILTER_VALUES}
+                label={'Autocomplete'}
+                isSingle={false}
+                type={'common.CommonTag'}
+            />
+        );
+        // Mock function to update the props of the root component
+        const handleFilterChangeMock = jest.fn((label, event) => {
+            component.setProps({filterValues: {[label]: event.target.value}});
+        });
+        component.setProps({handleFilterChange: handleFilterChangeMock});
+
+        await flushPromises();
+        component.update();
+        const selection = component.find('.autocomplete-layout__item--padded .selection');
+        expect(selection.length).toEqual(1);
+        expect(selection.find('.selection__label').text()).toEqual('Tag 1');
+    });
+});

--- a/client/common/js/tests/__snapshots__/Inputs.test.js.snap
+++ b/client/common/js/tests/__snapshots__/Inputs.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Inputs should render AutocompleteInput without error in "debug" mode 1`] = `
+"<div className=\\"filters__input-row\\">
+  <span className=\\"filters__input-label\\">
+    Autocomplete
+  </span>
+  <Autocomplete type=\\"common.CommonTag\\" name=\\"tags\\" canCreate={false} isSingle={false} value={[undefined]} onChange={[Function: bound mockConstructor]} fetchInitialValues={true} apiBase=\\"/autocomplete/\\" controlled={true} />
+</div>"
+`;

--- a/client/common/js/tests/factories/CategoriesFilterFactory.js
+++ b/client/common/js/tests/factories/CategoriesFilterFactory.js
@@ -154,9 +154,6 @@ export const BOOL_FILTER_VALUES = {
 export const CHOICE_FILTER_VALUES = {
   'status_of_prior_restraint': 'PENDING'
 }
-export const AUTOCOMPLETE_FILTER_VALUES = {
-  
-}
 export const EMPTY_FILTER_VALUES = {
 }
 export const PAGE_FETCH_PARAMS = {
@@ -164,3 +161,14 @@ export const PAGE_FETCH_PARAMS = {
 	'charged_under_espionage_act': 'True'
 }
 export const FILTERS_EXPANDED = true
+export const TAG_FILTER_VALUES = {
+  'tags': [
+    {'id': 1}
+  ]
+}
+export const TAG_MOCK_RESULTS = {
+  'items': [
+    {'pk': 1, 'title': 'Tag 1'},
+    {'pk': 2, 'title': 'Tag 2'}
+  ]
+}


### PR DESCRIPTION
Fixes #917 

PS: I found out that fetching the details for a tag (title, etc.) are done by the Autocomplete component. So when the URL already has the params `?tags=1` for example, then the [constructor for the Autocomponent component calls the `fetchInitialValues()`](https://github.com/wagtail/wagtail-autocomplete/blob/master/client/src/components/AutocompleteInput/AutocompleteInput.js#L28) hence loading the details. Whereas when selected from the dropdown, the dropdown list fetched, already has the title attribute for each tag dictionary. However, after I click the "Apply Filter" it re-renders everything (now the tags value is {id: 1} because of re-rendering) and Autocomplete also re-renders but the fetchInitialValues isn't called. Hence there is no title attribute present, and hence missing text.

The fetchInitialValues should be called even during re-rendering to get the other attributes like title. Now I have included the directly in `get value()` function of Autocomplete component. Might make sense to put that in render() instead.

The other way would be, on re-rendering, do something similar to fetchInitialValues of Autocomplete in the IncidentFilter component. But since the fetchInitialValues is already being used in case the URL has the params, I though of using the same function in the same component. Not sure if it's the best idea.

@chigby @harrislapiroff  if it looks good to you, I will add some kind of jest test to check that the autocomplete values have the title attribute.