### PR TITLE
Filter relations by humanized name

### DIFF
--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -176,12 +176,14 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
             context['export_path'] = self.url + self.reverse_subpage('export_view')
 
         incident_filter.clean()
-        category_ids = incident_filter.cleaned_data.get('categories')
+        category_data = incident_filter.cleaned_data.get('categories')
 
-        if not category_ids:
+        if not category_data:
             context['categories'] = CategoryPage.objects.live()
         else:
-            context['categories'] = CategoryPage.objects.filter(live=True, pk__in=category_ids)
+            context['categories'] = CategoryPage.objects.live().filter(
+                models.Q(pk__in=category_data.pks) | models.Q(title__in=category_data.strings)
+            )
 
         incident_qs = incident_filter.get_queryset() \
             .select_related('teaser_image', 'state', 'arresting_authority') \

--- a/incident/tests/test_incident_filter.py
+++ b/incident/tests/test_incident_filter.py
@@ -15,6 +15,7 @@ from incident.models import IncidentPage
 from incident.models.choices import ARREST_STATUS, STATUS_OF_CHARGES
 from incident.utils.incident_filter import (
     IncidentFilter,
+    ManyRelationValue,
 )
 
 
@@ -176,7 +177,7 @@ class CleanTest(TestCase):
         incident_filter.clean(strict=True)
 
         self.assertEqual(incident_filter.cleaned_data, {
-            'categories': [category.id],
+            'categories': ManyRelationValue(pks=[category.id]),
         })
 
     def test_param_requires_correct_category(self):

--- a/incident/tests/test_incident_filter.py
+++ b/incident/tests/test_incident_filter.py
@@ -232,13 +232,13 @@ class CleanTest(TestCase):
 
     def test_invalid_data(self):
         CategoryPage.objects.all().delete()
-        CategoryPageFactory(title='Category A', incident_filters=['state'])
-        incident_filter = IncidentFilter({'state': '???'})
+        CategoryPageFactory(title='Category A', incident_filters=['arrest_status'])
+        incident_filter = IncidentFilter({'arrest_status': '???'})
 
         with self.assertRaises(ValidationError) as cm:
             incident_filter.clean(strict=True)
 
         self.assertEqual(
             [str(error) for error in cm.exception],
-            ['Expected integer for relationship "state", received "???"'],
+            ['Invalid value for arrest_status: ???'],
         )

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -3,7 +3,7 @@ import operator
 from datetime import date
 import copy
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, FieldDoesNotExist
 from django.contrib.postgres.search import SearchQuery, SearchVector
 from django.db.models import (
     BooleanField,
@@ -587,6 +587,12 @@ class IncidentFilter(object):
             kwargs['filter_cls'] = ManyRelationFilter
         elif isinstance(model_field, ForeignKey):
             kwargs['filter_cls'] = RelationFilter
+            try:
+                model_field.related_model._meta.get_field('title')
+            except FieldDoesNotExist:
+                pass
+            else:
+                kwargs['text_fields'] = ['title']
         elif isinstance(model_field, DateField):
             kwargs['filter_cls'] = DateFilter
         elif model_field.choices:

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -331,8 +331,8 @@ class ManyRelationFilter(Filter):
             ))
         return value
 
-    def filter(self, queryset, value):
-        return queryset.filter(**{'{}__in'.format(self.lookup): value})
+    def get_query_arguments(self, value):
+        return Q(**{f'{self.lookup}__in': value})
 
     def get_verbose_name(self):
         if self.verbose_name:

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -33,7 +33,7 @@ class Filter(object):
     def __init__(self, name, model_field, lookup=None, verbose_name=None):
         self.name = name
         self.model_field = model_field
-        self.lookup = lookup or name
+        self._lookup = lookup
         self.verbose_name = verbose_name
 
     def __repr__(self):
@@ -44,6 +44,10 @@ class Filter(object):
 
     def get_value(self, data):
         return data.get(self.name) or None
+
+    @property
+    def lookup(self):
+        return self._lookup or self.name
 
     def clean(self, value, strict=False):
         return self.model_field.to_python(value)

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -55,13 +55,18 @@ class Filter(object):
     def get_allowed_parameters(self):
         return {self.name}
 
+    def get_query_arguments(self, value):
+        """Returns the give value as a Django Q-object appropriate for the
+filtering query."""
+        return Q(**{self.lookup: value})
+
     def filter(self, queryset, value):
         """
         Filter the queryset according to the given (cleaned) value.
 
         This will only get called if value is not None.
         """
-        return queryset.filter(**{self.lookup: value})
+        return queryset.filter(self.get_query_arguments(value))
 
     def get_verbose_name(self):
         return self.verbose_name or self.model_field.verbose_name

--- a/statistics/tests/test_validators.py
+++ b/statistics/tests/test_validators.py
@@ -135,13 +135,14 @@ class CleanTest(TestCase):
         self.assertEqual(dict(cm.exception), {'params': ['date_lower must be less than or equal to date_upper']})
 
     def test_clean__kwargs__cleans_with_incident_filter__invalid_param_value(self):
+        CategoryPageFactory(incident_filters=['status_of_charges'])
         with self.assertRaises(ValidationError) as cm:
             validate_dataset_params(
                 dataset='kwargs',
-                params='tags="hello"',
+                params='status_of_charges="hello"',
             )
 
-        self.assertEqual(dict(cm.exception), {'params': ['Invalid value for tags: hello']})
+        self.assertEqual(dict(cm.exception), {'params': ['Invalid value for status_of_charges: hello']})
 
     def test_clean__kwargs__cleans_with_incident_filter__variable_param_value(self):
         with self.assertRaises(ValidationError) as cm:
@@ -165,19 +166,21 @@ class CleanTest(TestCase):
         )
 
     def test_clean_kwargs__combine_multiple_errors(self):
-        category = CategoryPageFactory(incident_filters=['arrest_status'])
+        category = CategoryPageFactory(
+            incident_filters=['arrest_status', 'status_of_charges']
+        )
 
         with self.assertRaises(ValidationError) as cm:
             validate_dataset_params(
                 dataset='kwargs',
-                params='categories="{}" arrest_status="hello" tags="puppy"'.format(
+                params='categories="{}" arrest_status="hello" status_of_charges="puppy"'.format(
                     category.id,
                 ),
             )
 
         self.assertEqual(dict(cm.exception), {
             'params': [
+                'Invalid value for status_of_charges: puppy',
                 'Invalid value for arrest_status: hello',
-                'Invalid value for tags: puppy',
             ],
         })

--- a/statistics/tests/test_validators.py
+++ b/statistics/tests/test_validators.py
@@ -178,9 +178,10 @@ class CleanTest(TestCase):
                 ),
             )
 
-        self.assertEqual(dict(cm.exception), {
-            'params': [
+        self.assertEqual(
+            set(dict(cm.exception)['params']),
+            {
                 'Invalid value for status_of_charges: puppy',
-                'Invalid value for arrest_status: hello',
-            ],
-        })
+                'Invalid value for arrest_status: hello'
+            },
+        )


### PR DESCRIPTION
Refs #1061

This pull request updates the incident filter code to permit filtering by text on related items. For example, we can now call:

```python
IncidentFilter({'state': 'NM'}).get_queryset()
```
to retrieve all incidents that were in the state with abbreviation "NM," where previously we would have to know that this state has ID 36 and call 

```python
IncidentFilter({'state': '36'}).get_queryset()
```

The goal of this is to improve the human readability and constructability of API query strings. The GET parameters of URLs like `http://localhost:8000/api/edge/incidents/?state=36` are passed directly to `IncidentFilter`, so this change allows us to write URLs like this instead: `http://localhost:8000/api/edge/incidents/?state=NM`. The result will be the same.

I don't have an exhaustive list of exactly which fields are affected by this change, but here are the general rules.

1. Any field that's directly related to another object with a `title` field can be filtered by that title field. Example: `http://localhost:8000/api/edge/incidents/?arresting_authority=Keystone%20Cops`
2. This includes many-to-many relationships. Example: `http://localhost:8000/api/edge/incidents/?venue=Sea`
3. State, which does not have a `title` field, can be filtered by `name` OR `abbrevation`. Meaning: `http://localhost:8000/api/edge/incidents/?state=NM` and ``http://localhost:8000/api/edge/incidents/?state=New%20Mexico` are equivalent.
4. Categories can be filtered by title. Example: `http://localhost:8000/api/edge/incidents/?categories=Equipment Damage`. This is mostly the same as point 1, but categories do not have a "direct" relationship to incident pages and there is some additional technical baggage that goes along with this change. See commits.
5. Targeted institutions and charges can be filtered by title. These are also "indirect" relationships.
6. For filtering by multiple values, separate those values with commas. This parallels how filtering by ID works. Example: `http://localhost:8000/api/edge/incidents/?categories=Leak%20Case,Border%20Stop` should return the same as `http://localhost:8000/api/edge/incidents/?categories=9,4`. Note that this does, at present, make titles or other text queries containing commas problematic. I'm not sure exactly the best way to resolve this, though I think it does not apply extremely often.
7. Furthermore, though I'm not sure what the use-case is for this exactly, ID values and names can be combined. Example: `http://localhost:8000/api/edge/incidents/?categories=9,Border%20Stop`

I've added some tests to ensure that the new functionality works, and slightly updated a few where internal changes required it. I'm pretty confident that the filtering by IDs works exactly how it did before.

I'm not saying that this fully resolves the original issue, since there is also the suggestion of adding endpoints for some of these related items in addition to making the filtering easier.