### PR TITLE
Add command to halt CI job if package-lock.json is not changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,16 @@ reuse-blerbs:
         pip install pipenv
         pipenv sync
 
-version: 2
+version: 2.1
+commands:
+  check-changed-files-or-halt:
+    description: "Halt job if changed any changed file matches pattern"
+    parameters:
+      pattern:
+        type: string
+    steps:
+      - run: git diff --name-only develop...HEAD|grep -q '<< parameters.pattern >>' || circleci step halt
+
 jobs:
   safety_check:
     environment:
@@ -46,6 +55,8 @@ jobs:
     working_directory: ~/tracker
     steps:
       - checkout
+      - check-changed-files-or-halt:
+          pattern: ^package-lock.json$
 
       - *python_prereqs
 


### PR DESCRIPTION
Refs freedomofpress/fpf-www-projects#190

This pull request adds a command to halt the npm audit CI job (but proceed with the overall workflow) when package-log.json has not been changed on the branch being checked.

See https://github.com/freedomofpress/securethenews/pull/354 for further description of the effect of this on our CI workflows.