### PR TITLE
Selenium tests

### DIFF
--- a/common/tests/selenium.py
+++ b/common/tests/selenium.py
@@ -1,0 +1,84 @@
+import os
+import socket
+
+from django.db import connections
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.core.management import call_command
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from wagtail.core.models import Page, Site, Locale
+
+
+SELENIUM_HOST = os.environ['SELENIUM_HOST']
+HOST_IP = socket.gethostbyname(socket.gethostname())
+
+
+class SeleniumTest(StaticLiveServerTestCase):
+    host = HOST_IP
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.browser = webdriver.Remote(
+            command_executor=f'http://{SELENIUM_HOST}:4444/wd/hub',
+            desired_capabilities=DesiredCapabilities.FIREFOX,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.quit()
+        super().tearDownClass()
+
+    def populate_site(self):
+        """Create basic site and page data that is expected to exist by
+        wagtail but is removed during the database flush."""
+        root = Page.objects.create(
+            title='Root',
+            path='0001',
+            depth=1,
+        )
+
+        root_page = root.add_child(instance=Page(
+            title='Home',
+            path='00010001',
+            depth=2,
+        ))
+
+        Site.objects.create(
+            hostname=HOST_IP.rstrip(),
+            port=80,
+            is_default_site=True,
+            root_page=root_page,
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        Locale.objects.get_or_create(language_code='en')
+
+        try:
+            original_default_site = Site.objects.get(is_default_site=True, hostname='localhost')
+            original_default_site.hostname = HOST_IP.rstrip()
+            original_default_site.save()
+        except Site.DoesNotExist:
+            self.populate_site()
+
+    def _fixture_teardown(self):
+        # Allow TRUNCATE ... CASCADE and don't emit the post_migrate signal
+        # when flushing only a subset of the apps
+        # source:
+        # https://github.com/wagtail/wagtail/issues/1824#issuecomment-467383062
+        for db_name in self._databases_names(include_mirrors=False):
+            # Flush the database
+            inhibit_post_migrate = (
+                self.available_apps is not None or
+                (   # Inhibit the post_migrate signal when using serialized
+                    # rollback to avoid trying to recreate the serialized data.
+                    self.serialized_rollback and
+                    hasattr(connections[db_name], '_test_serialized_contents')
+                )
+            )
+            call_command('flush', verbosity=0, interactive=False,
+                         database=db_name, reset_sequences=False,
+                         allow_cascade=True,
+                         inhibit_post_migrate=inhibit_post_migrate)

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -5,3 +5,4 @@ django-debug-toolbar>=2.2.1
 django-silk
 flake8
 ipdb
+selenium

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -572,6 +572,10 @@ rsa==4.6 \
     # via
     #   -r requirements.txt
     #   google-auth
+selenium==3.141.0 \
+    --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
+    --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
+    # via -r dev-requirements.in
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
@@ -665,6 +669,7 @@ urllib3==1.25.10 \
     # via
     #   -r requirements.txt
     #   requests
+    #   selenium
 wagtail-autocomplete==0.6 \
     --hash=sha256:5f8ddf16d3ca365af4ad0f09e8f45d9e982ca854dc1b084a8a30f66b00a7739d
     # via -r requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,15 @@ services:
         aliases:
           - db
 
+  selenium:
+    image: selenium/standalone-firefox-debug:latest
+    ports:
+      - "127.0.0.1::5900"
+    networks:
+      app:
+        aliases:
+          - selenium
+
   node:
     build:
       context: .
@@ -54,6 +63,7 @@ services:
       DJANGO_XMLTEST_OUTPUT: "yes"
       DEPLOY_ENV: dev
       DJANGO_PROFILE: "${DJANGO_PROFILE:-no}"
+      SELENIUM_HOST: selenium
     working_dir: /django
     volumes:
       - ./:/django

--- a/incident/tests/test_filters_selenium.py
+++ b/incident/tests/test_filters_selenium.py
@@ -1,0 +1,509 @@
+import urllib.parse
+import itertools
+from datetime import timedelta
+
+from django.utils import timezone
+from wagtail.core.models import Page, Site
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import Select
+
+from common.tests.selenium import SeleniumTest
+from common.tests.factories import CategoryPageFactory
+from common.models.settings import (
+    SearchSettings,
+    IncidentFilterSettings,
+    GeneralIncidentFilter,
+)
+from home.tests.factories import HomePageFactory
+from incident.tests.factories import (
+    IncidentIndexPageFactory,
+    IncidentPageFactory,
+    IncidentUpdateFactory,
+    StateFactory,
+    EquipmentFactory,
+    EquipmentBrokenFactory,
+)
+from incident.models import choices
+
+
+def powerset(iterable):
+    "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+    s = list(iterable)
+    return itertools.chain.from_iterable(
+        itertools.combinations(s, r) for r in range(len(s) + 1)
+    )
+
+
+class FilterTest(SeleniumTest):
+    def setUp(self):
+        super().setUp()
+
+        self.root_page = Page.objects.get(slug='home')
+        site = Site.objects.get(is_default_site=True)
+
+        self.home_page = HomePageFactory(parent=self.root_page)
+
+        # configure search to enable filter display
+        search_settings = SearchSettings.for_site(site)
+        self.index = IncidentIndexPageFactory(parent=self.root_page)
+        search_settings.search_page = self.index
+        search_settings.save()
+
+        self.settings = IncidentFilterSettings.for_site(site)
+
+    def open_filters(self):
+        self.browser.find_element_by_css_selector('.filters__button--summary-toggle').click()
+
+    def apply_filters(self):
+        self.browser.find_element_by_xpath('//button[@type="submit"][text()="Apply Filters"]').click()
+
+    def add_general_filter(self, filter_name):
+        GeneralIncidentFilter.objects.create(
+            incident_filter=filter_name,
+            incident_filter_settings=self.settings,
+        )
+
+
+class BooleanFilterTestCase(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        self.category = CategoryPageFactory(
+            parent=self.root_page,
+            title='Leak Case',
+            incident_filters=['charged_under_espionage_act'],
+        )
+
+        self.true_bool = IncidentPageFactory(
+            categories=[self.category],
+            charged_under_espionage_act=True
+        )
+        self.false_bool = IncidentPageFactory(
+            categories=[self.category],
+            charged_under_espionage_act=False
+        )
+
+    def test_filters_boolean_true(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+
+        self.browser.find_element_by_css_selector('.filters__category').click()
+
+        self.browser.find_element_by_xpath('//button[text()="Yes"]').click()
+
+        self.apply_filters()
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['charged_under_espionage_act'],
+            ['True'],
+        )
+
+        self.open_filters()
+        selected_button = self.browser.find_element_by_css_selector('button.radio-pill__item--selected')
+        self.assertEqual(selected_button.text, 'Yes')
+
+    def test_filters_boolean_false(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+
+        self.browser.find_element_by_css_selector('.filters__category').click()
+
+        self.browser.find_element_by_xpath('//button[text()="No"]').click()
+
+        self.apply_filters()
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['charged_under_espionage_act'],
+            ['False'],
+        )
+
+        self.open_filters()
+        selected_button = self.browser.find_element_by_css_selector('button.radio-pill__item--selected')
+        self.assertEqual(selected_button.text, 'No')
+
+
+class IntegerFilterTest(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        self.add_general_filter('recently_updated')
+
+        IncidentPageFactory(
+            first_published_at=timezone.now() - timedelta(days=90),
+        )
+
+        incident_with_new_update = IncidentPageFactory(
+            first_published_at=timezone.now() - timedelta(days=90),
+        )
+        IncidentUpdateFactory(
+            page=incident_with_new_update,
+            date=timezone.now() - timedelta(days=3),
+        )
+
+    def test_filters_integer(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+        element = self.browser.find_element_by_css_selector('input.filter-int-input')
+        element.send_keys('10')
+        self.apply_filters()
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['recently_updated'],
+            ['10'],
+        )
+
+        self.open_filters()
+        element = self.browser.find_element_by_css_selector('input.filter-int-input')
+        self.assertEqual(element.get_attribute('value'), '10')
+
+
+class MultiRelationFilterTest(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        self.category = CategoryPageFactory(
+            parent=self.root_page,
+            title='Equipment Damage',
+            incident_filters=['equipment_broken'],
+        )
+
+        self.equipment = [
+            EquipmentFactory(name='Leather Armor'),
+            EquipmentFactory(name='Scale Mail'),
+            EquipmentFactory(name='Field Plate'),
+        ]
+
+        for equipment_set in powerset(self.equipment):
+            incident = IncidentPageFactory(categories=[self.category])
+            for equipment in equipment_set:
+                EquipmentBrokenFactory(
+                    incident=incident,
+                    equipment=equipment,
+                )
+        self.browser.get(self.live_server_url + self.home_page.url)
+        self.open_filters()
+        self.browser.find_element_by_css_selector('.filters__category').click()
+        self.autocomplete_input = self.browser.find_element_by_css_selector('.autocomplete__search')
+
+    def test_filters_multiple_related_selections(self):
+        for equipment in self.equipment[:2]:
+            self.autocomplete_input.clear()
+            self.autocomplete_input.send_keys(equipment.name, Keys.ENTER)
+
+        self.apply_filters()
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+        self.assertEqual(url.path, self.category.url)
+
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['equipment_broken'],
+            [f'{self.equipment[0].pk},{self.equipment[1].pk}'],
+        )
+
+        self.open_filters()
+
+        self.assertEqual(
+            {element.text for element in self.browser.find_elements_by_css_selector('.selection__label')},
+            {equipment.name for equipment in self.equipment[:2]}
+        )
+
+
+class RelationFilterTest(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        self.add_general_filter('state')
+
+        self.vermont = StateFactory(name='Vermont')
+        self.new_hampshire = StateFactory(name='New Hampshire')
+
+        IncidentPageFactory(state=self.vermont)
+        IncidentPageFactory(state=self.new_hampshire)
+
+        self.browser.get(self.live_server_url + self.home_page.url)
+        self.open_filters()
+        self.autocomplete_input = self.browser.find_element_by_css_selector('.autocomplete__search')
+
+    def test_filters_autocomplete_mouse_input(self):
+        self.autocomplete_input.click()
+        self.browser.find_element_by_css_selector('.suggestions__item').click()
+
+        self.apply_filters()
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+        self.assertEqual(url.path, self.index.url)
+
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['state'],
+            [str(self.vermont.pk)],
+        )
+
+        self.open_filters()
+        self.assertEqual(
+            {element.text for element in self.browser.find_elements_by_css_selector('.selection__label')},
+            {self.vermont.name}
+        )
+
+    def test_filters_autocomplete_keyboard_input(self):
+        self.autocomplete_input.send_keys(Keys.ARROW_DOWN, Keys.ENTER)
+
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(url.path, self.index.url)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['state'],
+            [str(self.new_hampshire.pk)],
+        )
+
+        self.open_filters()
+        self.assertEqual(
+            {element.text for element in self.browser.find_elements_by_css_selector('.selection__label')},
+            {self.new_hampshire.name}
+        )
+
+
+class SearchFilterTest(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        IncidentPageFactory(title='Cuttlefish')
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+    def test_filters_by_search(self):
+        self.open_filters()
+        element = self.browser.find_element_by_css_selector('input.filter-text-input')
+        element.send_keys('Cuttlefish')
+
+        self.apply_filters()
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+        self.assertEqual(url.path, self.index.url)
+
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['search'],
+            ['Cuttlefish'],
+        )
+
+        self.open_filters()
+        element = self.browser.find_element_by_css_selector('input.filter-text-input')
+        self.assertEqual(element.get_attribute('value'), 'Cuttlefish')
+
+
+class DateFilterTest(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        self.add_general_filter('date')
+
+        IncidentPageFactory(date='2020-02-15')
+        IncidentPageFactory(date='2020-03-15')
+        IncidentPageFactory(date='2020-04-15')
+
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+        self.lower, self.upper = self.browser.find_elements_by_css_selector('input.filter-date-picker')
+
+    def test_filters_lower_date(self):
+        self.lower.send_keys('04/01/2020')
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        self.assertEqual(len(incidents), 1)
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['date_lower'],
+            ['2020-04-01'],
+        )
+
+        self.open_filters()
+        lower, upper = self.browser.find_elements_by_css_selector('input.filter-date-picker')
+        self.assertEqual(lower.get_attribute('value'), '04/01/2020')
+        self.assertEqual(upper.get_attribute('value'), '')
+
+    def test_filters_upper_date(self):
+        self.upper.send_keys('04/01/2020')
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        self.assertEqual(len(incidents), 2)
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['date_upper'],
+            ['2020-04-01'],
+        )
+        self.open_filters()
+        lower, upper = self.browser.find_elements_by_css_selector('input.filter-date-picker')
+        self.assertEqual(lower.get_attribute('value'), '')
+        self.assertEqual(upper.get_attribute('value'), '04/01/2020')
+
+    def test_filters_upper_and_lower_date(self):
+        self.lower.send_keys('03/01/2020')
+        self.upper.send_keys('04/01/2020')
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        self.assertEqual(len(incidents), 1)
+
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['date_upper'],
+            ['2020-04-01'],
+        )
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['date_lower'],
+            ['2020-03-01'],
+        )
+        self.open_filters()
+        lower, upper = self.browser.find_elements_by_css_selector('input.filter-date-picker')
+        self.assertEqual(lower.get_attribute('value'), '03/01/2020')
+        self.assertEqual(upper.get_attribute('value'), '04/01/2020')
+
+
+class ChoiceFilterTest(FilterTest):
+    def setUp(self):
+        super().setUp()
+
+        self.category = CategoryPageFactory(
+            parent=self.root_page,
+            title='Attack',
+            incident_filters=['assailant', 'was_journalist_targeted'],
+        )
+        self.incidents = []
+        for (boolean, actor) in itertools.product(choices.MAYBE_BOOLEAN, choices.ACTORS):
+            self.incidents.append(
+                IncidentPageFactory(
+                    categories=[self.category],
+                    assailant=actor[0],
+                    was_journalist_targeted=boolean[0],
+                )
+            )
+
+    def test_filters_by_maybe_boolean_choice_unknown(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+
+        self.browser.find_element_by_css_selector('.filters__category').click()
+
+        self.browser.find_element_by_xpath('//button[text()="Unknown"]').click()
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(len(incidents), 6)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['was_journalist_targeted'],
+            [choices.MAYBE_BOOLEAN[0][0]],
+        )
+
+        self.open_filters()
+        selected_button = self.browser.find_element_by_css_selector('button.radio-pill__item--selected')
+        self.assertEqual(selected_button.text, 'Unknown')
+
+    def test_filters_by_maybe_boolean_choice_no(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+
+        self.browser.find_element_by_css_selector('.filters__category').click()
+
+        self.browser.find_element_by_xpath('//button[text()="No"]').click()
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(len(incidents), 6)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['was_journalist_targeted'],
+            [choices.MAYBE_BOOLEAN[2][0]],
+        )
+        self.open_filters()
+        selected_button = self.browser.find_element_by_css_selector('button.radio-pill__item--selected')
+        self.assertEqual(selected_button.text, 'No')
+
+    def test_filters_by_dropdown_choice(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+        self.browser.find_element_by_css_selector('.filters__category').click()
+
+        select = Select(self.browser.find_element_by_css_selector('select.choice-input'))
+        select.select_by_value(choices.ACTORS[1][0])
+
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(len(incidents), 3)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['assailant'],
+            [choices.ACTORS[1][0]],
+        )
+
+        self.open_filters()
+        select = Select(self.browser.find_element_by_css_selector('select.choice-input'))
+
+        self.assertEqual(
+            {element.text for element in select.all_selected_options},
+            {choices.ACTORS[1][1]}
+        )
+
+    def test_filters_by_multi_choice(self):
+        self.browser.get(self.live_server_url + self.home_page.url)
+
+        self.open_filters()
+        self.browser.find_element_by_css_selector('.filters__category').click()
+
+        select = Select(self.browser.find_element_by_css_selector('select.choice-input'))
+        select.select_by_value(choices.ACTORS[2][0])
+        self.browser.find_element_by_xpath('//button[text()="Yes"]').click()
+
+        self.apply_filters()
+
+        incidents = self.browser.find_elements_by_css_selector('article.incident')
+        url = urllib.parse.urlparse(self.browser.current_url)
+
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['assailant'],
+            [choices.ACTORS[2][0]],
+        )
+        self.assertEqual(
+            urllib.parse.parse_qs(url.query)['was_journalist_targeted'],
+            [choices.MAYBE_BOOLEAN[1][0]],
+        )
+
+        self.open_filters()
+        selected_button = self.browser.find_element_by_css_selector('button.radio-pill__item--selected')
+        select = Select(self.browser.find_element_by_css_selector('select.choice-input'))
+
+        self.assertEqual(selected_button.text, 'Yes')
+        self.assertEqual(
+            {element.text for element in select.all_selected_options},
+            {choices.ACTORS[2][1]}
+        )

--- a/incident/tests/test_pagination_selenium.py
+++ b/incident/tests/test_pagination_selenium.py
@@ -1,0 +1,35 @@
+from wagtail.core.models import Page
+
+from common.tests.selenium import SeleniumTest
+from incident.tests.factories import IncidentIndexPageFactory, IncidentPageFactory
+
+
+class PaginationTestCase(SeleniumTest):
+    def setUp(self):
+        super().setUp()
+        root_page = Page.objects.get(slug='home')
+
+        self.index = IncidentIndexPageFactory(parent=root_page)
+
+        IncidentPageFactory.create_batch(30, parent=self.index)
+
+    def test_next_page_button(self):
+        more_css = '.js-incident-loading-next-link'
+        incident_css = 'article.incident'
+        incidents_per_page = 8
+
+        self.browser.get(self.live_server_url + self.index.url)
+
+        incidents = self.browser.find_elements_by_css_selector(incident_css)
+        expected_incidents = incidents_per_page
+        self.assertEqual(len(incidents), expected_incidents)
+
+        self.browser.find_element_by_css_selector(more_css).click()
+        incidents = self.browser.find_elements_by_css_selector(incident_css)
+        expected_incidents += incidents_per_page
+        self.assertEqual(len(incidents), expected_incidents)
+
+        self.browser.find_element_by_css_selector(more_css).click()
+        incidents = self.browser.find_elements_by_css_selector(incident_css)
+        expected_incidents += incidents_per_page
+        self.assertEqual(len(incidents), expected_incidents)

--- a/incident/tests/test_pagination_selenium.py
+++ b/incident/tests/test_pagination_selenium.py
@@ -1,7 +1,28 @@
 from wagtail.core.models import Page
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 
 from common.tests.selenium import SeleniumTest
 from incident.tests.factories import IncidentIndexPageFactory, IncidentPageFactory
+
+
+class element_has_href(object):
+    """An expectation for checking that an element has a particular href value.
+
+    locator - used to find the element
+    returns the WebElement once it has the particular css class
+    """
+
+    def __init__(self, locator, css_class):
+        self.locator = locator
+        self.css_class = css_class
+
+    def __call__(self, driver):
+        element = driver.find_element(*self.locator)   # Finding the referenced element
+        if self.css_class in element.get_attribute("href"):
+            return element
+        else:
+            return False
 
 
 class PaginationTestCase(SeleniumTest):
@@ -25,11 +46,15 @@ class PaginationTestCase(SeleniumTest):
         self.assertEqual(len(incidents), expected_incidents)
 
         self.browser.find_element_by_css_selector(more_css).click()
+        wait = WebDriverWait(self.browser, 10)
+        wait.until(element_has_href((By.CSS_SELECTOR, more_css), "?page=3"))
         incidents = self.browser.find_elements_by_css_selector(incident_css)
         expected_incidents += incidents_per_page
         self.assertEqual(len(incidents), expected_incidents)
 
         self.browser.find_element_by_css_selector(more_css).click()
+        wait = WebDriverWait(self.browser, 10)
+        wait.until(element_has_href((By.CSS_SELECTOR, more_css), "?page=4"))
         incidents = self.browser.find_elements_by_css_selector(incident_css)
         expected_incidents += incidents_per_page
         self.assertEqual(len(incidents), expected_incidents)

--- a/statistics/tests/test_statistics_tags.py
+++ b/statistics/tests/test_statistics_tags.py
@@ -28,10 +28,12 @@ class NumIncidentsTest(TestCase):
             title='hello',
             date=datetime.date(2017, 1, 1),
             categories=[cls.category],
+            state=None,
         )
         cls.old_incident = IncidentPageFactory(
             title='goodbye',
             date=datetime.date(2016, 1, 1),
+            state=None,
         )
 
     def setUp(self):


### PR DESCRIPTION
Fixes #734 

This pull request adds some basic, non-exhaustive browser-based testing using a selenium container. There are tests for the pagination behavior on incident lists, and for the basic functionality of the different filter types.