### PR TITLE
Restrict incident body images to width of container

### DIFF
--- a/client/common/sass/_incident.sass
+++ b/client/common/sass/_incident.sass
@@ -96,6 +96,11 @@ $max-image-vh-ratio: 0.75
 	margin: $incident-attr-margin
 	color: $gray-mid-dark-text
 
+	section
+		img
+			max-width: 100%
+			height: auto
+
 .incident__update-item
 	margin: 20px 0 0 0
 	padding-top: 20px


### PR DESCRIPTION
This pull request limits the width of images in the body field of incident pages to be at most the width of the body container.

Fixes #979