### PR TITLE
Disable logging of response content

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -288,6 +288,12 @@ DJANGO_LOGGING = {
     "DISABLE_EXISTING_LOGGERS": True,
     "PROPOGATE": False,
     "SQL_LOG": False,
+    # Prevent django-logging from parsing json content that we are
+    # only going to discard.
+    "CONTENT_JSON_ONLY": False,
+    # Do not log the content of responses by default--these might be
+    # quite big!
+    "RESPONSE_FIELDS": ("status", "reason", "charset", "headers"),
 }
 
 LOGGING = {


### PR DESCRIPTION
This pull request removes the "content" of a response from the log objects created by `django-logging`. In some ways it's a re-do of #927, which I think was lost when we standardized some of the logging features across sites. 

I've updated two settings. The first one tells django-logging not to try and parse JSON response data at all, this is wasting time since we don't want to log that parsed data in the first place.

The second one removes the "content" field from the set of response fields on the logging object. I've set it to the default fields but without `content`.