### PR TITLE
Update Matomo/Piwik tracking code to match latest recommendation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ upgrade-pip: ## Uses pip-compile to update requirements.txt for upgrading a spec
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
 	docker run -v "$(DIR):/code" -w /code -it python:3.9-slim \
-		bash -c 'apt-get update && apt-get install gcc -y && \
+		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
@@ -71,7 +71,7 @@ update-pip-dev: ## Uses pip-compile to update dev-requirements.txt for upgrading
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
 	docker run -v "$(DIR):/code" -w /code -it python:3.9-slim \
-		bash -c 'apt-get update && apt-get install gcc -y && \
+		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -295,9 +295,8 @@ googleapis-common-protos==1.52.0 \
 gprof2dot==2019.11.30 \
     --hash=sha256:b43fe04ebb3dfe181a612bbfc69e90555b8957022ad6a466f0308ed9c7f22e99
     # via django-silk
-gunicorn==19.9.0 \
-    --hash=sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471 \
-    --hash=sha256:fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3
+gunicorn==20.1.0 \
+    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
     # via -r requirements.txt
 html5lib==1.0.1 \
     --hash=sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3 \
@@ -728,6 +727,7 @@ setuptools==42.0.2 \
     # via
     #   google-api-core
     #   google-auth
+    #   gunicorn
     #   ipdb
     #   ipython
     #   protobuf

--- a/requirements.txt
+++ b/requirements.txt
@@ -192,9 +192,8 @@ googleapis-common-protos==1.52.0 \
     --hash=sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351 \
     --hash=sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24
     # via google-api-core
-gunicorn==19.9.0 \
-    --hash=sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471 \
-    --hash=sha256:fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3
+gunicorn==20.1.0 \
+    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
     # via -r requirements.in
 html5lib==1.0.1 \
     --hash=sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3 \

--- a/tracker/static/js/piwik.js
+++ b/tracker/static/js/piwik.js
@@ -1,9 +1,11 @@
-var idSite = 5;
-var piwikTrackingApiUrl = 'https://analytics.freedom.press/piwik.php';
-
 var _paq = window._paq = window._paq || [];
-
-_paq.push(['setTrackerUrl', piwikTrackingApiUrl]);
-_paq.push(['setSiteId', idSite]);
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
+(function() {
+    var u="https://analytics.freedom.press/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '5']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -67,7 +67,6 @@
 	{% endblock %}
 	{% if django_settings.ANALYTICS_ENABLED %}
 		<script type="text/javascript" src="{% static 'js/piwik.js' %}"></script>
-		<script src="https://analytics.freedom.press/piwik.js" async defer></script>
 		<noscript><p><img src="https://analytics.freedom.press/piwik.php?idsite=5" style="border:0;" alt="" /></p></noscript>
 	{% endif %}
 {% endblock %}


### PR DESCRIPTION
This pull request updates the Matomo tracking code to match the latest recommended use of their tracking code. Notably, the loading of the `https://analytics.freedom.press/piwik.js` resource is moved into the JS file itself, instead of being loaded via a script tag.

Fixes #1010 