### PR TITLE
Removes livepreview

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -63,8 +63,6 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
 
     subpage_types = ['blog.BlogPage']
 
-    LIVEPREVIEW_DISABLED = True
-
     @route(r'^feed/$')
     def feed(self, request):
         return BlogIndexPageFeed(self)(request)

--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -124,8 +124,6 @@ class OrganizationIndexPage(Page):
 
     subpage_types = ['common.OrganizationPage']
 
-    LIVEPREVIEW_DISABLED = True
-
     def serve(self, request):
         raise Http404()
 
@@ -308,8 +306,6 @@ class CategoryPage(MetadataPageMixin, Page):
         FieldPanel('plural_name'),
         FieldPanel('page_color'),
     ]
-
-    LIVEPREVIEW_DISABLED = True
 
     def clean(self):
         self.methodology = unescape(self.methodology)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -754,9 +754,6 @@ wagtail-inventory==1.2 \
     --hash=sha256:2728ca57bd68baae0da50dafa923586c489cef65cfc5ac5a25cc147eedf7ce92 \
     --hash=sha256:815ba1bb96216f12bb411bd387d2a6cf991fee204af9e3dfcd40ad77202f58dc
     # via -r requirements.txt
-wagtail-livepreview==0.1 \
-    --hash=sha256:fc19d1337933185575e4fb1bd6b0c785fb423d73347745048cdb2887765bdfbf
-    # via -r requirements.txt
 wagtail-metadata==3.4.0 \
     --hash=sha256:4d94e3de715d5cb07cb05005f949428b8c68d33a5cd324b8eca10565ed5d0046 \
     --hash=sha256:a17b1b545446f092ec4074a1c5734931a1af0c68a9a56be1732158753df36746

--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -56,8 +56,6 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
 
     subpage_types = ['incident.IncidentPage']
 
-    LIVEPREVIEW_DISABLED = True
-
     @route('export/')
     @method_decorator(require_http_methods(['HEAD', 'GET', 'OPTIONS']))
     def export_view(self, request: 'HttpRequest') -> HttpResponse:

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,6 @@ wagtail>=2.11.8,<2.12
 wagtail-autocomplete>=0.6
 wagtail-factories>=2.0.1
 wagtail-django-recaptcha
-wagtail-livepreview
 wagtail-metadata>=3.4.0
 unittest-xml-reporting
 wagtail-inventory>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -501,9 +501,6 @@ wagtail-inventory==1.2 \
     --hash=sha256:2728ca57bd68baae0da50dafa923586c489cef65cfc5ac5a25cc147eedf7ce92 \
     --hash=sha256:815ba1bb96216f12bb411bd387d2a6cf991fee204af9e3dfcd40ad77202f58dc
     # via -r requirements.in
-wagtail-livepreview==0.1 \
-    --hash=sha256:fc19d1337933185575e4fb1bd6b0c785fb423d73347745048cdb2887765bdfbf
-    # via -r requirements.in
 wagtail-metadata==3.4.0 \
     --hash=sha256:4d94e3de715d5cb07cb05005f949428b8c68d33a5cd324b8eca10565ed5d0046 \
     --hash=sha256:a17b1b545446f092ec4074a1c5734931a1af0c68a9a56be1732158753df36746

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -225,20 +225,11 @@ WEBPACK_LOADER = {  # noqa: W605
     }
 }
 
-# Makes Livepreview optional
-LIVEPREVIEW_ENABLED = os.environ.get('LIVEPREVIEW_ENABLED', False)
-if LIVEPREVIEW_ENABLED:
-    # The livepreview needs to be added in the INSTALLED_APPS above the
-    # 'wagtail.admin' app
-    INSTALLED_APPS.insert(INSTALLED_APPS.index('wagtail.admin'), 'livepreview')
-    LIVEPREVIEW_USE_FILE_RENDERING = False
-
 # Disable analytics by default
 ANALYTICS_ENABLED = False
 
 # Export analytics settings for use in site templates
 SETTINGS_EXPORT = [
-    'LIVEPREVIEW_ENABLED',
     'ANALYTICS_ENABLED',
 ]
 # Prevent template variable name collision with wagtail settings

--- a/tracker/templates/livepreview_js.html
+++ b/tracker/templates/livepreview_js.html
@@ -1,3 +1,0 @@
-{% load livepreview_tags %}
-
-{% livepreview_js %}

--- a/tracker/templates/super.html
+++ b/tracker/templates/super.html
@@ -52,8 +52,5 @@
 	<body class="{% block body_class %}{% endblock %}">
 		{% block body %}
 		{% endblock %}
-		{% if django_settings.LIVEPREVIEW_ENABLED %}
-			{% include "livepreview_js.html" %}
-		{% endif %}
 	</body>
 </html>


### PR DESCRIPTION
This PR removes the wagtail livepreview from all places in tracker. Additionally, on infra side, might want to remove `LIVEPREVIEW_ENABLED` environment variable.

Closes https://github.com/freedomofpress/infrastructure/issues/3581