### PR TITLE
Improve targeted journalist/institution summary query

### DIFF
--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -721,20 +721,20 @@ class IncidentFilter(object):
             date__year=TODAY.year,
         )
 
-        total_queryset = queryset
+        incident_ids = list(queryset.values_list('pk', flat=True))
         num_this_year = incidents_this_year.count()
         num_this_month = incidents_this_month.count()
 
-        tj_queryset = TargetedJournalist.objects.filter(incident__in=queryset)
+        tj_queryset = TargetedJournalist.objects.filter(incident__in=incident_ids)
         tj_inst_queryset = tj_queryset.filter(
             institution_id=OuterRef('pk')
         ).values_list('institution_id', flat=True)
 
         summary = (
-            ('Total Results', total_queryset.count()),
+            ('Total Results', len(incident_ids)),
             ('Journalists affected', Journalist.objects.filter(targeted_incidents__in=tj_queryset).distinct().count()),
             ('Institutions affected', Institution.objects.filter(
-                Q(institutions_incidents__in=total_queryset) | Q(id__in=Subquery(tj_inst_queryset))
+                Q(institutions_incidents__in=incident_ids) | Q(id__in=Subquery(tj_inst_queryset))
             ).distinct().count()),
         )
 


### PR DESCRIPTION
This change replaces our use of `total_queryset` with `incident_ids`, i.e. replacing an entire queryset (which has the potential to contain some complex filters) with a list of IDs, which we query once and then save as a Python value.  This causes the Django ORM to use an `IN (<static list of ids>)` query rather than `IN (<potentially complicated subquery>)`.

In particular I think this saves us a lot of trouble on the institution summary, which Django was running as a left join with two
very large `OR` expressions in the where-clause.  But all the complexity in those expressions was due to the filtering, which we can change to a static list of IDs and get the same results with a lot less number crunching.

Part of an ongoing effort to solve #1013 