### PR TITLE
Adds observableusercontent in connect_src CSP

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -289,12 +289,11 @@ CSP_CONNECT_SRC = [
     "https://releases.wagtail.io/latest.txt",
     # Observable Notebooks
     "https://cdn.jsdelivr.net",
-    "https://pressfreedomtracker.us",
+    "https://static.observableusercontent.com/",
 ]
 CSP_IMG_SRC = [
     "'self'",
     "https://analytics.freedom.press",
-    "https://media.pressfreedomtracker.us",
     # For Twitter Widgets
     "https://platform.twitter.com",
     "https://syndication.twitter.com",


### PR DESCRIPTION
I have removed 2 rules because they didn't make sense on a second look for tracker.
For adding the media links in the CSP, like other repositories, an environment variable `DJANGO_CSP_MEDIA_ORIGINS` needs to be set in the deployment environment.

Fixes #1070 