### PR TITLE
Restore setuptools/distutils behavior to that of versions < 50.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ reuse-blerbs:
         pyenv global 3.5.2
         pip install -U pip
         pip install pipenv
-        pipenv install
+        pipenv sync
 
 version: 2
 jobs:


### PR DESCRIPTION
Experiencing a problem where `pip install pipenv` yields:

```
SystemError: Parent module 'setuptools' not loaded, cannot perform relative import
```

My understanding so far: [setuptools version 50.0](https://setuptools.readthedocs.io/en/latest/history.html#v50-0-0) was released with this change:

> Once again, Setuptools overrides the stdlib distutils on import. For environments or invocations where this behavior is undesirable, users are provided with a temporary escape hatch. If the environment variable `SETUPTOOLS_USE_DISTUTILS` is set to `stdlib`, Setuptools will fall back to the legacy behavior. Use of this escape hatch is discouraged, but it is provided to ease the transition while proper fixes for edge cases can be addressed.

Furthermore, Pipenv [always installs the latest version of setuptools within virtualenvs it creates](https://github.com/pypa/pipenv/issues/2364). These facts seem to have combined to cause our package installation to fail at various levels, including the creation of a PIpenv, and the installation of packages _within_ a Pipenv. These result in the error quoted at the top of this PR.

Further reading in setuptools bug reports:

* [setuptools 50 breaks pip installation](https://github.com/pypa/setuptools/issues/2350)
* [setuptools 50.0 cannot import distutils in python 3.5.1](https://github.com/pypa/setuptools/issues/2352)

Notably, it seems like this behavior does not affect our builds on more recent versions of ubuntu (STN and SecureDrop.org), and in the case of this repo, the problem is fixed by using setting the environment variable 

```
SETUPTOOLS_USE_DISTUTILS=stdlib
```

as mentioned above. Meaning I think we can temporarily use this variable until we move away from the combination of python version and ubuntu version that seem to be causing the problem here.

This pull request applies that environment variable to our Circle CI jobs, but I think other work will be needed to get it working in other parts of our infrastructure.

