### PR TITLE
Remove site URI from API image URL responses

### DIFF
--- a/incident/models/export.py
+++ b/incident/models/export.py
@@ -92,11 +92,12 @@ def to_json(obj, allowed_fields=[]):
 
 
 def _serialize_field(obj, field):
-    site = obj.get_site()
     if field.name == 'teaser_image':
-        val = getattr(obj, field.name)
-        if val:
-            val = site.root_url + val.get_rendition('fill-1330x880').url
+        teaser_image = getattr(obj, field.name)
+        if teaser_image:
+            val = teaser_image.get_rendition('fill-1330x880').url
+        else:
+            val = None
     elif field.name == 'slug':
         val = obj.get_full_url()
     elif type(field) == models.ForeignKey:

--- a/incident/models/topic_page.py
+++ b/incident/models/topic_page.py
@@ -33,9 +33,8 @@ class IncidentSchema(Schema):
     description = fields.Method('get_description')
 
     def get_image(self, obj):
-        site = obj.get_site()
-        if obj.teaser_image and site.root_url:
-            return site.root_url + obj.teaser_image.get_rendition('width-720').url
+        if obj.teaser_image:
+            return obj.teaser_image.get_rendition('width-720').url
         else:
             return ''
 


### PR DESCRIPTION
Fixes #988 

This pull request removes the site `root_url` from being prepended to image URL fields in API responses (both CSV and JSON formats).

We are in the situation where our production environment is different from the development environment because our media (i.e. our `MEDIA_ROOT` setting) is stored on a different domain in production, so the URLs attached to the images are _always_ absolute in production. 

I've made the decision here to alter the results for these image fields so that we only ever return the URL that Django/Wagtail have associated with the image. Previously, I think we were trying to be clever so that we could get absolute URLs in development mode. But I think the value of correct data outweighs the value of absolute URLs in development mode. It's also not necessarily clear that the consumer of this data in dev mode will want an absolute URL at all. So that use case is being removed, essentially. Which I think is fine.