### PR TITLE
Rate limit email signups

### DIFF
--- a/client/common/js/emails/EmailSignup.js
+++ b/client/common/js/emails/EmailSignup.js
@@ -28,6 +28,7 @@ class EmailSignup extends PureComponent {
 			INPUT,
 			LOADING,
 			ALREADY_SIGNED_UP,
+			TOO_MANY_REQUESTS,
 			SUCCESS,
 		} = EmailSignup
 
@@ -44,14 +45,20 @@ class EmailSignup extends PureComponent {
 		}
 
 		const handleReject = (error) => {
+			let errorMessage
 			if (error.response.data === 'already_signed_up') {
 				var state = ALREADY_SIGNED_UP
+				errorMessage = error.response.data
+			} else if (error.response.status === 429) {
+				var state = TOO_MANY_REQUESTS
+				errorMessage = error.response.statusText
 			} else {
 				var state = INPUT
+				errorMessage = error.response.data
 			}
 			this.setState({
 				state,
-				errorMessage: error.response.data,
+				errorMessage,
 			})
 		}
 
@@ -66,6 +73,7 @@ class EmailSignup extends PureComponent {
 			INPUT,
 			LOADING,
 			ALREADY_SIGNED_UP,
+			TOO_MANY_REQUESTS,
 			SUCCESS,
 		} = EmailSignup
 
@@ -84,6 +92,14 @@ class EmailSignup extends PureComponent {
 			return (
 				<div className="emails-signup__message emails-signup__message--already-signed-up">
 					<p className="emails-signup__text">This email address is already signed up.</p>
+				</div>
+			)
+		}
+
+		if (state === TOO_MANY_REQUESTS) {
+			return (
+				<div className="emails-signup__message emails-signup__message--already-signed-up">
+					<p className="emails-signup__text">Too many sign-up requests made. Please try again later.</p>
 				</div>
 			)
 		}
@@ -148,6 +164,9 @@ EmailSignup.ALREADY_SIGNED_UP = 'already_signed_up'
 
 
 EmailSignup.SUCCESS = 'success'
+
+
+EmailSignup.TOO_MANY_REQUESTS = 'too_many_requests'
 
 
 export default EmailSignup

--- a/emails/views.py
+++ b/emails/views.py
@@ -1,12 +1,18 @@
 from django.core.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, throttle_classes
+from rest_framework.throttling import UserRateThrottle
 
 from emails.models import EmailSignup
 
 
+class EmailSignupCreateUserThrottle(UserRateThrottle):
+    rate = '20/hour'
+
+
 @api_view(['POST'])
+@throttle_classes([EmailSignupCreateUserThrottle])
 def email_signup_create(request):
     if 'email_address' not in request.POST:
         return Response(status=400)

--- a/emails/views.py
+++ b/emails/views.py
@@ -1,16 +1,15 @@
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, HttpResponseBadRequest
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.decorators import api_view
 
 from emails.models import EmailSignup
 
 
-@csrf_exempt
-@require_POST
+@api_view(['POST'])
 def email_signup_create(request):
     if 'email_address' not in request.POST:
-        return HttpResponseBadRequest()
+        return Response(status=400)
     email_address = request.POST.get('email_address')
 
     try:
@@ -22,10 +21,10 @@ def email_signup_create(request):
         if len(message) > 0:
             message = message[0]
         if 'already exists' in message:
-            return HttpResponseBadRequest('already_signed_up')
+            return Response('already_signed_up', status=400)
         else:
-            return HttpResponseBadRequest(message)
+            return Response(status=400)
     except Exception:
-        return HttpResponseBadRequest()
+        return Response(status=400)
 
-    return HttpResponse('success')
+    return Response('success', status=status.HTTP_200_OK)


### PR DESCRIPTION
This pull request adds rate limiting to the email signups creation endpoint. Currently 20 per hour per user, but this can be easily changed.

The way this is implemented is using Django Rest Framework's (DRF) throttling system, which I think is fairly well-suited to this problem since:
1. The thing we want to throttle is basically already a REST endpoint.
2. It is a lot less code and overhead than copying over the rate-limiting system from freedom.press

So I modified the signup view slightly to make it DRF compatible without changing its functionality, then applied throttling to it. 