### PR TITLE
Fix vulnerability in elliptic package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6040,9 +6040,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -6055,9 +6055,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }


### PR DESCRIPTION
This fixes a vulnerability reported by `npm audit`:

> HIGH: 1547 - Signature Malleability
> 
> The Elliptic package before version 6.5.3 for Node.js allows ECDSA signature malleability via variations in 
> encoding, leading '\0' bytes, or integer overflows. This could conceivably have a security-relevant impact if an 
> application relied on a single canonical signature.
> 
> Upgrade to version 6.5.3 or later.
> 
> - Version:   6.5.2
> - Path:      webpack>node-libs-browser>crypto-browserify>browserify-sign>elliptic
> - More info: https://npmjs.com/advisories/1547
