### PR TITLE
Use an explicit random seed in the test suite

### DIFF
--- a/common/test_runner.py
+++ b/common/test_runner.py
@@ -1,0 +1,27 @@
+from xmlrunner.extra.djangotestrunner import XMLTestRunner
+import factory.random
+
+from django.conf import settings
+from django.test.runner import DiscoverRunner
+
+
+class WithSeedMixin(object):
+    """Modifies a test runner class to use a given constant from
+    `settings.RANDOM_SEED` to seed the generation of randomized
+    factory objects.
+
+    """
+    def setup_test_environment(self):
+        seed = settings.RANDOM_SEED
+        if seed:
+            factory.random.reseed_random(seed)
+            print(f'Using seed: {seed}')
+        super().setup_test_environment()
+
+
+class SeededXMLRunner(WithSeedMixin, XMLTestRunner):
+    pass
+
+
+class SeededDiscoveryRunner(WithSeedMixin, DiscoverRunner):
+    pass

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -404,3 +404,6 @@ LOGGING = {
         },
     },
 }
+
+TEST_RUNNER = 'common.test_runner.SeededDiscoveryRunner'
+RANDOM_SEED = 876394101

--- a/tracker/settings/production-ci.py
+++ b/tracker/settings/production-ci.py
@@ -1,6 +1,6 @@
 from .production import *  # noqa: F403, F401
 
-TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_RUNNER = 'common.test_runner.SeededXMLRunner'
 TEST_OUTPUT_DIR = "/home/gcorn"
 TEST_OUTPUT_FILE_NAME = "app-tests.xml"
 TEST_OUTPUT_DESCRIPTIONS = True


### PR DESCRIPTION
Adds a test runner whose purpose is to configure the seed for Factory Boy (as described [in the documentation](https://factoryboy.readthedocs.io/en/stable/recipes.html#recipe-random-management)) to prevent randomly generated objects from causing unexpected and ephemeral test failures.

Such failures are particularly common for our incident-related inline objects that consist solely of a single field that must be unique.  When randomly generating several of these for a test, if the same value is chosen for that field for more than one object (an uncommon but definitely possible occurrence) then only a single object will be created where the test expected two, thus potentially causing a test assertion against an aggregate count to fail.

My hope is that using the same seed locally and on CI will prevent us from being surprised when such problems occur.

I've placed the seed in the base settings file, which makes it consistent across development and CI environments but also allows for fairly easy customization locally should the situation call for it. I chose the number with `random.randint(0, 1_000_000_000)`.

Fixes #1060 