### PR TITLE
Change django-logging encoding from 'ascii' to 'utf-8'

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -357,6 +357,7 @@ DJANGO_LOGGING = {
     # Do not log the content of responses by default--these might be
     # quite big!
     "RESPONSE_FIELDS": ("status", "reason", "charset", "headers"),
+    "ENCODING": "utf-8",
 }
 
 LOGGING = {


### PR DESCRIPTION
The default is not acceptable for logging the "content" response, which may contain non-ascii characters.  Even though we are ultimately discarding the content, `django-logging` still encodes it first.

Refs https://github.com/freedomofpress/fpf-www-projects/issues/180