### PR TITLE
Fix merge views

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -31,4 +31,3 @@ class BaseMergeForm(forms.Form):
 
 class TagMergeForm(BaseMergeForm):
     merge_model = CommonTag
-    merge_model_type = 'common.CommonTag'

--- a/common/forms.py
+++ b/common/forms.py
@@ -21,7 +21,7 @@ class BaseMergeForm(forms.Form):
             widget=type(
                 '_Autocomplete',
                 (Autocomplete,),
-                dict(target_model=self.merge_model_type, can_create=False, is_single=False)
+                dict(target_model=self.merge_model, can_create=False, is_single=False)
             ),
             label='{} to merge'.format(capfirst(self.merge_model_name))
         )

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -2,6 +2,7 @@ from django.core.files.base import ContentFile
 from django.urls import reverse
 from django.test import TestCase
 from wagtail.documents.models import Document
+from wagtail.tests.utils import WagtailPageTests
 from common.models import CommonTag
 from common.wagtail_hooks import CommonTagAdmin
 from django.contrib.auth import get_user_model
@@ -32,6 +33,12 @@ class DocumentDownloadTest(TestCase):
         )
 
         self.assertEqual(response['content-disposition'], 'inline; filename="{}"'.format(document.filename))
+
+
+class MergeTagFormTestCase(WagtailPageTests):
+    def test_getting_the_form_succeeds(self):
+        self.response = self.client.get(CommonTagAdmin().url_helper.merge_url)
+        self.assertEqual(self.response.status_code, 200)
 
 
 class MergeTagTestCase(TestCase):

--- a/incident/forms.py
+++ b/incident/forms.py
@@ -4,39 +4,31 @@ from incident.models import Charge, Nationality, Venue, PoliticianOrPublic, Jour
 
 class JournalistMergeForm(BaseMergeForm):
     merge_model = Journalist
-    merge_model_type = 'incident.Journalist'
 
 
 class InstitutionMergeForm(BaseMergeForm):
     merge_model = Institution
-    merge_model_type = 'incident.Institution'
 
 
 class ChargeMergeForm(BaseMergeForm):
     merge_model = Charge
-    merge_model_type = 'incident.Charge'
 
 
 class LawEnforcementOrganizationForm(BaseMergeForm):
     merge_model = LawEnforcementOrganization
-    merge_model_type = 'incident.LawEnforcementOrganization'
 
 
 class NationalityMergeForm(BaseMergeForm):
     merge_model = Nationality
-    merge_model_type = 'incident.Nationality'
 
 
 class VenueMergeForm(BaseMergeForm):
     merge_model = Venue
-    merge_model_type = 'incident.Venue'
 
 
 class PoliticianOrPublicMergeForm(BaseMergeForm):
     merge_model = PoliticianOrPublic
-    merge_model_type = 'incident.PoliticianOrPublic'
 
 
 class GovernmentWorkerMergeForm(BaseMergeForm):
     merge_model = GovernmentWorker
-    merge_model_type = 'incident.GovernmentWorker'

--- a/incident/tests/test_views.py
+++ b/incident/tests/test_views.py
@@ -5,9 +5,10 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from wagtail.core.models import Site
 from wagtail.core.rich_text import RichText
+from wagtail.tests.utils import WagtailPageTests
 
 from incident.models import Charge, Nationality, PoliticianOrPublic, Venue, Journalist, Institution, TargetedJournalist, GovernmentWorker
-from incident.wagtail_hooks import ChargeAdmin, NationalityAdmin, VenueAdmin, PoliticianOrPublicAdmin, JournalistAdmin, InstitutionAdmin, GovernmentWorkerAdmin
+from incident.wagtail_hooks import ChargeAdmin, NationalityAdmin, VenueAdmin, PoliticianOrPublicAdmin, JournalistAdmin, InstitutionAdmin, GovernmentWorkerAdmin, IncidentGroup
 from incident.tests.factories import (
     IncidentPageFactory,
     IncidentIndexPageFactory,
@@ -56,6 +57,15 @@ class IncidentAdminSearch(TestCase):
             set(response.context['pages']),
             {self.incident_page1, self.incident_page3},
         )
+
+
+class MergeFormViewTestCase(WagtailPageTests):
+    def test_getting_the_form_succeeds(self):
+        for item in IncidentGroup.items:
+            admin = item()
+            with self.subTest(form=f'Merge {admin.menu_label} form'):
+                self.response = self.client.get(item().url_helper.merge_url)
+                self.assertEqual(self.response.status_code, 200)
 
 
 class InstitutionMergeViewTestCase(TestCase):


### PR DESCRIPTION
Somewhere along the line, the autocomplete widget was changed to specify the `target_model` as a reference to the model class itself instead of a string.  This was causing the merge form pages to not work, the page wouldn't even load without an error.  

This PR fixes that problem, and restores the merge view functionality for all Incident many-to-many models (Tags, Institutions, etc.). It also adds some very basic tests to make sure that loading the all the various form pages at least returns a 200 response.
