### PR TITLE
Relationship endpoints

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ omit =
     */migrations/*.py
     */tests/*.py
     tracker/settings/*.py
+    incident/devdata.py
 skip_empty = True
 show_missing = True
 

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -28,7 +28,7 @@ from common.devdata import (
 from forms.models import FormPage
 from home.models import HomePage, HomePageFeature
 from incident.models import IncidentIndexPage, IncidentPage
-from incident.tests.factories import IncidentIndexPageFactory, IncidentLinkFactory, MultimediaIncidentUpdateFactory, MultimediaIncidentPageFactory
+from incident.devdata import IncidentIndexPageFactory, IncidentLinkFactory, MultimediaIncidentUpdateFactory, MultimediaIncidentPageFactory
 from menus.models import Menu, MenuItem
 
 

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -74,6 +74,11 @@ class JournalistSerializer(serializers.Serializer):
     title = serializers.CharField()
 
 
+class InstitutionSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+
+
 class BaseIncidentSerializer(serializers.Serializer):
     title = serializers.CharField()
     url = serializers.SerializerMethodField()

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -69,12 +69,8 @@ class StateSerializer(serializers.Serializer):
     abbreviation = serializers.CharField()
 
 
-class JournalistSerializer(serializers.Serializer):
-    id = serializers.IntegerField()
-    title = serializers.CharField()
-
-
-class InstitutionSerializer(serializers.Serializer):
+class ItemSerializer(serializers.Serializer):
+    """Serializer for incident-related items possessing only primary key and title fields."""
     id = serializers.IntegerField()
     title = serializers.CharField()
 

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -69,6 +69,11 @@ class StateSerializer(serializers.Serializer):
     abbreviation = serializers.CharField()
 
 
+class EquipmentSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
 class ItemSerializer(serializers.Serializer):
     """Serializer for incident-related items possessing only primary key and title fields."""
     id = serializers.IntegerField()

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -53,7 +53,7 @@ class FlatListField(serializers.ListField):
         return ', '.join([str(element) for element in obj])
 
 
-class EquipmentSerializer(serializers.Serializer):
+class EquipmentAmountSerializer(serializers.Serializer):
     quantity = serializers.IntegerField()
     equipment = serializers.StringRelatedField(read_only=True)
 
@@ -162,8 +162,8 @@ class BaseIncidentSerializer(serializers.Serializer):
 
 class IncidentSerializer(BaseIncidentSerializer):
     links = IncidentLinkSerializer(many=True)
-    equipment_seized = EquipmentSerializer(many=True, read_only=True)
-    equipment_broken = EquipmentSerializer(many=True, read_only=True)
+    equipment_seized = EquipmentAmountSerializer(many=True, read_only=True)
+    equipment_broken = EquipmentAmountSerializer(many=True, read_only=True)
     state = StateSerializer()
 
     updates = serializers.StringRelatedField(many=True)

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -69,6 +69,11 @@ class StateSerializer(serializers.Serializer):
     abbreviation = serializers.CharField()
 
 
+class JournalistSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+
+
 class BaseIncidentSerializer(serializers.Serializer):
     title = serializers.CharField()
     url = serializers.SerializerMethodField()

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -80,6 +80,14 @@ class ItemSerializer(serializers.Serializer):
     title = serializers.CharField()
 
 
+class CategorySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    methodology = serializers.CharField()
+    page_color = serializers.CharField()
+    plural_name = serializers.CharField()
+
+
 class BaseIncidentSerializer(serializers.Serializer):
     title = serializers.CharField()
     url = serializers.SerializerMethodField()

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -86,6 +86,39 @@ class InstitutionAPITest(APITestCase):
         })
 
 
+class GovernmentWorkerAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.worker = factories.GovernmentWorkerFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('governmentworker-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('governmentworker-detail', args=(self.worker.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('governmentworker-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.worker.title,
+            'id': self.worker.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -284,6 +284,49 @@ class EquipmentAPITest(APITestCase):
         })
 
 
+class CategoryAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.get(is_default_site=True)
+        root_page = site.root_page
+        cls.incident_index = IncidentIndexPageFactory.build()
+        root_page.add_child(instance=cls.incident_index)
+
+        cls.category = CategoryPageFactory(parent=root_page)
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('category-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('category-detail', args=(self.category.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('category-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'id': self.category.pk,
+            'title': self.category.title,
+            'methodology': self.category.methodology,
+            'plural_name': self.category.plural_name,
+            'page_color': self.category.page_color,
+        })
+        self.assertEqual(response.status_code, 200)
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -53,6 +53,39 @@ class JournalistAPITest(APITestCase):
         })
 
 
+class InstitutionAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.institution = factories.InstitutionFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('institution-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('institution-detail', args=(self.institution.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('institution-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.institution.title,
+            'id': self.institution.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -152,6 +152,39 @@ class ChargeAPITest(APITestCase):
         })
 
 
+class NationalityAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.nationality = factories.NationalityFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('nationality-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('nationality-detail', args=(self.nationality.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('nationality-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.nationality.title,
+            'id': self.nationality.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -16,6 +16,7 @@ from incident.tests.factories import (
     IncidentUpdateFactory,
     IncidentLinkFactory,
     VenueFactory,
+    StateFactory,
 )
 
 
@@ -72,6 +73,8 @@ class IncidentAPITest(APITestCase):
         cls.incident = IncidentPageFactory(
             parent=cls.incident_index,
             authors=[author1, author2],
+            state=StateFactory(),
+            teaser='Teaser',
             categories=[cls.cat1, cls.cat2],
             equipment_search=True,
             equipment_damage=True,
@@ -119,9 +122,9 @@ class IncidentAPITest(APITestCase):
             {
                 'title': inc.title,
                 'url': inc.get_full_url(),
-                'first_published_at': inc.first_published_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
-                'last_published_at': inc.last_published_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
-                'latest_revision_created_at': inc.latest_revision_created_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'first_published_at': inc.first_published_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'last_published_at': inc.last_published_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'latest_revision_created_at': inc.latest_revision_created_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 'authors': [author.author.title for author in inc.authors.all()],
                 'updates': [str(update) for update in inc.updates.all()],
                 'categories': [cat.category.title for cat in inc.categories.all()],

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -218,6 +218,39 @@ class PoliticianAPITest(APITestCase):
         })
 
 
+class VenueAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.venue = factories.VenueFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('venue-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('venue-detail', args=(self.venue.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('venue-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.venue.title,
+            'id': self.venue.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -9,6 +9,7 @@ from common.tests.factories import (
     CustomImageFactory,
     CommonTagFactory,
 )
+from incident.tests import factories
 from incident.tests.factories import (
     IncidentPageFactory,
     IncidentIndexPageFactory,
@@ -16,6 +17,39 @@ from incident.tests.factories import (
     IncidentLinkFactory,
     VenueFactory,
 )
+
+
+class JournalistAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.journalist = factories.JournalistFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('journalist-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('journalist-detail', args=(self.journalist.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('journalist-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.journalist.title,
+            'id': self.journalist.pk,
+        })
 
 
 class IncidentAPITest(APITestCase):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -119,6 +119,39 @@ class GovernmentWorkerAPITest(APITestCase):
         })
 
 
+class ChargeAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.charge = factories.ChargeFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('charge-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('charge-detail', args=(self.charge.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('charge-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.charge.title,
+            'id': self.charge.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -185,6 +185,39 @@ class NationalityAPITest(APITestCase):
         })
 
 
+class PoliticianAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.politician = factories.PoliticianOrPublicFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('politicianorpublic-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('politicianorpublic-detail', args=(self.politician.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('politicianorpublic-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.politician.title,
+            'id': self.politician.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -251,6 +251,39 @@ class VenueAPITest(APITestCase):
         })
 
 
+class EquipmentAPITest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.equipment = factories.EquipmentFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('equipment-list'),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('equipment-detail', args=(self.equipment.pk,)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('equipment-list'),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'name': self.equipment.name,
+            'id': self.equipment.pk,
+        })
+
+
 class IncidentAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -17,6 +17,7 @@ from incident.tests.factories import (
     IncidentUpdateFactory,
     IncidentLinkFactory,
     VenueFactory,
+    StateFactory,
 )
 
 
@@ -84,11 +85,17 @@ class IncidentCSVTestCase(TestCase):
 
         author1, author2, author3 = PersonPageFactory.create_batch(3, parent=root_page)
         cls.cat1, cls.cat2, cls.cat3 = CategoryPageFactory.create_batch(3, parent=root_page)
+        state = StateFactory()
 
         cls.incident = IncidentPageFactory(
             parent=cls.incident_index,
             authors=[author1, author2],
             categories=[cls.cat1, cls.cat2],
+            city='City A',
+            state=state,
+            teaser='Teaser',
+            image_caption='Caption',
+            lawsuit_name='Lawsuit Name',
             equipment_search=True,
             equipment_damage=True,
             arrest=True,
@@ -183,9 +190,9 @@ class IncidentCSVTestCase(TestCase):
             {
                 'title': inc.title,
                 'url': inc.get_full_url(),
-                'first_published_at': inc.first_published_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
-                'last_published_at': inc.last_published_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
-                'latest_revision_created_at': inc.latest_revision_created_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                'first_published_at': inc.first_published_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'last_published_at': inc.last_published_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                'latest_revision_created_at': inc.latest_revision_created_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
                 'authors': ', '.join([author.author.title for author in inc.authors.all()]),
                 'updates': ', '.join([str(update) for update in inc.updates.all()]),
                 'categories': ', '.join([cat.category.title for cat in inc.categories.all()]),

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -6,5 +6,6 @@ from incident.api import views
 router = routers.DefaultRouter()
 router.register(r'incidents', views.IncidentViewSet, basename='incidentpage')
 router.register(r'journalists', views.JournalistViewSet)
+router.register(r'institutions', views.InstitutionViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -8,5 +8,6 @@ router.register(r'incidents', views.IncidentViewSet, basename='incidentpage')
 router.register(r'journalists', views.JournalistViewSet)
 router.register(r'institutions', views.InstitutionViewSet)
 router.register(r'governmentworkers', views.GovernmentWorkerViewSet)
+router.register(r'charges', views.ChargeViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -1,9 +1,10 @@
 from rest_framework import routers
 
-from incident.api.views import IncidentViewSet
+from incident.api import views
 
 
 router = routers.DefaultRouter()
-router.register(r'incidents', IncidentViewSet, basename='incidentpage')
+router.register(r'incidents', views.IncidentViewSet, basename='incidentpage')
+router.register(r'journalists', views.JournalistViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -11,5 +11,6 @@ router.register(r'governmentworkers', views.GovernmentWorkerViewSet)
 router.register(r'charges', views.ChargeViewSet)
 router.register(r'nationalities', views.NationalityViewSet)
 router.register(r'politicians', views.PoliticianOrPublicViewSet)
+router.register(r'venues', views.VenueViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -12,5 +12,6 @@ router.register(r'charges', views.ChargeViewSet)
 router.register(r'nationalities', views.NationalityViewSet)
 router.register(r'politicians', views.PoliticianOrPublicViewSet)
 router.register(r'venues', views.VenueViewSet)
+router.register(r'equipment', views.EquipmentViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -13,5 +13,6 @@ router.register(r'nationalities', views.NationalityViewSet)
 router.register(r'politicians', views.PoliticianOrPublicViewSet)
 router.register(r'venues', views.VenueViewSet)
 router.register(r'equipment', views.EquipmentViewSet)
+router.register(r'categories', views.CategoryViewSet, basename='category')
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -9,5 +9,6 @@ router.register(r'journalists', views.JournalistViewSet)
 router.register(r'institutions', views.InstitutionViewSet)
 router.register(r'governmentworkers', views.GovernmentWorkerViewSet)
 router.register(r'charges', views.ChargeViewSet)
+router.register(r'nationalities', views.NationalityViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -7,5 +7,6 @@ router = routers.DefaultRouter()
 router.register(r'incidents', views.IncidentViewSet, basename='incidentpage')
 router.register(r'journalists', views.JournalistViewSet)
 router.register(r'institutions', views.InstitutionViewSet)
+router.register(r'governmentworkers', views.GovernmentWorkerViewSet)
 
 api_urls = router.urls

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -10,5 +10,6 @@ router.register(r'institutions', views.InstitutionViewSet)
 router.register(r'governmentworkers', views.GovernmentWorkerViewSet)
 router.register(r'charges', views.ChargeViewSet)
 router.register(r'nationalities', views.NationalityViewSet)
+router.register(r'politicians', views.PoliticianOrPublicViewSet)
 
 api_urls = router.urls

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -8,7 +8,12 @@ from rest_framework.response import Response
 from rest_framework.utils.urls import remove_query_param
 from rest_framework_csv.renderers import PaginatedCSVRenderer
 
-from incident.api.serializers import IncidentSerializer, FlatIncidentSerializer
+from incident.api.serializers import (
+    IncidentSerializer,
+    JournalistSerializer,
+    FlatIncidentSerializer,
+)
+from incident import models
 from incident.utils.incident_filter import IncidentFilter
 
 if TYPE_CHECKING:
@@ -95,3 +100,8 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         incidents = incident_filter.get_queryset()
 
         return incidents.with_most_recent_update().with_public_associations()
+
+
+class JournalistViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.Journalist.objects.all()
+    serializer_class = JournalistSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -115,3 +115,8 @@ class InstitutionViewSet(viewsets.ReadOnlyModelViewSet):
 class GovernmentWorkerViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.GovernmentWorker.objects.all()
     serializer_class = ItemSerializer
+
+
+class ChargeViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.Charge.objects.all()
+    serializer_class = ItemSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -8,10 +8,12 @@ from rest_framework.response import Response
 from rest_framework.utils.urls import remove_query_param
 from rest_framework_csv.renderers import PaginatedCSVRenderer
 
+from common.models import CategoryPage
 from incident.api.serializers import (
     IncidentSerializer,
     ItemSerializer,
     EquipmentSerializer,
+    CategorySerializer,
     FlatIncidentSerializer,
 )
 from incident import models
@@ -141,3 +143,8 @@ class VenueViewSet(viewsets.ReadOnlyModelViewSet):
 class EquipmentViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Equipment.objects.all()
     serializer_class = EquipmentSerializer
+
+
+class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = CategoryPage.objects.all()
+    serializer_class = CategorySerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -130,3 +130,8 @@ class NationalityViewSet(viewsets.ReadOnlyModelViewSet):
 class PoliticianOrPublicViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.PoliticianOrPublic.objects.all()
     serializer_class = ItemSerializer
+
+
+class VenueViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.Venue.objects.all()
+    serializer_class = ItemSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -10,8 +10,7 @@ from rest_framework_csv.renderers import PaginatedCSVRenderer
 
 from incident.api.serializers import (
     IncidentSerializer,
-    InstitutionSerializer,
-    JournalistSerializer,
+    ItemSerializer,
     FlatIncidentSerializer,
 )
 from incident import models
@@ -105,9 +104,14 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
 
 class JournalistViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Journalist.objects.all()
-    serializer_class = JournalistSerializer
+    serializer_class = ItemSerializer
 
 
 class InstitutionViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Institution.objects.all()
-    serializer_class = InstitutionSerializer
+    serializer_class = ItemSerializer
+
+
+class GovernmentWorkerViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.GovernmentWorker.objects.all()
+    serializer_class = ItemSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -120,3 +120,8 @@ class GovernmentWorkerViewSet(viewsets.ReadOnlyModelViewSet):
 class ChargeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Charge.objects.all()
     serializer_class = ItemSerializer
+
+
+class NationalityViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.Nationality.objects.all()
+    serializer_class = ItemSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -11,6 +11,7 @@ from rest_framework_csv.renderers import PaginatedCSVRenderer
 from incident.api.serializers import (
     IncidentSerializer,
     ItemSerializer,
+    EquipmentSerializer,
     FlatIncidentSerializer,
 )
 from incident import models
@@ -135,3 +136,8 @@ class PoliticianOrPublicViewSet(viewsets.ReadOnlyModelViewSet):
 class VenueViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Venue.objects.all()
     serializer_class = ItemSerializer
+
+
+class EquipmentViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.Equipment.objects.all()
+    serializer_class = EquipmentSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -10,6 +10,7 @@ from rest_framework_csv.renderers import PaginatedCSVRenderer
 
 from incident.api.serializers import (
     IncidentSerializer,
+    InstitutionSerializer,
     JournalistSerializer,
     FlatIncidentSerializer,
 )
@@ -105,3 +106,8 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
 class JournalistViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Journalist.objects.all()
     serializer_class = JournalistSerializer
+
+
+class InstitutionViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.Institution.objects.all()
+    serializer_class = InstitutionSerializer

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -125,3 +125,8 @@ class ChargeViewSet(viewsets.ReadOnlyModelViewSet):
 class NationalityViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Nationality.objects.all()
     serializer_class = ItemSerializer
+
+
+class PoliticianOrPublicViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = models.PoliticianOrPublic.objects.all()
+    serializer_class = ItemSerializer

--- a/incident/management/commands/createincidents.py
+++ b/incident/management/commands/createincidents.py
@@ -3,10 +3,10 @@ from django.db import transaction
 
 from common.models import CategoryPage
 from incident.models import IncidentIndexPage
-from common.tests.factories import (
+from common.tests.devdata import (
     PersonPageFactory,
 )
-from incident.tests.factories import (
+from incident.devdata import (
     MultimediaIncidentPageFactory, IncidentPageFactory, VenueFactory,
 )
 

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -309,12 +309,42 @@ class GetRelatedIncidentsTest(TestCase):
         tag2 = CommonTagFactory()
         tag3 = CommonTagFactory()
         tag4 = CommonTagFactory()
-        subject = IncidentPageFactory(parent=self.index, tags=[tag1, tag2, tag3], categories=[self.category])
+        state = StateFactory()
+        subject = IncidentPageFactory(
+            parent=self.index,
+            tags=[tag1, tag2, tag3],
+            categories=[self.category],
+            state=state,
+        )
 
-        closely_related = IncidentPageFactory(parent=self.index, tags=[tag1, tag2, tag3], categories=[self.category])
-        somewhat_related = IncidentPageFactory(parent=self.index, tags=[tag1, tag3], categories=[self.category])
-        slightly_related = IncidentPageFactory(parent=self.index, tags=[tag2, tag4], categories=[self.category])
-        IncidentPageFactory(parent=self.index, tags=[tag4], categories=[self.category])
+        closely_related = IncidentPageFactory(
+            title='Closely',
+            state=state,
+            parent=self.index,
+            tags=[tag1, tag2, tag3],
+            categories=[self.category],
+        )
+        somewhat_related = IncidentPageFactory(
+            title='Somewhat',
+            state=state,
+            parent=self.index,
+            tags=[tag1, tag3],
+            categories=[self.category],
+        )
+        slightly_related = IncidentPageFactory(
+            title='Slightly',
+            state=state,
+            parent=self.index,
+            tags=[tag2, tag4],
+            categories=[self.category]
+        )
+        IncidentPageFactory(
+            title='Not related',
+            state=None,
+            parent=self.index,
+            tags=[tag4],
+            categories=[self.category],
+        )
 
         related_incidents = subject.get_related_incidents()
 
@@ -363,8 +393,8 @@ class GetRelatedIncidentsTest(TestCase):
         tag2 = CommonTagFactory()
         tag3 = CommonTagFactory()
         tag4 = CommonTagFactory()
-        state = StateFactory(name='New Mexico')
-        other_state = StateFactory(name='Colorado')
+        state = StateFactory()
+        other_state = StateFactory()
         subject = IncidentPageFactory(
             parent=self.index,
             tags=[tag1, tag2, tag3],
@@ -880,13 +910,13 @@ class IncidentPageTests(TestCase):
 
         Region.objects.create(
             isocode=united_states,
-            regcode='AK',
-            name='Alaska',
+            regcode='AK2',
+            name='Alaska 2',
             geonameid=1,
         )
         state = StateFactory(
-            name='Alaska',
-            abbreviation='AK',
+            name='Alaska 2',
+            abbreviation='AK2',
         )
 
         geoname = GeoName.objects.create(
@@ -895,7 +925,7 @@ class IncidentPageTests(TestCase):
             latitude=1.0,
             longitude=2.0,
             isocode=united_states,
-            regcode='AK',
+            regcode='AK2',
         )
         incident = IncidentPage(
             date=date.today(),


### PR DESCRIPTION
Fixes #1061

This PR adds read-only endpoints for the following incident-related items:

| Related Entity | Example URL | 
| ------------------ | --------------------|
| Journalists | http://localhost:8000/api/edge/journalists/ |
| Institutions | http://localhost:8000/api/edge/institutions/3/ |
| Government Workers | http://localhost:8000/api/edge/governmentworkers/ |
| Charges | http://localhost:8000/api/edge/governmentworkers/ |
| Nationalities | http://localhost:8000/api/edge/nationalities/ |
| Politicians or Public Figures | http://localhost:8000/api/edge/politicians/1/ |
| Venues | http://localhost:8000/api/edge/venues/ |
| Equipment | http://localhost:8000/api/edge/equipment/6/ |

There are two "views" for each item: a list view and a detail view. The list view is the "base" view (e.g. `/venues/`) and the detail view is the view for a single item that can be reached by appending the ID of the entry (e.g. `/venues/33/`).

Right now the views are not paginated, meaning the list view lists all the entities. It's a lot less data-per-item than Incidents, but it potentially is a lot of values. If we do want to add pagination, it would not be very hard to do, though I am not sure we would want to apply cursor-based pagination to the title/name fields, since the title/name field feels like it is not as unchanging as we might want, though possibly I am overworrying about that. It might actually be fine.

Addendum: I also did some work to try to reduce some of the randomness in the test suite by moving the random/realistic incident-related factories into a file called `devdata.py`. I did something similar for the factories in the `common` app a little while ago (see 17164b02e398863ffa8d0134bc23f337008eb5d7). I hope that this will continue to reduce the annoying test failures on CI and locally due to non-deterministic tests. One thing to note is that I put `devdata.py` into the coverage omit list because (1) the factories were formerly in the `/tests/` directory which is also omitted from coverage analysis, and (2) this file is not really part of our application code, it's more of a library to help build realistic test data and it would definitely require a bit more work to ensure every code pathway is covered, which is not really the goal of our test suite anyway (it's to ensure our application works properly).