### PR TITLE
Add JS shim to correct category ordering on incident creation

### DIFF
--- a/incident/templates/wagtailadmin/base.html
+++ b/incident/templates/wagtailadmin/base.html
@@ -1,0 +1,33 @@
+{% extends "wagtailadmin/base.html" %}
+{% load static %}
+
+{% comment %}
+
+This template exists to shim a JS function into the wagtail admin to
+correct for a bug in the wagtail admin where inline panels defined
+with a `min_num` are not correctly ordered during object creation.
+
+See https://github.com/wagtail/wagtail/issues/4010 for details.  If
+that issue is fixed, then this function can and should be removed.
+
+{% endcomment %}
+
+{% block extra_js %}
+	{{ block.super }}
+	<script>
+		function fixOrderables() {
+			// Find all inputs that contain -ORDER in their ID.
+			$("input[id*='-ORDER").each(function(){
+				if($(this).val() === ""){
+					var inputId = $(this).attr("id");
+					// Extract the "real" order from the ID and 1 to new order value.
+					var inputVal = parseInt(inputId.substr(inputId.indexOf("-ORDER") - 1, 1))+1;
+					if (parseInt($(this).val()) != inputVal){
+						$(this).val(inputVal);
+					}
+				}
+			});
+		}
+		document.addEventListener("DOMContentLoaded", fixOrderables);
+	</script>
+{% endblock %}


### PR DESCRIPTION
This PR adds a small JS function to the admin pages to re-number certain `<input>` fields related to ordering if they appear to be erroneously blank. This function was mostly borrowed from the [wagtail issue](https://github.com/wagtail/wagtail/issues/4010) that more fully describes this bug.

I've tested this locally and it appears to fix the problem, but it ought to be removed if/when the bug is fixed in wagtail itself.

Fixes #922