### PR TITLE
Reinstate by-default pagination for incidents API, JSON format

### DIFF
--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -77,7 +77,7 @@ class IncidentAPITest(APITestCase):
             reverse('incidentpage-list'),
             HTTP_ACCEPT='application/json',
         )
-        data = response.json()[0]
+        data = response.json()['results'][0]
         inc = self.incident
 
         self.maxDiff = None
@@ -159,7 +159,7 @@ class IncidentAPITest(APITestCase):
             HTTP_ACCEPT='application/json',
         )
 
-        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(len(response.json()['results']), 1)
 
     def test_dynamic_fields(self):
         response = self.client.get(
@@ -169,6 +169,6 @@ class IncidentAPITest(APITestCase):
         )
 
         self.assertEqual(
-            list(response.json()[0].keys()),
+            list(response.json()['results'][0].keys()),
             ['city', 'state'],
         )

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class IncidentCursorPagination(CursorPagination):
-    page_size = None
+    page_size = 25
     page_size_query_param = 'limit'
     ordering = '-unique_date'
 
@@ -44,6 +44,11 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         if self.request.accepted_renderer.format == 'csv':
             return FlatIncidentSerializer
         return super().get_serializer_class()
+
+    def paginate_queryset(self, queryset):
+        if self.request.accepted_renderer.format == 'csv':
+            return None
+        return super().paginate_queryset(queryset)
 
     def get_queryset(self):
         incident_filter = IncidentFilter(self.request.GET)


### PR DESCRIPTION
Was removed in aa4950d6fe689d9c4b707ae2e25fd141e9c2774d

Does not apply pagination to the CSV format

Fixes #1065