### PR TITLE
Add fields parameter to export view

### DIFF
--- a/incident/models/export.py
+++ b/incident/models/export.py
@@ -54,7 +54,7 @@ def is_exportable(field):
     return not (name.startswith('tagged_') or name in EXCLUDED_FIELDS)
 
 
-def to_row(obj):
+def to_row(obj, allowed_fields=[]):
     """Flatten a model object into a list of strings suitable for a CSV
 
     This function attempts to introspect an object's fields and turn
@@ -67,17 +67,24 @@ def to_row(obj):
     row = []
 
     model = type(obj)
-    model_fields = model._meta.get_fields()
+    if allowed_fields:
+        model_fields = [f for f in model._meta.get_fields() if f.name in allowed_fields]
+    else:
+        model_fields = model._meta.get_fields()
 
     for field in filter(is_exportable, model_fields):
         row.append(_serialize_field(obj, field))
     return row
 
 
-def to_json(obj):
+def to_json(obj, allowed_fields=[]):
     incident_dict = {}
     model = type(obj)
-    model_fields = model._meta.get_fields()
+    if allowed_fields:
+        model_fields = [f for f in model._meta.get_fields() if f.name in allowed_fields]
+    else:
+        model_fields = model._meta.get_fields()
+
     for field in filter(is_exportable, model_fields):
         incident_dict[field.name] = _serialize_field(obj, field)
     return incident_dict

--- a/incident/tests/test_incidents_export.py
+++ b/incident/tests/test_incidents_export.py
@@ -128,3 +128,39 @@ class IncidentExportTestCase(TestCase):
         response_data = json.loads(response.content.decode('utf-8'))
         self.assertEqual(len(response_data), 1)
         self.assertEqual(response_data[0].keys(), expected_headers)
+
+    def test_fields__json(self):
+        IncidentPageFactory(
+            city='Albuquerque',
+            date='2010-01-01',
+            title='Took a Wrong Turn',
+        )
+        response = self.client.get(
+            self.incident_index.get_full_url() + 'export/?format=json&fields=title,city,date'
+        )
+        response_data = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(
+            response_data,
+            [{'city': 'Albuquerque', 'date': '2010-01-01', 'title': 'Took a Wrong Turn'}]
+        )
+
+    def test_fields__csv(self):
+        IncidentPageFactory(
+            city='Albuquerque',
+            date='2010-01-01',
+            title='Took a Wrong Turn',
+        )
+        response = self.client.get(
+            self.incident_index.get_full_url() + 'export/?format=csv&fields=title,city,date'
+        )
+
+        content = b''.join(list(response.streaming_content)).strip().decode('utf-8').splitlines()
+        headers = content[0].split(',')
+        data = content[1].split(',')
+
+        expected_headers = ['title', 'date', 'city']
+        self.assertEqual(headers, expected_headers)
+
+        expected_data = ['Took a Wrong Turn', '2010-01-01', 'Albuquerque']
+        self.assertEqual(data, expected_data)


### PR DESCRIPTION
This pull request updates the export API to check for a `fields` parameter in the data sent to it. This parameter takes a comma-separated list of field names and instructs the API to only return those fields (if available) in the response data.

Fixes #934 