### PR TITLE
Update to version of django-logging with request duration support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -140,8 +140,8 @@ django-filter==2.4.0 \
     # via
     #   -r requirements.txt
     #   wagtail
-https://github.com/freedomofpress/django-logging/zipball/34fbeeea7a83bd54f8551bb50382a06b69814d4e \
-    --hash=sha256:25d9a5e3393591a2fb81b22d069ac586e11abdfcad64ada8b911ca852ef9aa67
+https://github.com/freedomofpress/django-logging/zipball/ced87b3266e350c68afd0aea8895d5d595f5fc83 \
+    --hash=sha256:bd8ec3ac68f4e9f4d0e7eaaeaa658dd6198b2f335c608318d4001562ae60aac3
     # via -r requirements.txt
 django-modelcluster==5.1 \
     --hash=sha256:783d177f7bf5c8f30fe365c347b9a032920de371fe1c63d955d7b283684d4c08 \

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/freedomofpress/django-logging/zipball/34fbeeea7a83bd54f8551bb50382a06b69814d4e
+https://github.com/freedomofpress/django-logging/zipball/ced87b3266e350c68afd0aea8895d5d595f5fc83
 bleach>=3.1.3
 dj-database-url
 Django>=2.2.22,<2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,8 +73,8 @@ django-filter==2.4.0 \
     --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
     --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1
     # via wagtail
-https://github.com/freedomofpress/django-logging/zipball/34fbeeea7a83bd54f8551bb50382a06b69814d4e \
-    --hash=sha256:25d9a5e3393591a2fb81b22d069ac586e11abdfcad64ada8b911ca852ef9aa67
+https://github.com/freedomofpress/django-logging/zipball/ced87b3266e350c68afd0aea8895d5d595f5fc83 \
+    --hash=sha256:bd8ec3ac68f4e9f4d0e7eaaeaa658dd6198b2f335c608318d4001562ae60aac3
     # via -r requirements.in
 django-modelcluster==5.1 \
     --hash=sha256:783d177f7bf5c8f30fe365c347b9a032920de371fe1c63d955d7b283684d4c08 \


### PR DESCRIPTION
Refs https://github.com/freedomofpress/fpf-www-projects/issues/174

This pull request enables the latest version of django-logging, which includes the duration field in the request logs.

