### PR TITLE
Add middleware for tracking and reporting page generation time

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -1,0 +1,25 @@
+import time
+import logging
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def page_time_middleware(get_response):
+    def middleware(request):
+        start_time = time.perf_counter_ns()
+
+        response = get_response(request)
+
+        duration = (time.perf_counter_ns() - start_time) // 1_000_000
+
+        response['X-Page-Generation-Time-ms'] = duration
+        if duration > settings.SLOW_PAGE_WARN_THRESHOLD:
+            logger.warning(f'Slow page warning: {request.method} {request.path} duration: {duration}ms')
+        elif duration > settings.SLOW_PAGE_LOG_THRESHOLD:
+            logger.info(f'Slow page notice: {request.method} {request.path} duration: {duration}ms')
+        return response
+
+    return middleware

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -85,6 +85,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'common.middleware.page_time_middleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -334,3 +335,6 @@ LOGGING = {
         },
     },
 }
+
+SLOW_PAGE_LOG_THRESHOLD = int(os.environ.get('SLOW_PAGE_LOG_THRESHOLD', 3000))
+SLOW_PAGE_WARN_THRESHOLD = int(os.environ.get('SLOW_PAGE_WARN_THRESHOLD', 6000))


### PR DESCRIPTION
This pull request adds a fairly simple middleware that records how long a page took to fully render. This information is used to put a notice in the log if the time recorded was above a certain threshold. This information is also added to the response headers, which I thought might be useful sometimes for interactive debugging and information gathering, but might not be something we want.

I have two "log level" thresholds defined in the settings. My reason for doing this is I didn't want to overwhelm the logs with WARN level events when this was turned on, but I did want to set a fairly low threshold to start collecting data for a large sample of pages. If this is too granular, we can change it fairly easily. Also the exact thresholds can be adjusted if we don't think they'll be good for starting off. Right now an INFO level message is logged if a page takes longer than 3 seconds, and a WARN level message is logged if longer than 6 seconds.

Refs https://github.com/freedomofpress/fpf-www-projects/issues/174