### PR TITLE
Fix category counts

### DIFF
--- a/incident/models/topic_page.py
+++ b/incident/models/topic_page.py
@@ -242,6 +242,7 @@ class TopicPage(RoutablePageMixin, MetadataPageMixin, Page):
             id__in=models.Subquery(
                 IncidentCategorization.objects.filter(
                     incident_page__tags=self.incident_tag,
+                    incident_page__live=True,
                     category=models.OuterRef('category_id')
                 ).order_by('-incident_page__date').values_list('id', flat=True)[:self.incidents_per_module]
             )

--- a/incident/tests/test_topic_api.py
+++ b/incident/tests/test_topic_api.py
@@ -158,6 +158,16 @@ class TopicPageApi(TestCase):
 
         self.assertEqual(cat2['total_journalists'], 0)
 
+    def test_GET_does_not_include_draft_incidents(self):
+        response = self.client.get(self.url)
+        data = json.loads(response.content.decode('utf-8'))
+        cat2 = data[0]
+
+        self.assertNotIn(
+            self.draft_incident.get_full_url(),
+            [i['url'] for i in cat2['incidents']]
+        )
+
     def test_GET_counts_distinct_journalists(self):
         TargetedJournalistFactory(
             journalist=self.tj_incident_1.journalist,


### PR DESCRIPTION
This pull request:

1. Updates the topic page API to include only _distinct_ journalists in the "journalists affected" count. Fixes #940.

2. Updates the topic page API to exclude draft incident pages from the list of incidents in each category.