### PR TITLE
Improve topic page performance

### DIFF
--- a/incident/models/topic_page.py
+++ b/incident/models/topic_page.py
@@ -25,6 +25,11 @@ from common.utils import (
 from incident.models import IncidentCategorization
 
 
+class NongroupingSubquery(models.Subquery):
+    def get_group_by_cols(self):
+        return []
+
+
 class IncidentSchema(Schema):
     title = fields.Str()
     date = fields.DateTime()
@@ -250,7 +255,7 @@ class TopicPage(RoutablePageMixin, MetadataPageMixin, Page):
         cats = CategoryPage.objects.live().prefetch_related(
             models.Prefetch('incidents', queryset=with_incident_page, to_attr='categorization_list')
         ).annotate(
-            total_journalists=models.Subquery(journalist_count.values('total_journalists'), output_field=models.IntegerField()),
+            total_journalists=NongroupingSubquery(journalist_count.values('total_journalists'), output_field=models.IntegerField()),
             total_incidents=models.Count('incidents__incident_page', filter=models.Q(incidents__incident_page__tags=self.incident_tag, incidents__incident_page__live=True))
         ).order_by('-total_incidents')
 

--- a/incident/models/topic_page.py
+++ b/incident/models/topic_page.py
@@ -38,10 +38,15 @@ class IncidentSchema(Schema):
     description = fields.Method('get_description')
 
     def get_image(self, obj):
-        if obj.teaser_image:
-            return obj.teaser_image.get_rendition('width-720').url
-        else:
+        if not obj.teaser_image:
             return ''
+        val = ''
+        for rend in obj.teaser_image.renditions.all():
+            if rend.filter_spec == 'width-720':
+                val = rend.url
+        if not val:
+            val = obj.teaser_image.get_rendition('width-720').url
+        return val
 
     def get_description(self, obj):
         return obj.body.render_as_block()


### PR DESCRIPTION
This pull request attempts to decrease the topic page load time, mainly by improving two fairly inefficient SQL queries. The first, and slowest, one had a very gnarly `GROUP BY` clause that was not needed at all, probably caused by a bug in Django. The second one was something I originally wrote as a subquery to enforce a `LIMIT` amount in the query itself and work around the limitations of prefetching. It turns out that the SQL emitted by this technique is not good, and we can save ourselves by doing the limit in python. More explanation can be found in the commit messages.

Refs #1013

I tested this locally with the data from our staging database, here's some comparisons:

Before:
![image](https://user-images.githubusercontent.com/561931/113630983-c1472e00-9636-11eb-852b-b12a011b8261.png)

After:
![image](https://user-images.githubusercontent.com/561931/113631011-cb692c80-9636-11eb-80d5-412538e685a3.png)
