### PR TITLE
Put unique date generation in `full_clean`

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -669,15 +669,18 @@ class IncidentPage(MetadataPageMixin, Page):
             context['related_qs'] = urlencode(related_filter)
         return context
 
-    def save(self, *args, **kwargs):
+    def full_clean(self, *args, **kwargs):
         if self.unique_date and self.unique_date[:10] != str(self.date):
+            # if the date has been changed, only change the date part
+            # of unique_date
             uuid_ = self.unique_date[11:]
             self.unique_date = f'{self.date}-{uuid_}'
         elif not self.unique_date:
+            # create a new uuid for unique date if it's not present
             uuid_ = uuid.uuid1()
             self.unique_date = f'{self.date}-{uuid_}'
 
-        super().save(*args, **kwargs)
+        super().full_clean(*args, **kwargs)
 
     def detention_duration(self):
         """

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -670,8 +670,12 @@ class IncidentPage(MetadataPageMixin, Page):
         return context
 
     def save(self, *args, **kwargs):
-        uuid_ = uuid.uuid1()
-        self.unique_date = f'{self.date}-{uuid_}'
+        if self.unique_date and self.unique_date[:10] != str(self.date):
+            uuid_ = self.unique_date[11:]
+            self.unique_date = f'{self.date}-{uuid_}'
+        else:
+            uuid_ = uuid.uuid1()
+            self.unique_date = f'{self.date}-{uuid_}'
 
         super().save(*args, **kwargs)
 

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -673,7 +673,7 @@ class IncidentPage(MetadataPageMixin, Page):
         if self.unique_date and self.unique_date[:10] != str(self.date):
             uuid_ = self.unique_date[11:]
             self.unique_date = f'{self.date}-{uuid_}'
-        else:
+        elif not self.unique_date:
             uuid_ = uuid.uuid1()
             self.unique_date = f'{self.date}-{uuid_}'
 


### PR DESCRIPTION
This PR moves the `unique_date` generation to from `save()` to `full_clean()`. It also slightly changes how we make populate the field so that the UUID is only generated once per incident.

The move to `full_clean` was done in response to some errors we noticed in production, and I was able to cause an error locally when attempting to preview an incident that had not yet been saved. The changes on this PR were able to resolve the local error for me.

Error information from production:

```
{'type': 'django.core.exceptions.ValidationError',
 'message': "{'unique_date': ['This field cannot be blank.']}",
 'traceback': [{'file': '/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py',
 'method': '_get_response',
 'line': 113},
 {'file': '/usr/local/lib/python3.9/site-packages/django/views/decorators/cache.py',
 'method': '_wrapped_view_func',
 'line': 44},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/admin/urls/__init__.py',
 'method': 'wrapper',
 'line': 127},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/admin/auth.py',
 'method': 'decorated_view',
 'line': 172},
 {'file': '/usr/local/lib/python3.9/site-packages/django/views/generic/base.py',
 'method': 'view',
 'line': 71},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/admin/views/pages/edit.py',
 'method': 'dispatch',
 'line': 131},
 {'file': '/usr/local/lib/python3.9/site-packages/django/views/generic/base.py',
 'method': 'dispatch',
 'line': 97},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/admin/views/pages/edit.py',
 'method': 'post',
 'line': 218},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/admin/views/pages/edit.py',
 'method': 'form_valid',
 'line': 238},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/admin/views/pages/edit.py',
 'method': 'publish_action',
 'line': 273},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/core/models.py',
 'method': 'save_revision',
 'line': 1318},
 {'file': '/usr/local/lib/python3.9/site-packages/wagtail/core/models.py',
 'method': 'full_clean',
 'line': 976},
 {'file': '/usr/local/lib/python3.9/site-packages/django/db/models/base.py',
 'method': 'full_clean',
 'line': 1206}]}
```

I was _not_ able to reproduce this exact traceback locally, but I suspect this change will fix that error, as well.