### PR TITLE
Rate limit by Cloudflares "CF-Connecting-IP" header when possible

### DIFF
--- a/emails/views.py
+++ b/emails/views.py
@@ -10,6 +10,12 @@ from emails.models import EmailSignup
 class EmailSignupCreateUserThrottle(UserRateThrottle):
     rate = '20/hour'
 
+    def get_ident(self, request):
+        try:
+            return request.headers["CF-Connecting-IP"]
+        except KeyError:
+            return super().get_ident(request)
+
 
 @api_view(['POST'])
 @throttle_classes([EmailSignupCreateUserThrottle])


### PR DESCRIPTION
Django Rest Framework's default configuration uses the X-Forwarded-For header to identify clients.  The presence of Cloudflare in our production/staging system complicates this, and from testing a little bit I don't think we should rely on X-Forwarded-For.

See, for example, [these logs of testing on the staging server](https://logs.freedom.press/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-08-10T14:00:00.000Z',to:'2021-08-10T15:00:00.000Z'))&_a=(columns:!(django.request.meta.http_x_forwarded_for,django.request.meta.remote_addr),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:resource.labels.cluster_name,negate:!f,params:(query:www-staging),type:phrase),query:(match_phrase:(resource.labels.cluster_name:www-staging))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:resource.labels.container_name,negate:!f,params:(query:pressfreedomtracker),type:phrase),query:(match_phrase:(resource.labels.container_name:pressfreedomtracker))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:django.request.path,negate:!t,params:(query:%2Fhealth%2Fok%2F),type:phrase),query:(match_phrase:(django.request.path:%2Fhealth%2Fok%2F))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'filebeat-*',key:django.request.meta.path_info,negate:!f,params:(query:%2Femails%2Fcreate%2F),type:phrase),query:(match_phrase:(django.request.meta.path_info:%2Femails%2Fcreate%2F)))),index:'filebeat-*',interval:auto,query:(language:kuery,query:''),sort:!())). All those requests were made by me, but the X-F-F header is not consistent. I am actually not sure what's going on exactly, or why I'm seeing this, but this behavior is interfering with our ability to apply the rate limit.

According to the Cloudflare docs, we can obtain the IP address that the website visitor connected to Cloudflare with from the CF-Connecting-IP header. I hope this will get us a more precise view of the client IP address.

More reading:

https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-CloudFlare-handle-HTTP-Request-headers-

https://www.django-rest-framework.org/api-guide/throttling/#how-clients-are-identified