### PR TITLE
Disable livepreview file rendering for k8s compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6961,8 +6961,7 @@
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
-      "dev": true
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
     },
     "file": {
       "version": "0.2.2",
@@ -14250,7 +14249,7 @@
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15463,10 +15462,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-      "dev": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -230,6 +230,7 @@ if LIVEPREVIEW_ENABLED:
     # The livepreview needs to be added in the INSTALLED_APPS above the
     # 'wagtail.admin' app
     INSTALLED_APPS.insert(INSTALLED_APPS.index('wagtail.admin'), 'livepreview')
+    LIVEPREVIEW_USE_FILE_RENDERING = False
 
 # Disable analytics by default
 ANALYTICS_ENABLED = False


### PR DESCRIPTION
Fixes #975

This pull request disables the live preview feature's file rendering strategy, as described in the ticket.