### PR TITLE
feat: Add Content Security Policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ test-results
 
 # Ignore files created to communicate system deployment info
 .versioninfo
+
+# Jetbrains IDE
+.idea

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -130,6 +130,10 @@ django-anymail==6.0 \
 django-cprofile-middleware==1.0.5 \
     --hash=sha256:b942185a38f3b582935a55c768f126ce9a6f0cefceee3b5d19e6b307ad129889
     # via -r dev-requirements.in
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
+    # via -r requirements.txt
 django-debug-toolbar==3.2.1 \
     --hash=sha256:a5ff2a54f24bf88286f9872836081078f4baa843dc3735ee88524e89f8821e33 \
     --hash=sha256:e759e63e3fe2d3110e0e519639c166816368701eab4a47fed75d7de7018467b9
@@ -185,6 +189,7 @@ django==2.2.22 \
     # via
     #   -r requirements.txt
     #   django-anymail
+    #   django-csp
     #   django-debug-toolbar
     #   django-filter
     #   django-logging-json

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ bleach>=3.1.3
 dj-database-url
 Django>=2.2.22,<2.3
 django-anymail
+django-csp>=3.7
 django-modelcluster
 django-recaptcha
 django-settings-export

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,10 @@ django-anymail==6.0 \
     --hash=sha256:ab5cbfb280492c9cb2ef0497f8ebda4dcb3f99603dcf63c88ae623a66cad71f4 \
     --hash=sha256:f872089943f30283d485d121924598f4156f5bfa76a0885fd66df5205102be0b
     # via -r requirements.in
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
+    # via -r requirements.in
 django-filter==2.4.0 \
     --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
     --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1
@@ -111,6 +115,7 @@ django==2.2.22 \
     # via
     #   -r requirements.in
     #   django-anymail
+    #   django-csp
     #   django-filter
     #   django-logging-json
     #   django-recaptcha

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -276,19 +276,32 @@ CSP_FRAME_SRC = (
     # For Twitter Widgets
     "https://platform.twitter.com",
 )
-CSP_CONNECT_SRC = (
+CSP_CONNECT_SRC = [
     "'self'",
     "https://analytics.freedom.press",
     # For Wagtail Admin
     "https://releases.wagtail.io/latest.txt",
-)
-CSP_IMG_SRC = (
+]
+CSP_IMG_SRC = [
     "'self'",
-    "analytics.freedom.press",
+    "https://analytics.freedom.press",
     "https://media.pressfreedomtracker.us",
-    # For Wagtail Admin
-    "http://www.gravatar.com",
-)
+    # For Twitter Widgets
+    "https://platform.twitter.com",
+    "https://syndication.twitter.com",
+    "https://pbs.twimg.com",
+    "https://ton.twimg.com",
+    "data:",
+]
+CSP_OBJECT_SRC = ["'self'"]
+CSP_MEDIA_SRC = ["'self'"]
+
+if os.environ.get("DJANGO_CSP_MEDIA_ORIGINS"):
+    csp_media_origins = os.environ["DJANGO_CSP_MEDIA_ORIGINS"].split()
+    CSP_MEDIA_SRC.extend(csp_media_origins)  # video files
+    CSP_IMG_SRC.extend(csp_media_origins)
+    CSP_OBJECT_SRC.extend(csp_media_origins)
+    CSP_CONNECT_SRC.extend(csp_media_origins)
 
 # Report URI must be a string, not a tuple.
 CSP_REPORT_URI = os.environ.get('DJANGO_CSP_REPORT_URI',

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -101,6 +101,9 @@ if os.environ.get('DJANGO_WHITENOISE'):
 MIDDLEWARE.extend([
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
     'django_logging.middleware.DjangoLoggingMiddleware',
+
+    # Middleware for content security policy
+    'csp.middleware.CSPMiddleware',
 ])
 
 
@@ -251,6 +254,45 @@ NOCAPTCHA = True
 # django-taggit
 TAGGIT_CASE_INSENSITIVE = True
 
+# Content Security Policy
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_SCRIPT_SRC = (
+    "'self'",
+    "https://analytics.freedom.press",
+    # For Wagtail Admin
+    "'unsafe-inline'",
+    # For Twitter Widgets
+    "'unsafe-eval'",
+    "https://platform.twitter.com/widgets.js",
+    "https://platform.twitter.com/js/horizon_tweet.2bd42981e3af03ce9186a5655508da28.js",
+)
+CSP_STYLE_SRC = (
+    "'self'",
+    # For Wagtail Admin and Twitter Widgets.
+    "'unsafe-inline'",
+)
+CSP_FRAME_SRC = (
+    "'self'",
+    # For Twitter Widgets
+    "https://platform.twitter.com",
+)
+CSP_CONNECT_SRC = (
+    "'self'",
+    "https://analytics.freedom.press",
+    # For Wagtail Admin
+    "https://releases.wagtail.io/latest.txt",
+)
+CSP_IMG_SRC = (
+    "'self'",
+    "analytics.freedom.press",
+    "https://media.pressfreedomtracker.us",
+    # For Wagtail Admin
+    "http://www.gravatar.com",
+)
+
+# Report URI must be a string, not a tuple.
+CSP_REPORT_URI = os.environ.get('DJANGO_CSP_REPORT_URI',
+                                'https://freedomofpress.report-uri.com/r/d/csp/enforce')
 
 # Logging
 #

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -259,12 +259,18 @@ CSP_DEFAULT_SRC = ("'self'",)
 CSP_SCRIPT_SRC = (
     "'self'",
     "https://analytics.freedom.press",
+    "https://www.google.com/recaptcha",
+    "https://www.gstatic.com/recaptcha",
     # For Wagtail Admin
     "'unsafe-inline'",
     # For Twitter Widgets
     "'unsafe-eval'",
     "https://platform.twitter.com/widgets.js",
     "https://platform.twitter.com/js/horizon_tweet.2bd42981e3af03ce9186a5655508da28.js",
+    # Observable Notebooks
+    "https://cdn.jsdelivr.net",
+    "https://api.observablehq.com",
+    "https://bundle.run",
 )
 CSP_STYLE_SRC = (
     "'self'",
@@ -281,6 +287,9 @@ CSP_CONNECT_SRC = [
     "https://analytics.freedom.press",
     # For Wagtail Admin
     "https://releases.wagtail.io/latest.txt",
+    # Observable Notebooks
+    "https://cdn.jsdelivr.net",
+    "https://pressfreedomtracker.us",
 ]
 CSP_IMG_SRC = [
     "'self'",


### PR DESCRIPTION
Fixes #1024 
Fixes #1028

Adds Content Security Policies similar to [securedrop.org](https://github.com/freedomofpress/securedrop.org/blob/develop/securedrop/settings/base.py#L313-L367) and [securethenews](https://github.com/freedomofpress/securethenews/blob/develop/securethenews/settings/base.py#L251-L303).