### PR TITLE
Add prefetching to incident queryset for incident index page

### DIFF
--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -333,7 +333,27 @@ class CategoryPage(MetadataPageMixin, Page):
         else:
             context['export_path'] = None
 
-        incident_qs = incident_filter.get_queryset()
+        incident_qs = incident_filter.get_queryset() \
+            .with_most_recent_update() \
+            .select_related('teaser_image', 'state', 'arresting_authority') \
+            .prefetch_related(
+                'authors',
+                'categories__category',
+                'current_charges',
+                'dropped_charges',
+                'equipment_broken__equipment',
+                'equipment_seized__equipment',
+                'links',
+                'politicians_or_public_figures_involved',
+                'tags',
+                'target_nationality',
+                'targeted_institutions',
+                'targeted_journalists',
+                'teaser_image__renditions',
+                'updates',
+                'venue',
+                'workers_whose_communications_were_obtained',
+        )
 
         paginator, entries = paginate(
             request,

--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -177,7 +177,26 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
         else:
             context['categories'] = CategoryPage.objects.filter(live=True, pk__in=category_ids)
 
-        incident_qs = incident_filter.get_queryset()
+        incident_qs = incident_filter.get_queryset() \
+            .select_related('teaser_image', 'state', 'arresting_authority') \
+            .prefetch_related(
+                'authors',
+                'categories__category',
+                'current_charges',
+                'dropped_charges',
+                'equipment_broken__equipment',
+                'equipment_seized__equipment',
+                'links',
+                'politicians_or_public_figures_involved',
+                'tags',
+                'target_nationality',
+                'targeted_institutions',
+                'targeted_journalists',
+                'teaser_image__renditions',
+                'updates',
+                'venue',
+                'workers_whose_communications_were_obtained',
+        )
 
         paginator, entries = paginate(
             request,

--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -179,6 +179,7 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
 
         incident_qs = incident_filter.get_queryset() \
             .select_related('teaser_image', 'state', 'arresting_authority') \
+            .with_most_recent_update() \
             .prefetch_related(
                 'authors',
                 'categories__category',

--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -54,7 +54,7 @@ It can take the following context variables:
 		{% endif %}
 		<div class='incident__date' title="Published: {{ incident.first_published_at|date:'F j, Y' }}">
 			{{ incident.date|date:"F j, Y" }}
-				{% if teaser and incident.recently_updated %}
+				{% if teaser and incident.updated_days_ago < 7 %}
 				<span
 					class="alert alert--green"
 					title="Updated {{ incident.last_updated|date:'F j, Y'}}"

--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -8,7 +8,6 @@ It can take the following context variables:
 
 {% load wagtailcore_tags wagtailsettings_tags wagtailimages_tags typogrify_tags %}
 {% load render_as_template %}
-{% get_settings use_default_site=True %}
 
 <article class="
 	incident
@@ -103,12 +102,15 @@ It can take the following context variables:
 				{% endfor %}
 			{% endif %}
 		</div>
-		{% if not incident.suppress_footer and not teaser and settings.common.SiteSettings.incident_footer %}
-			<div class="incident__call-to-action">
-				{% filter typogrify|richtext %}
-					{% render_as_template settings.common.SiteSettings.incident_footer %}
-				{% endfilter %}
-			</div>
+		{% if not incident.suppress_footer and not teaser %}
+			{% get_settings use_default_site=True %}
+			{% if settings.common.SiteSettings.incident_footer %}
+				<div class="incident__call-to-action">
+					{% filter typogrify|richtext %}
+						{% render_as_template settings.common.SiteSettings.incident_footer %}
+					{% endfilter %}
+				</div>
+			{% endif %}
 		{% endif %}
 		{% if not teaser %}
 			{% for update in incident.get_updates_by_asc_date %}

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -22,7 +22,7 @@
 	<div class="grid-50 js-incident-loading-parent">
 		{% for incident in entries_page %}
 			<div class="grid-50__item js-incident-loading-item">
-				{% include "incident/_incident.html" with incident=incident.specific teaser=True %}
+				{% include "incident/_incident.html" with incident=incident teaser=True %}
 			</div>
 		{% endfor %}
 	</div>


### PR DESCRIPTION
This is identical to the query changes made to the export views in https://github.com/freedomofpress/pressfreedomtracker.us/pull/1008