### PR TITLE
Attempt to fix transient selenium test failure

### DIFF
--- a/incident/tests/test_pagination_selenium.py
+++ b/incident/tests/test_pagination_selenium.py
@@ -1,28 +1,9 @@
 from wagtail.core.models import Page
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
 
 from common.tests.selenium import SeleniumTest
 from incident.tests.factories import IncidentIndexPageFactory, IncidentPageFactory
-
-
-class element_has_href(object):
-    """An expectation for checking that an element has a particular href value.
-
-    locator - used to find the element
-    returns the WebElement once it has the particular css class
-    """
-
-    def __init__(self, locator, css_class):
-        self.locator = locator
-        self.css_class = css_class
-
-    def __call__(self, driver):
-        element = driver.find_element(*self.locator)   # Finding the referenced element
-        if self.css_class in element.get_attribute("href"):
-            return element
-        else:
-            return False
 
 
 class PaginationTestCase(SeleniumTest):
@@ -47,14 +28,14 @@ class PaginationTestCase(SeleniumTest):
 
         self.browser.find_element_by_css_selector(more_css).click()
         wait = WebDriverWait(self.browser, 10)
-        wait.until(element_has_href((By.CSS_SELECTOR, more_css), "?page=3"))
+        wait.until(expected_conditions.url_contains('?endpage=2'))
         incidents = self.browser.find_elements_by_css_selector(incident_css)
         expected_incidents += incidents_per_page
         self.assertEqual(len(incidents), expected_incidents)
 
         self.browser.find_element_by_css_selector(more_css).click()
         wait = WebDriverWait(self.browser, 10)
-        wait.until(element_has_href((By.CSS_SELECTOR, more_css), "?page=4"))
+        wait.until(expected_conditions.url_contains('?endpage=3'))
         incidents = self.browser.find_elements_by_css_selector(incident_css)
         expected_incidents += incidents_per_page
         self.assertEqual(len(incidents), expected_incidents)


### PR DESCRIPTION
Fixes some problems we've noticed on CI: [example 1](https://app.circleci.com/pipelines/github/freedomofpress/pressfreedomtracker.us/1120/workflows/476b87df-1595-4e58-9e4d-327c325c91ec/jobs/7975), [example 2](https://app.circleci.com/pipelines/github/freedomofpress/pressfreedomtracker.us/1121/workflows/67f1058f-5e36-46c0-a733-cc071d0aba29/jobs/7978).

Some technical details explained in the commit message. The short explanation is: waiting for elements on a page can be subject to race conditions, so let's try waiting for the URL to change instead.