### PR TITLE
Smarter related incidents

### DIFF
--- a/incident/templates/incident/incident_page.html
+++ b/incident/templates/incident/incident_page.html
@@ -9,19 +9,22 @@
 {% block maincontainer %}
 <main>
 	{% include 'incident/_incident.html' with incident=page only %}
-	{% include "common/_section_heading.html" with label="Related Incidents" %}
-	<div class="grid-50">
-		{% for related_case in page.get_related_incidents %}
-			<div class="grid-50__item">
-				{% include "incident/_incident.html" with incident=related_case teaser=True only %}
-			</div>
-		{% endfor %}
-	</div>
-	<a
-		href="{% pageurl page.get_parent %}?categories={{ page.categories.all|comma_separated_pks:'category' }}"
-		class="button button--outline button--center">
-		More related incidents
-	</a>
+	{% if related_incidents %}
+		{% include "common/_section_heading.html" with label="Related Incidents" %}
+
+		<div class="grid-50">
+			{% for related_case in related_incidents %}
+				<div class="grid-50__item">
+					{% include "incident/_incident.html" with incident=related_case teaser=True only %}
+				</div>
+			{% endfor %}
+		</div>
+		<a
+			href="{% pageurl page.get_parent %}?{{ related_qs }}"
+			class="button button--outline button--center">
+			More related incidents
+		</a>
+	{% endif %}
 </main>
 {% endblock %}
 

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -28,7 +28,8 @@ from .factories import (
     IncidentIndexPageFactory,
     IncidentPageFactory,
     IncidentUpdateFactory,
-    TopicPageFactory
+    TopicPageFactory,
+    StateFactory,
 )
 
 
@@ -256,30 +257,34 @@ class GetRelatedIncidentsTest(TestCase):
 
     def test_get_related_incidents__saved(self):
         IncidentPageFactory(parent=self.index)
+        tag = CommonTagFactory()
         related_incident = IncidentPageFactory(parent=self.index)
-        category_incident = IncidentPageFactory(parent=self.index, categories=[self.category])
+        tagged_incident = IncidentPageFactory(parent=self.index, categories=[self.category], tags=[tag])
         incident = IncidentPageFactory(
             parent=self.index,
             categories=[self.category],
             related_incidents=[related_incident],
+            tags=[tag],
         )
 
         related_incidents = incident.get_related_incidents()
-        self.assertEqual(related_incidents, [related_incident, category_incident])
+        self.assertEqual(related_incidents, [related_incident, tagged_incident])
 
     def test_get_related_incidents__unsaved(self):
         IncidentPageFactory(parent=self.index)
+        tag = CommonTagFactory()
         related_incident = IncidentPageFactory(parent=self.index)
-        category_incident = IncidentPageFactory(parent=self.index, categories=[self.category])
+        tagged_incident = IncidentPageFactory(parent=self.index, categories=[self.category], tags=[tag])
         incident = IncidentPageFactory(
             parent=self.index,
-            categories=[self.category]
+            categories=[self.category],
+            tags=[tag],
         )
 
         incident.related_incidents = [related_incident]
 
         related_incidents = incident.get_related_incidents()
-        self.assertEqual(related_incidents, [related_incident, category_incident])
+        self.assertEqual(related_incidents, [related_incident, tagged_incident])
 
     def test_get_related_incidents__include_related_once_only(self):
         # Related incidents should only be included once, for being related
@@ -305,15 +310,104 @@ class GetRelatedIncidentsTest(TestCase):
         closely_related = IncidentPageFactory(parent=self.index, tags=[tag1, tag2, tag3], categories=[self.category])
         somewhat_related = IncidentPageFactory(parent=self.index, tags=[tag1, tag3], categories=[self.category])
         slightly_related = IncidentPageFactory(parent=self.index, tags=[tag2, tag4], categories=[self.category])
-        unrelated = IncidentPageFactory(parent=self.index, tags=[tag4], categories=[self.category])
+        IncidentPageFactory(parent=self.index, tags=[tag4], categories=[self.category])
 
         related_incidents = subject.get_related_incidents()
 
         self.assertEqual(
             related_incidents,
-            [closely_related, somewhat_related]
+            [closely_related, somewhat_related, slightly_related]
         )
 
+    def test_get_related_incidents__ordered_by_descending_date(self):
+        tag1 = CommonTagFactory()
+        tag2 = CommonTagFactory()
+        tag3 = CommonTagFactory()
+
+        subject = IncidentPageFactory(parent=self.index, tags=[tag1, tag2, tag3], categories=[self.category])
+
+        closely_related_old = IncidentPageFactory(
+            parent=self.index,
+            tags=[tag1, tag2, tag3],
+            categories=[self.category],
+            date='2016-01-01',
+        )
+        closely_related_new = IncidentPageFactory(
+            parent=self.index,
+            tags=[tag1, tag2, tag3],
+            categories=[self.category],
+            date='2020-01-01',
+        )
+        closely_related_recent = IncidentPageFactory(
+            parent=self.index,
+            tags=[tag1, tag2, tag3],
+            categories=[self.category],
+            date='2019-01-01',
+        )
+        related_incidents = subject.get_related_incidents()
+
+        self.assertEqual(
+            related_incidents,
+            [closely_related_new, closely_related_recent, closely_related_old]
+        )
+
+    def test_get_related_incidents__using_location(self):
+        tag1 = CommonTagFactory()
+        tag2 = CommonTagFactory()
+        tag3 = CommonTagFactory()
+        tag4 = CommonTagFactory()
+        state = StateFactory(name='New Mexico')
+        other_state = StateFactory(name='Colorado')
+        subject = IncidentPageFactory(
+            parent=self.index,
+            tags=[tag1, tag2, tag3],
+            categories=[self.category],
+            city='Albuquerque',
+            state=state,
+        )
+        close = IncidentPageFactory(
+            title='Close',
+            parent=self.index,
+            tags=[tag2],
+            categories=[self.category],
+            city='Albuquerque',
+            state=state,
+        )
+        nearby = IncidentPageFactory(
+            title='Nearby',
+            parent=self.index,
+            tags=[tag3],
+            categories=[self.category],
+            city='Santa Fe',
+            state=state,
+        )
+        far = IncidentPageFactory(
+            title='Far',
+            parent=self.index,
+            tags=[tag1],
+            categories=[self.category],
+            city='Denver',
+            state=other_state,
+        )
+        nearby_no_tag_overlap = IncidentPageFactory(
+            title='Nearby, no tag overlap',
+            parent=self.index,
+            tags=[tag4],
+            categories=[self.category],
+            city='Santa Fe',
+            state=state,
+        )
+        IncidentPageFactory(
+            title='No relation',
+            parent=self.index,
+            tags=[tag4],
+            categories=[self.category],
+            city='Denver',
+            state=other_state,
+        )
+        related_incidents = subject.get_related_incidents()
+
+        self.assertEqual(related_incidents, [close, nearby, far, nearby_no_tag_overlap])
 
 
 class GetIncidentUpdatesTest(TestCase):


### PR DESCRIPTION
This pull request:

- Updates the logic of how related incidents are found to take into account incident tags and the incident city/state data. Here is how the related incidents at the bottom of each incident page is determined in this PR:

  1. A "threshold" for how many incidents we want is set. I've established that as 4, but it can be changed to anything.
  1. Collect all incidents with explicit relationships to the page. These are incidents are ones that were chosen as "related incidents" in the admin. These will always be shown, no matter how many of them there are.
  1. If we have not collected enough to meet the threshold, find more incidents based on how similar they are to the one on the page. These incidents are all taken from the same category as the one on the page. Incidents with a high number of matching tags are prioritized first, followed by matching city and state, then lastly matching just on state. 
  1. If we still have not met the threshold, we've exhausted the incidents I feel are related enough to call "related" and we display only what we have collected so far. IMO, this is "as good as we can get" without adding additional parameters to the search, which I am open to doing. Though given that we are talking about only between 1 and 4 incidents total here, I am not sure this will come up all that often.

- Updates the "More related incidents" link to take into account tags and location. If the incident has tags, the link will now lead to a search page for the incident's category and tags. If there are no tags, then it will lead to a search page for the incident's category and city and/or state. The current behavior is to link to the search page for _just_ the incident's category.

- Handles the case where when an incident page has zero related incidents, even given all of the above.

Fixes #941 