### PR TITLE
Fix recently updated maker for featured pages

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -714,11 +714,14 @@ class IncidentPage(MetadataPageMixin, Page):
         """
         Determines whether an incident has been updated within the last week. Returns a boolean.
         """
-        latest_update = self.updates.order_by('-date').first()
-        if latest_update:
-            delta = datetime.datetime.now(datetime.timezone.utc) - latest_update.date
-            return delta.days < 7
-        return False
+        if getattr(self, 'updated_days_ago', None) is not None:
+            return self.updated_days_ago < 7
+        else:
+            latest_update = self.updates.order_by('-date').first()
+            if latest_update:
+                delta = datetime.datetime.now(datetime.timezone.utc) - latest_update.date
+                return delta.days < 7
+            return False
 
     def get_updates_by_asc_date(self):
         """

--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -54,7 +54,7 @@ It can take the following context variables:
 		{% endif %}
 		<div class='incident__date' title="Published: {{ incident.first_published_at|date:'F j, Y' }}">
 			{{ incident.date|date:"F j, Y" }}
-				{% if teaser and incident.updated_days_ago < 7 %}
+				{% if teaser and incident.recently_updated %}
 				<span
 					class="alert alert--green"
 					title="Updated {{ incident.last_updated|date:'F j, Y'}}"

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -333,18 +333,21 @@ class GetRelatedIncidentsTest(TestCase):
         closely_related_old = IncidentPageFactory(
             parent=self.index,
             tags=[tag1, tag2, tag3],
+            state=None,
             categories=[self.category],
             date='2016-01-01',
         )
         closely_related_new = IncidentPageFactory(
             parent=self.index,
             tags=[tag1, tag2, tag3],
+            state=None,
             categories=[self.category],
             date='2020-01-01',
         )
         closely_related_recent = IncidentPageFactory(
             parent=self.index,
             tags=[tag1, tag2, tag3],
+            state=None,
             categories=[self.category],
             date='2019-01-01',
         )


### PR DESCRIPTION
This pull request reworks the incident method `recently_updated` method to check for a cached value if it exists.

Since the `_incident.html` template is used in several places, and we're not sure exactly what the state of the incident model will be going into it, we cannot be sure that `updated_days_ago` will be
populated.  This property is not a model attribute but an annotation that has to be applied at the query level.  In particular, it will _not_ be set if the incident being rendered is a featured page on the home page.

I've solved this problem by using the model method `recently_updated` to either defer to `updated_days_ago` if present, or query the database to find the value if it's not present.  This should correctly deduce if an incident was recently updated in all cases, while preserving efficiency where possible.

One other benefit is we get to remove a "magic number" from the template code.