### PR TITLE
Update references to the GitHub repository name in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ The Press Freedom Tracker invites help from people able to contribute code, bug 
 
 ## Reporting bugs, problems, or unexpected behavior
 
-If you encounter something that is broken, confusing, or that you think could be improved, you should open a [GitHub Issue](https://github.com/freedomofpress/tracker/issues/new).  It's helpful to describe the situation in as much detail as you can, but you don't have to know why an error is occurring, or even if one is at all.
+If you encounter something that is broken, confusing, or that you think could be improved, you should open a [GitHub Issue](https://github.com/freedomofpress/pressfreedomtracker.us/issues/new).  It's helpful to describe the situation in as much detail as you can, but you don't have to know why an error is occurring, or even if one is at all.
 
 ## New ideas and features
 
-Do you have an idea for something new that you think belongs in the Press Freedom Tracker?  We are happy to hear about it.  Please [open an issue](https://github.com/freedomofpress/tracker/issues/new) describing your idea or feature, and the community and maintainers will give you feedback about it.
+Do you have an idea for something new that you think belongs in the Press Freedom Tracker?  We are happy to hear about it.  Please [open an issue](https://github.com/freedomofpress/pressfreedomtracker.us/issues/new) describing your idea or feature, and the community and maintainers will give you feedback about it.
 
 ## Submitting code and patches
 
@@ -18,7 +18,7 @@ model for code contributions via GitHub pull requests.
 
 ### Finding something to work on
 
-If you're looking for an issue to work out, check out our [open issues](https://github.com/freedomofpress/tracker/issues) and look for ones tagged as [help wanted](https://github.com/freedomofpress/tracker/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [small](https://github.com/freedomofpress/tracker/issues?q=is%3Aopen+is%3Aissue+label%3ASmall). These issues are the easiest way to start contributing, but if there are other items that catch your interest, please feel free to work on them.
+If you're looking for an issue to work out, check out our [open issues](https://github.com/freedomofpress/pressfreedomtracker.us/issues) and look for ones tagged as [help wanted](https://github.com/freedomofpress/pressfreedomtracker.us/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [small](https://github.com/freedomofpress/pressfreedomtracker.us/issues?q=is%3Aopen+is%3Aissue+label%3ASmall). These issues are the easiest way to start contributing, but if there are other items that catch your interest, please feel free to work on them.
 
 ### Let us know you're working on something
 

--- a/README.rst
+++ b/README.rst
@@ -224,4 +224,4 @@ Search
 The search bar on the site is a shortcut to using incident search.
 This is because the site is primarily incident-related, and using incident search provides more powerful filtering as well as enhanced previews.
 As a result, there is no generic wagtail search view which includes other content such as blog posts.
-See https://github.com/freedomofpress/pressfreedom/pull/592.
+See https://github.com/freedomofpress/pressfreedomtracker.us/pull/592.

--- a/STATISTICS.rst
+++ b/STATISTICS.rst
@@ -132,7 +132,7 @@ Choice filters
 
 Choice fields can be filtered by providing one or more choice options.
 Choice options will vary from filter to filter.
-Valid choices can be found in `incident/models/choices.py <https://github.com/freedomofpress/pressfreedom/blob/master/incident/models/choices.py>`_.
+Valid choices can be found in `incident/models/choices.py <https://github.com/freedomofpress/pressfreedomtracker.us/blob/develop/incident/models/choices.py>`_.
 
 .. code:: jinja
 


### PR DESCRIPTION
This pull request updates the documentation to have the links to the GitHub site for this project use the new repo name.