### PR TITLE
Fix a bug in generating unique dates

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 from urllib.parse import urlencode
 
 from django import forms
@@ -669,7 +670,8 @@ class IncidentPage(MetadataPageMixin, Page):
         return context
 
     def save(self, *args, **kwargs):
-        self.unique_date = f'{self.date}-{self.pk}'
+        uuid_ = uuid.uuid1()
+        self.unique_date = f'{self.date}-{uuid_}'
 
         super().save(*args, **kwargs)
 

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -774,11 +774,11 @@ class IncidentPageTests(TestCase):
 
     def test_computes_unique_date(self):
         incident1 = IncidentPage(
-            date=date(2020, 6,16),
+            date=date(2020, 6, 16),
             title='Test Incident 1',
         )
         incident2 = IncidentPage(
-            date=date(2020, 6,16),
+            date=date(2020, 6, 16),
             title='Test Incident 2',
         )
         self.incident_index.add_child(instance=incident1)

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -773,9 +773,30 @@ class IncidentPageTests(TestCase):
         root_page.add_child(instance=cls.incident_index)
 
     def test_computes_unique_date(self):
-        incident = IncidentPageFactory(parent=self.incident_index)
+        incident1 = IncidentPage(
+            date=date(2020, 6,16),
+            title='Test Incident 1',
+        )
+        incident2 = IncidentPage(
+            date=date(2020, 6,16),
+            title='Test Incident 2',
+        )
+        self.incident_index.add_child(instance=incident1)
+        self.incident_index.add_child(instance=incident2)
 
-        self.assertEqual(
-            incident.unique_date,
-            f'{incident.date}-{incident.pk}',
+        UNIQUE_DATE_FORMAT = r'\d{4}-\d{2}-\d{2}-[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
+
+        self.assertRegex(
+            incident1.unique_date,
+            UNIQUE_DATE_FORMAT
+        )
+
+        self.assertRegex(
+            incident2.unique_date,
+            UNIQUE_DATE_FORMAT
+        )
+
+        self.assertNotEqual(
+            incident1.unique_date,
+            incident2.unique_date
         )


### PR DESCRIPTION
Previously we were generating unique dates for incidents by concatenating
incident date with incident database id on save. Unfortunately, because
when an incident is first saved it has no database id, this was
generating unique date keys that looked like "2020-06-16-None" and were
not guaranteed to be unique.

The test was missing this error because using the IncidentPageFactory
triggered multiple calls to .save() and the key was corrected on the
second call--thus the test passed.

I've rewritten the functionality to use a generated-on-the-fly uuid
instead of database id and the test to compare two incidents against
each other to verify their unique dates are not identical. I also
rewrote the test to use IncidentPage directly instead of the factory.

Suggested Review Process
---------------------------

1. Read the above, make sure it makes sense
2. Read the code, make sure it does what I said above
3. Bonus step: run the application locally and ensure you can create two different incidents that happened on the same date (We'll also have an opportunity to test this on staging once merged)