### PR TITLE
Updates code to make it compatible with newer version of wagtail-autocomplete

### DIFF
--- a/common/forms.py
+++ b/common/forms.py
@@ -21,7 +21,7 @@ class BaseMergeForm(forms.Form):
             widget=type(
                 '_Autocomplete',
                 (Autocomplete,),
-                dict(target_model=self.merge_model, can_create=False, is_single=False)
+                dict(target_model=self.merge_model)
             ),
             label='{} to merge'.format(capfirst(self.merge_model_name))
         )

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -740,8 +740,9 @@ wagtail==2.11.8 \
     #   wagtail-factories
     #   wagtail-inventory
     #   wagtail-metadata
-wagtail-autocomplete==0.6 \
-    --hash=sha256:5f8ddf16d3ca365af4ad0f09e8f45d9e982ca854dc1b084a8a30f66b00a7739d
+wagtail-autocomplete==0.7.0 \
+    --hash=sha256:69d4b72407532781014c9766a57977eb56f16bb1ad97a0e9133d2c67383e4596 \
+    --hash=sha256:f8f8b2e2e4d0229946a20fa439af17f252e3865a6cb9b27903c284a0c065edd8
     # via -r requirements.txt
 wagtail-django-recaptcha==1.0 \
     --hash=sha256:fc177e75da966e9db1dfd9a566c40d30567518d9280b5db4fec4d50a8c853154

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -500,10 +500,10 @@ class IncidentPage(MetadataPageMixin, Page):
                 FieldPanel('date'),
                 FieldPanel('exact_date_unknown'),
                 FieldPanel('city'),
-                AutocompletePanel('state', page_type='incident.State'),
+                AutocompletePanel('state', target_model='incident.State'),
                 InlinePanel('targeted_journalists', label='Targeted Journalists'),
-                AutocompletePanel('targeted_institutions', 'incident.Institution', is_single=False),
-                AutocompletePanel('tags', 'common.CommonTag', is_single=False),
+                AutocompletePanel('targeted_institutions', 'incident.Institution'),
+                AutocompletePanel('tags', 'common.CommonTag'),
                 InlinePanel('categories', label='Incident categories', min_num=1),
             ]
         ),
@@ -528,9 +528,9 @@ class IncidentPage(MetadataPageMixin, Page):
             children=[
                 FieldPanel('arrest_status'),
                 FieldPanel('status_of_charges'),
-                AutocompletePanel('arresting_authority', page_type='incident.LawEnforcementOrganization'),
-                AutocompletePanel('current_charges', 'incident.Charge', is_single=False),
-                AutocompletePanel('dropped_charges', 'incident.Charge', is_single=False),
+                AutocompletePanel('arresting_authority', target_model='incident.LawEnforcementOrganization'),
+                AutocompletePanel('current_charges', 'incident.Charge'),
+                AutocompletePanel('dropped_charges', 'incident.Charge'),
                 FieldPanel('detention_date'),
                 FieldPanel('release_date'),
                 FieldPanel('unnecessary_use_of_force'),
@@ -542,7 +542,7 @@ class IncidentPage(MetadataPageMixin, Page):
             classname='collapsible collapsed',
             children=[
                 FieldPanel('lawsuit_name'),
-                AutocompletePanel('venue', 'incident.Venue', is_single=False),
+                AutocompletePanel('venue', 'incident.Venue'),
             ]
         ),
 
@@ -577,7 +577,7 @@ class IncidentPage(MetadataPageMixin, Page):
                 FieldPanel('target_us_citizenship_status'),
                 FieldPanel('denial_of_entry'),
                 FieldPanel('stopped_previously'),
-                AutocompletePanel('target_nationality', 'incident.Nationality', is_single=False),
+                AutocompletePanel('target_nationality', 'incident.Nationality'),
                 FieldPanel('did_authorities_ask_for_device_access'),
                 FieldPanel('did_authorities_ask_for_social_media_user'),
                 FieldPanel('did_authorities_ask_for_social_media_pass'),
@@ -599,7 +599,7 @@ class IncidentPage(MetadataPageMixin, Page):
             heading='Leak Prosecution (incl. Legal Case, Arrest/Detention',
             classname='collapsible collapsed',
             children=[
-                AutocompletePanel('workers_whose_communications_were_obtained', 'incident.GovernmentWorker', is_single=False),
+                AutocompletePanel('workers_whose_communications_were_obtained', 'incident.GovernmentWorker'),
                 FieldPanel('charged_under_espionage_act'),
             ]
         ),
@@ -637,11 +637,11 @@ class IncidentPage(MetadataPageMixin, Page):
             heading='Denial of Access',
             classname='collapsible collapsed',
             children=[
-                AutocompletePanel('politicians_or_public_figures_involved', 'incident.PoliticianOrPublic', is_single=False),
+                AutocompletePanel('politicians_or_public_figures_involved', 'incident.PoliticianOrPublic'),
             ]
         ),
 
-        AutocompletePanel('related_incidents', 'incident.IncidentPage', is_single=False),
+        AutocompletePanel('related_incidents', 'incident.IncidentPage'),
     ]
     settings_panels = Page.settings_panels + [
         FieldPanel('suppress_footer')

--- a/incident/models/inlines.py
+++ b/incident/models/inlines.py
@@ -86,7 +86,7 @@ class EquipmentSeized(models.Model):
     _autocomplete_model = 'incident.Equipment'
 
     panels = [
-        AutocompletePanel('equipment', page_type='incident.Equipment'),
+        AutocompletePanel('equipment', target_model='incident.Equipment'),
         FieldPanel('quantity'),
     ]
 
@@ -111,7 +111,7 @@ class EquipmentBroken(models.Model):
     _autocomplete_model = 'incident.Equipment'
 
     panels = [
-        AutocompletePanel('equipment', page_type='incident.Equipment'),
+        AutocompletePanel('equipment', target_model='incident.Equipment'),
         FieldPanel('quantity'),
     ]
 

--- a/incident/models/topic_page.py
+++ b/incident/models/topic_page.py
@@ -234,7 +234,7 @@ class TopicPage(RoutablePageMixin, MetadataPageMixin, Page):
             heading='Incidents',
             children=[
                 PageChooserPanel('incident_index_page'),
-                AutocompletePanel('incident_tag', page_type='common.CommonTag'),
+                AutocompletePanel('incident_tag', target_model='common.CommonTag'),
                 FieldPanel('incidents_per_module'),
                 FieldPanel('start_date'),
                 FieldPanel('end_date'),

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ structlog>=21,<22
 typing
 typogrify
 wagtail>=2.11.8,<2.12
-wagtail-autocomplete>=0.6
+wagtail-autocomplete>=0.7
 wagtail-factories>=2.0.1
 wagtail-django-recaptcha
 wagtail-metadata>=3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -487,8 +487,9 @@ wagtail==2.11.8 \
     #   wagtail-factories
     #   wagtail-inventory
     #   wagtail-metadata
-wagtail-autocomplete==0.6 \
-    --hash=sha256:5f8ddf16d3ca365af4ad0f09e8f45d9e982ca854dc1b084a8a30f66b00a7739d
+wagtail-autocomplete==0.7.0 \
+    --hash=sha256:69d4b72407532781014c9766a57977eb56f16bb1ad97a0e9133d2c67383e4596 \
+    --hash=sha256:f8f8b2e2e4d0229946a20fa439af17f252e3865a6cb9b27903c284a0c065edd8
     # via -r requirements.in
 wagtail-django-recaptcha==1.0 \
     --hash=sha256:fc177e75da966e9db1dfd9a566c40d30567518d9280b5db4fec4d50a8c853154


### PR DESCRIPTION
Blocked on a newer release of wagtail-autocomplete including https://github.com/wagtail/wagtail-autocomplete/pull/101 . That will fix https://github.com/freedomofpress/pressfreedomtracker.us/issues/1138

In this PR, updated the code to remove and change the parts deprecated by edit handlers and in turn by wagtail-autocomplete in newer versions.