### PR TITLE
Add AGPLv3 license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2013- Freedom of the Press Foundation
+Copyright (C) 2017- Freedom of the Press Foundation
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007


### PR DESCRIPTION
Fixes #644 

This pull request adds license the AGPLv3 license file, copied over from our securedrop repo (as linked in the issue).

My one question here would be if the copyright date at the top, 2013, is correct. @eloquence do you have information on that?