### PR TITLE
API documentation and Swagger (initial pass)

### DIFF
--- a/api_docs/Incidents.md
+++ b/api_docs/Incidents.md
@@ -1,0 +1,271 @@
+# Incidents
+
+Incidents are occurrences of violations of the freedom of the press committed by government authorities or private individuals.  The API contains information about when the incident took place, who was involved, and what kind of violation happened.
+
+## Endpoints
+
+```
+GET incidents/
+```
+
+Gets a list of all incidents.
+
+## Parameters
+
+Parameters can be applied to the API request as part of the URL's query string.  All parameters are optional.
+
+### Query parameters
+
+These parameters can be used to customize the query and response that the API returns.
+
+
+
+| Query string parameter | Type    | Description                                                                                                                                                                           |
+|------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `limit`                | integer | The maximum number of results to return per page. If this parameter is not provided, then the set of results will not be paginated.                                                   |
+| `fields`               | string  | A comma-separated list of field names. The incidents returned in the response will include only the ones given in this parameter. The set of available field names is detailed below. |
+| `format`               | string  | Describes the format of the data in the response. Can be either `json` (the default) or `csv`.                                                                                        |
+
+
+### Filtering parameters
+
+These parameters can be used to filter which incidents are returned in the response.  Only incidents that match the values given will be included in the response.
+
+TODO: fill in this section.
+
+## Sample request
+
+```
+curl -X GET "https://pressfreedomtracker.us/api/edge/incidents/?limit=2&format=json"
+```
+
+## Sample response
+
+Here is a sample response:
+
+```
+{
+  "next": "http://localhost:8000/api/edge/incidents/?cursor=cD0yMDIxLTAyLTIwLTQ3Mzk%3D&format=json&limit=2",
+  "previous": null,
+  "results": [
+    {
+      "title": "Break this exactly I.",
+      "url": "http://localhost:8000/all-incidents/break-this-exactly-i/",
+      "first_published_at": "2021-04-17T04:45:30Z",
+      "last_published_at": "2021-04-20T04:45:30Z",
+      "latest_revision_created_at": "2021-04-22T04:45:30Z",
+      "date": "2021-03-21",
+      "exact_date_unknown": false,
+      "city": "Carterstad",
+      "body": "<div class=\"rich-text\"><p>Lorem ipsum dolor sit amet.</p></div>",
+      "teaser": "<div class=\"rich-text\">Mind although win turn.</div>",
+      "teaser_image": null,
+      "primary_video": null,
+      "image_caption": "<div class=\"rich-text\">Wait culture case western any size citizen.</div>",
+      "arresting_authority": null,
+      "arrest_status": null,
+      "status_of_charges": null,
+      "release_date": null,
+      "detention_date": null,
+      "unnecessary_use_of_force": false,
+      "lawsuit_name": "Christopher Simpson v. Lisa Armstrong",
+      "status_of_seized_equipment": null,
+      "is_search_warrant_obtained": false,
+      "actor": null,
+      "border_point": null,
+      "stopped_at_border": false,
+      "target_us_citizenship_status": null,
+      "denial_of_entry": false,
+      "stopped_previously": false,
+      "did_authorities_ask_for_device_access": null,
+      "did_authorities_ask_for_social_media_user": null,
+      "did_authorities_ask_for_social_media_pass": null,
+      "did_authorities_ask_about_work": null,
+      "were_devices_searched_or_seized": null,
+      "assailant": null,
+      "was_journalist_targeted": null,
+      "charged_under_espionage_act": false,
+      "subpoena_type": null,
+      "held_in_contempt": null,
+      "detention_status": null,
+      "third_party_in_possession_of_communications": null,
+      "third_party_business": null,
+      "legal_order_type": null,
+      "status_of_prior_restraint": null,
+      "links": [],
+      "equipment_seized": [],
+      "equipment_broken": [],
+      "state": {
+        "name": "Texas",
+        "abbreviation": "TX"
+      },
+      "updates": [],
+      "venue": [
+        "DarkRed Court of South Dakota",
+        "LightSalmon Court of Louisiana"
+      ],
+      "workers_whose_communications_were_obtained": [
+        "John A. Worker",
+        "Tyler H. Worker"
+      ],
+      "target_nationality": [],
+      "targeted_institutions": [
+        "The Dennisville Tribune 4",
+        "The Stevenburgh Tribune 5"
+      ],
+      "tags": [],
+      "current_charges": [],
+      "dropped_charges": [],
+      "politicians_or_public_figures_involved": [],
+      "authors": [
+        "Diana Gomez",
+        "Chase Mejia"
+      ],
+      "categories": [
+        "Leak Case"
+      ],
+      "targeted_journalists": [
+        "Ronald Castro (The North Andreastad Daily News 7)",
+        "Megan Wright (The Adamsmouth Sun 6)"
+      ],
+      "subpoena_statuses": null
+    },
+    {
+      "title": "Heavy everything every which activity husband head.",
+      "url": "http://localhost:8000/all-incidents/heavy-everything-every-which-activity-husband-head/",
+      "first_published_at": "2021-03-08T19:55:23Z",
+      "last_published_at": null,
+      "latest_revision_created_at": null,
+      "date": "2021-02-20",
+      "exact_date_unknown": false,
+      "city": "Bairdview",
+      "body": "<div class=\"rich-text\"><p>Lorem ipsum dolor sit amet.</p></div>",
+      "teaser": "<div class=\"rich-text\">Memory himself never pass thing relate store.</div>",
+      "teaser_image": null,
+      "primary_video": null,
+      "image_caption": "<div class=\"rich-text\">Over network rate act however seek.</div>",
+      "arresting_authority": null,
+      "arrest_status": null,
+      "status_of_charges": null,
+      "release_date": null,
+      "detention_date": null,
+      "unnecessary_use_of_force": false,
+      "lawsuit_name": null,
+      "status_of_seized_equipment": null,
+      "is_search_warrant_obtained": false,
+      "actor": null,
+      "border_point": null,
+      "stopped_at_border": false,
+      "target_us_citizenship_status": null,
+      "denial_of_entry": false,
+      "stopped_previously": false,
+      "did_authorities_ask_for_device_access": null,
+      "did_authorities_ask_for_social_media_user": null,
+      "did_authorities_ask_for_social_media_pass": null,
+      "did_authorities_ask_about_work": null,
+      "were_devices_searched_or_seized": null,
+      "assailant": null,
+      "was_journalist_targeted": null,
+      "charged_under_espionage_act": false,
+      "subpoena_type": null,
+      "held_in_contempt": null,
+      "detention_status": null,
+      "third_party_in_possession_of_communications": null,
+      "third_party_business": null,
+      "legal_order_type": null,
+      "status_of_prior_restraint": null,
+      "links": [],
+      "equipment_seized": [],
+      "equipment_broken": [],
+      "state": null,
+      "updates": [],
+      "venue": [],
+      "workers_whose_communications_were_obtained": [],
+      "target_nationality": [],
+      "targeted_institutions": [
+        "The Dianestad Post 1581",
+        "The West Jonathon Tribune 1582"
+      ],
+      "tags": [],
+      "current_charges": [],
+      "dropped_charges": [],
+      "politicians_or_public_figures_involved": [],
+      "authors": [],
+      "categories": [
+        "Subpoena / Legal Order"
+      ],
+      "targeted_journalists": [
+        "Leah Barnett (The Lake Chrisfurt Sun 1583)"
+      ],
+      "subpoena_statuses": null
+    }
+  ]
+}
+```
+
+### Field descriptions
+
+This table describes all the fields on the incident objects in the `results` object array.
+
+| Field                                         | Description                                                                                                                                                                             | Data Type        |
+|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| `title`                                       | Title of the incident                                                                                                                                                                   | string           |
+| `url`                                         | URL linking to the article about this incident on the Press Freedom Tracker website                                                                                                     | string           |
+| `first_published_at`                          | When the article about this incident was first published.                                                                                                                               | datetime         |
+| `last_published_at`                           | When the article about this incident was most recently published.                                                                                                                       | datetime         |
+| `latest_revision_created_at`                  | When the article about this incident was most recently updated.                                                                                                                         | datetime         |
+| `date`                                        | When the incident happened.                                                                                                                                                             | date             |
+| `exact_date_unknown`                          | This field will be set to `true` if the exact date of the incident is not known, meaning the `date` field is not a precise value.                                                       | boolean          |
+| `city`                                        | The city the incident happened in.                                                                                                                                                      | string           |
+| state                                         | The state the incident happened in.                                                                                                                                                     | object           |
+| `body`                                        | The HTML content of the article about this incident on the Press Freedom Tracker website                                                                                                | string           |
+| `teaser`                                      | A short description of the content of the article about this incident on the Press Freedom Tracker website                                                                              | string           |
+| `teaser_image`                                | The URL of an image related to this incident.                                                                                                                                           | string           |
+| `primary_video`                               | The URL of a video related to this incident.                                                                                                                                            | string           |
+| `image_caption`                               | The caption of image from the `teaser_image` field.                                                                                                                                     | string           |
+| `arresting_authority`                         | The name of the law-enforcement organization involve in an arrest incident.                                                                                                             | string           |
+| `arrest_status`                               | The status of the arrest in an arrest incident. Can be one of: `UNKNOWN`, `DETAINED_NO_PROCESSING`, `DETAINED_CUSTODY`, `ARRESTED_CUSTODY`, or `ARRESTED_RELEASED`.                     | string           |
+| `status_of_charges`                           | The status of the charges in the incident. Can be one of: `UNKNOWN`, `NOT_CHARGED`, `CHARGES_PENDING`, `CHARGES_DROPPED`, `CONVICTED`, `ACQUITTED`, or `PENDING_APPEAL`.                | string           |
+| `release_date`                                | The date of release for an arrest incident.                                                                                                                                             | date             |
+| `detention_date`                              | The date of detention for an arrest incident.                                                                                                                                           | date             |
+| `unnecessary_use_of_force`                    | If unnecessary force was used in the incident.                                                                                                                                          | boolean          |
+| `lawsuit_name`                                | The name of the lawsuit pertaining to the incident.                                                                                                                                     | string           |
+| `status_of_seized_equipment`                  | The status of any equipment seized during the incident. Can be one of: `UNKNOWN`, `CUSTODY`, `RETURNED_FULL`, or `RETURNED_PART`.                                                       | string           |
+| `is_search_warrant_obtained`                  | Whether or not a search warrant was obtained for this incident.                                                                                                                         | boolean          |
+| `actor`                                       | A description of the principal actor involved in the incident. Can be one of: `UNKNOWN`, `LAW_ENFORCEMENT`, `PRIVATE_SECURITY`, `POLITICIAN`, `PUBLIC_FIGURE`, or `PRIVATE_INDIVIDUAL`. | string           |
+| `border_point`                                | What border-crossing point a border-stop incident occurred at.                                                                                                                          | string           |
+| `stopped_at_border`                           | If the incident involved a stop at the border.                                                                                                                                          | boolean          |
+| `target_us_citizenship_status`                | The citizenship status of the target of the incident. Can be one of: `US_CITIZEN`, `PERMANENT_RESIDENT`, or `NON_RESIDENT`                                                              | string           |
+| `denial_of_entry`                             | If the incident involved denying entry to the country.                                                                                                                                  | boolean          |
+| `stopped_previously`                          | If the incident targeted someone who had been previously stopped at the border.                                                                                                         | boolean          |
+| `did_authorities_ask_for_device_access`       | If authorities asked for access to the target's electronic devices during the incident. Can be one of: `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                            | string           |
+| `did_authorities_ask_for_social_media_user`   | If authorities asked for the target's social media username during the incident. Can be one of: `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                                   | string           |
+| `did_authorities_ask_for_social_media_pass`   | If authorities asked for the target's social media password during the incident. Can be one of: `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                                   | string           |
+| `did_authorities_ask_about_work`              | If authorities asked about the target's work during the incident. Can be one of: `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                                                  | string           |
+| `were_devices_searched_or_seized`             | If devices were searched or seized during the incident. Can be one of: `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                                                            | string           |
+| `assailant`                                   | The type of assailant in an assault incident. Can be one of: `UNKNOWN`, `LAW_ENFORCEMENT`, `PRIVATE_SECURITY`, `POLITICIAN`, `PUBLIC_FIGURE`, or `PRIVATE_INDIVIDUAL`.                  | string           |
+| `was_journalist_targeted`                     | If a journalist was specifically targeted in the incident. Can be one of `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                                                          | string           |
+| `charged_under_espionage_act`                 | If someone was charged under the espionage act as part of the incident.                                                                                                                 | boolean          |
+| `subpoena_type`                               | The type of subpoena used in a legal case incident. Can be one of `TESTIMONY_ABOUT_SOURCE`, `OTHER_TESTIMONY`, `JOURNALIST_COMMUNICATIONS`                                              | string           |
+| `held_in_contempt`                            | If the target was held in contempt of court during the incident. Can be one of `NOTHING`, `JUST_TRUE`, `JUST_FALSE`.                                                                    | string           |
+| `detention_status`                            | The status of the detainee. Can be one of `HELD_IN_CONTEMPT_NO_JAIL`, `IN_JAIL`, or `RELEASED`.                                                                                         | string           |
+| `third_party_in_possession_of_communications` | A description of what third-party possess communications in an incident involving a legal order for a journalist's records.                                                             | string           |
+| `third_party_business`                        | What type of business the above third-party is engaged in. Can be one of: `TELECOM`, `TECH_COMPANY`, `ISP`, `FINANCIAL`, `TRAVEL` or `OTHER`.                                           | string           |
+| `legal_order_type`                            | What type of legal order was involved in the incident. Can be one of: `SUBPOENA`, `2703`, `WARRANT`, `NATIONAL_SECURITY_LETTER`, `FISA` or `OTHER`.                                     | string           |
+| `status_of_prior_restraint`                   | Status of prior restraint related to the incident. Can be one of `PENDING`, `DROPPED`, `STRUCK_DOWN`, `UPHELD`, or `IGNORED`.                                                           | string           |
+| `links`                                       | A collection of links pertaining to the incident.                                                                                                                                       | array of objects |
+| `equipment_seized`                            | What equipment, and how much, was seized during the incident.                                                                                                                           | array of objects |
+| `equipment_broken`                            | What equipment, and how much, was broken during the incident.                                                                                                                           | array of objects |
+| `updates`                                     | Updates to the article on the Press Freedom Tracker after it was initially published.                                                                                                   | array of strings |
+| `venue`                                       | Courts that are hearing or have heard the case related to the incident.                                                                                                                 | array of strings |
+| `workers_whose_communications_were_obtained`  | Targets whose communications were obtained in leak investigation incidents.                                                                                                             | array of strings |
+| `target_nationality`                          | Nationalities of targets of the incident.                                                                                                                                               | array of strings |
+| `target_institutions`                         | Institutions targeted during the incident.                                                                                                                                              | array of strings |
+| `tags`                                        | Tags used to classify the incident.                                                                                                                                                     | array of strings |
+| `current_charges`                             | Charges made in legal cases related to the incident.                                                                                                                                    | array of strings |
+| `dropped_charges`                             | Charges made that were later dropped as part of the incident.                                                                                                                           | array of strings |
+| `politicians_or_public_figures_involved`      | Politicians or public figures involved in the incident.                                                                                                                                 | array of strings |
+| `authors`                                     | Authors of the article about the incident on the Press Freedom Tracker website.                                                                                                         | array of strings |
+| `categories`                                  | Categories that the incident is filed-under on the Press Freedom Tracker website.                                                                                                       | array of strings |
+| `targeted_journalists`                        | Journalists (and what institution they belonged to, if any) targeted during the incident.                                                                                               | array of strings |
+| `subpoena_statuses`                           | Statuses of any subpoenas involved in the incident. For each subpoena, the status can be one of: `UNKNOWN`, `PENDING`, `DROPPED`, `QUASHED`, `UPHELD`, `CARRIED_OUT`, or `IGNORED`.     | array of strings |

--- a/api_docs/Incidents.md
+++ b/api_docs/Incidents.md
@@ -22,7 +22,7 @@ These parameters can be used to customize the query and response that the API re
 
 | Query string parameter | Type    | Description                                                                                                                                                                           |
 |------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `limit`                | integer | The maximum number of results to return per page. If this parameter is not provided, then the set of results will not be paginated.                                                   |
+| `limit`                | integer | The maximum number of results to return per page. If this parameter is not provided, it will default to 25.                                                                           |
 | `fields`               | string  | A comma-separated list of field names. The incidents returned in the response will include only the ones given in this parameter. The set of available field names is detailed below. |
 | `format`               | string  | Describes the format of the data in the response. Can be either `json` (the default) or `csv`.                                                                                        |
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -24,6 +24,8 @@ attrs==21.4.0 \
     --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
+    #   -r requirements.txt
+    #   jsonschema
     #   outcome
     #   trio
 autopep8==1.6.0 \
@@ -213,6 +215,7 @@ django==3.2.13 \
     #   django-taggit
     #   django-treebeard
     #   djangorestframework
+    #   drf-spectacular
     #   wagtail
 django-anymail==8.5 \
     --hash=sha256:2325932f56f914d96e0a54db850f2b246ed2277b753f75319620d051a51551e2 \
@@ -284,6 +287,7 @@ djangorestframework==3.13.1 \
     # via
     #   -r requirements.txt
     #   djangorestframework-csv
+    #   drf-spectacular
     #   wagtail
 djangorestframework-csv==2.1.1 \
     --hash=sha256:aa0ee4c894fe319c68e042b05c61dace43a9fb6e6872e1abe1724ca7ea4d15f7
@@ -298,6 +302,10 @@ draftjs-exporter==2.1.7 \
     # via
     #   -r requirements.txt
     #   wagtail
+drf-spectacular==0.22.1 \
+    --hash=sha256:17ac5e31e5d6150dd5fa10843b429202f4f38069202acc44394cc5a771de63d9 \
+    --hash=sha256:866e16ddaae167a1234c76cd8c351161373551db994ce9665b347b32d5daf38b
+    # via -r requirements.txt
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
@@ -435,6 +443,12 @@ idna==3.3 \
     #   requests
     #   trio
     #   urllib3
+inflection==0.5.1 \
+    --hash=sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417 \
+    --hash=sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2
+    # via
+    #   -r requirements.txt
+    #   drf-spectacular
 ipdb==0.13.9 \
     --hash=sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5
     # via -r dev-requirements.in
@@ -452,6 +466,12 @@ jinja2==3.1.1 \
     # via
     #   -r requirements.txt
     #   django-silk
+jsonschema==4.4.0 \
+    --hash=sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83 \
+    --hash=sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823
+    # via
+    #   -r requirements.txt
+    #   drf-spectacular
 l18n==2021.3 \
     --hash=sha256:1956e890d673d17135cc20913253c154f6bc1c00266c22b7d503cc1a5a42d848 \
     --hash=sha256:78495d1df95b6f7dcc694d1ba8994df709c463a1cbac1bf016e1b9a5ce7280b9
@@ -751,6 +771,31 @@ pyparsing==3.0.7 \
     # via
     #   -r requirements.txt
     #   packaging
+pyrsistent==0.18.1 \
+    --hash=sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c \
+    --hash=sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc \
+    --hash=sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e \
+    --hash=sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26 \
+    --hash=sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec \
+    --hash=sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286 \
+    --hash=sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045 \
+    --hash=sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec \
+    --hash=sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8 \
+    --hash=sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c \
+    --hash=sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca \
+    --hash=sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22 \
+    --hash=sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a \
+    --hash=sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96 \
+    --hash=sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc \
+    --hash=sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1 \
+    --hash=sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07 \
+    --hash=sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6 \
+    --hash=sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b \
+    --hash=sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5 \
+    --hash=sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pysocks==1.7.1 \
     --hash=sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299 \
     --hash=sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5 \
@@ -777,6 +822,43 @@ pytz==2022.1 \
     #   django-silk
     #   djangorestframework
     #   l18n
+pyyaml==6.0 \
+    --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \
+    --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b \
+    --hash=sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57 \
+    --hash=sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b \
+    --hash=sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4 \
+    --hash=sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07 \
+    --hash=sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba \
+    --hash=sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9 \
+    --hash=sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287 \
+    --hash=sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513 \
+    --hash=sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0 \
+    --hash=sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0 \
+    --hash=sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92 \
+    --hash=sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f \
+    --hash=sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2 \
+    --hash=sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc \
+    --hash=sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c \
+    --hash=sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86 \
+    --hash=sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4 \
+    --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c \
+    --hash=sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34 \
+    --hash=sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b \
+    --hash=sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c \
+    --hash=sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb \
+    --hash=sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737 \
+    --hash=sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3 \
+    --hash=sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d \
+    --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53 \
+    --hash=sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78 \
+    --hash=sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803 \
+    --hash=sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a \
+    --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
+    --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
+    # via
+    #   -r requirements.txt
+    #   drf-spectacular
 requests==2.27.1 \
     --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
     --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
@@ -899,6 +981,12 @@ unittest-xml-reporting==3.2.0 \
     --hash=sha256:edd8d3170b40c3a81b8cf910f46c6a304ae2847ec01036d02e9c0f9b85762d28 \
     --hash=sha256:f3d7402e5b3ac72a5ee3149278339db1a8f932ee405f48bcb9c681372f2717d5
     # via -r requirements.txt
+uritemplate==4.1.1 \
+    --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
+    --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
+    # via
+    #   -r requirements.txt
+    #   drf-spectacular
 urllib3[secure,socks]==1.26.9 \
     --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
     --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -216,6 +216,7 @@ django==3.2.13 \
     #   django-treebeard
     #   djangorestframework
     #   drf-spectacular
+    #   drf-spectacular-sidecar
     #   wagtail
 django-anymail==8.5 \
     --hash=sha256:2325932f56f914d96e0a54db850f2b246ed2277b753f75319620d051a51551e2 \
@@ -302,10 +303,16 @@ draftjs-exporter==2.1.7 \
     # via
     #   -r requirements.txt
     #   wagtail
-drf-spectacular==0.22.1 \
+drf-spectacular[sidecar]==0.22.1 \
     --hash=sha256:17ac5e31e5d6150dd5fa10843b429202f4f38069202acc44394cc5a771de63d9 \
     --hash=sha256:866e16ddaae167a1234c76cd8c351161373551db994ce9665b347b32d5daf38b
     # via -r requirements.txt
+drf-spectacular-sidecar==2022.6.1 \
+    --hash=sha256:917ba08197573c37b7ee23726cffaf5e12f4fe6d9771cd428a4263042c2bee47 \
+    --hash=sha256:91bf519651c45ca3df606bc2e073681b8a786f4a3b1abec9abb6d097dfa08e7f
+    # via
+    #   -r requirements.txt
+    #   drf-spectacular
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -1,8 +1,11 @@
+from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers
 
 from incident.models import choices
 
 
+@extend_schema_field(OpenApiTypes.STR)
 class SummaryField(serializers.RelatedField):
     def to_representation(self, value):
         return value.summary
@@ -157,15 +160,18 @@ class BaseIncidentSerializer(serializers.Serializer):
             for field_name in existing - allowed:
                 self.fields.pop(field_name)
 
+    @extend_schema_field(OpenApiTypes.URI)
     def get_url(self, obj):
         if self.context.get('request'):
             return obj.get_full_url(self.context['request'])
         else:
             return obj.get_full_url()
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_body(self, obj):
         return str(obj.body)
 
+    @extend_schema_field(OpenApiTypes.URI)
     def get_teaser_image(self, obj):
         teaser_image = obj.teaser_image
         if teaser_image:

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -20,13 +20,15 @@ from incident.tests.factories import (
 
 
 class JournalistAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         cls.journalist = factories.JournalistFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('journalist-list'),
+            reverse('journalist-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -34,7 +36,7 @@ class JournalistAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('journalist-detail', args=(self.journalist.pk,)),
+            reverse('journalist-detail', args=(self.version, self.journalist.pk)),
             HTTP_ACCEPT='application/json',
         )
 
@@ -42,7 +44,7 @@ class JournalistAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('journalist-list'),
+            reverse('journalist-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -53,13 +55,15 @@ class JournalistAPITest(APITestCase):
 
 
 class InstitutionAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         cls.institution = factories.InstitutionFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('institution-list'),
+            reverse('institution-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -67,7 +71,7 @@ class InstitutionAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('institution-detail', args=(self.institution.pk,)),
+            reverse('institution-detail', args=(self.version, self.institution.pk)),
             HTTP_ACCEPT='application/json',
         )
 
@@ -75,7 +79,7 @@ class InstitutionAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('institution-list'),
+            reverse('institution-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -86,13 +90,15 @@ class InstitutionAPITest(APITestCase):
 
 
 class GovernmentWorkerAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         cls.worker = factories.GovernmentWorkerFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('governmentworker-list'),
+            reverse('governmentworker-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -100,7 +106,7 @@ class GovernmentWorkerAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('governmentworker-detail', args=(self.worker.pk,)),
+            reverse('governmentworker-detail', args=(self.version, self.worker.pk)),
             HTTP_ACCEPT='application/json',
         )
 
@@ -108,7 +114,7 @@ class GovernmentWorkerAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('governmentworker-list'),
+            reverse('governmentworker-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -119,13 +125,15 @@ class GovernmentWorkerAPITest(APITestCase):
 
 
 class ChargeAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         cls.charge = factories.ChargeFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('charge-list'),
+            reverse('charge-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -133,7 +141,7 @@ class ChargeAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('charge-detail', args=(self.charge.pk,)),
+            reverse('charge-detail', args=(self.version, self.charge.pk)),
             HTTP_ACCEPT='application/json',
         )
 
@@ -141,7 +149,7 @@ class ChargeAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('charge-list'),
+            reverse('charge-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -152,13 +160,15 @@ class ChargeAPITest(APITestCase):
 
 
 class NationalityAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         cls.nationality = factories.NationalityFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('nationality-list'),
+            reverse('nationality-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -166,7 +176,7 @@ class NationalityAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('nationality-detail', args=(self.nationality.pk,)),
+            reverse('nationality-detail', args=(self.version, self.nationality.pk)),
             HTTP_ACCEPT='application/json',
         )
 
@@ -174,7 +184,7 @@ class NationalityAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('nationality-list'),
+            reverse('nationality-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -185,13 +195,15 @@ class NationalityAPITest(APITestCase):
 
 
 class PoliticianAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         cls.politician = factories.PoliticianOrPublicFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('politicianorpublic-list'),
+            reverse('politicianorpublic-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -199,7 +211,7 @@ class PoliticianAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('politicianorpublic-detail', args=(self.politician.pk,)),
+            reverse('politicianorpublic-detail', args=(self.version, self.politician.pk,)),
             HTTP_ACCEPT='application/json',
         )
 
@@ -207,7 +219,7 @@ class PoliticianAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('politicianorpublic-list'),
+            reverse('politicianorpublic-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -217,14 +229,16 @@ class PoliticianAPITest(APITestCase):
         })
 
 
-class EquipmentAPITest(APITestCase):
+class VenueAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
-        cls.equipment = factories.EquipmentFactory()
+        cls.venue = factories.VenueFactory()
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('equipment-list'),
+            reverse('venue-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -232,7 +246,10 @@ class EquipmentAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('equipment-detail', args=(self.equipment.pk,)),
+            reverse(
+                'venue-detail',
+                args=(self.version, self.venue.pk),
+            ),
             HTTP_ACCEPT='application/json',
         )
 
@@ -240,7 +257,42 @@ class EquipmentAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('equipment-list'),
+            reverse('venue-list', kwargs={'version': self.version}),
+            HTTP_ACCEPT='application/json',
+        )
+        data = response.json()[0]
+        self.assertEqual(data, {
+            'title': self.venue.title,
+            'id': self.venue.pk,
+        })
+
+
+class EquipmentAPITest(APITestCase):
+    version = 'edge'
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.equipment = factories.EquipmentFactory()
+
+    def test_list_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('equipment-list', kwargs={'version': self.version}),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_retrieve_api_requests_are_successful(self):
+        response = self.client.get(
+            reverse('equipment-detail', args=(self.version, self.equipment.pk)),
+            HTTP_ACCEPT='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_result_attributes(self):
+        response = self.client.get(
+            reverse('equipment-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -251,6 +303,8 @@ class EquipmentAPITest(APITestCase):
 
 
 class CategoryAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         site = Site.objects.get(is_default_site=True)
@@ -262,7 +316,7 @@ class CategoryAPITest(APITestCase):
 
     def test_list_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('category-list'),
+            reverse('category-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -270,7 +324,10 @@ class CategoryAPITest(APITestCase):
 
     def test_retrieve_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('category-detail', args=(self.category.pk,)),
+            reverse(
+                'category-detail',
+                args=(self.version, self.category.pk),
+            ),
             HTTP_ACCEPT='application/json',
         )
 
@@ -278,7 +335,7 @@ class CategoryAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('category-list'),
+            reverse('category-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -294,6 +351,8 @@ class CategoryAPITest(APITestCase):
 
 
 class IncidentAPITest(APITestCase):
+    version = 'edge'
+
     @classmethod
     def setUpTestData(cls):
         site = Site.objects.get(is_default_site=True)
@@ -342,7 +401,7 @@ class IncidentAPITest(APITestCase):
 
     def test_api_requests_are_successful(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
 
@@ -350,7 +409,7 @@ class IncidentAPITest(APITestCase):
 
     def test_result_attributes(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': self.version}),
             HTTP_ACCEPT='application/json',
         )
         data = response.json()[0]
@@ -434,7 +493,7 @@ class IncidentAPITest(APITestCase):
             categories=[self.cat2],
         )
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': self.version}),
             {'categories': str(self.cat1.pk)},
             HTTP_ACCEPT='application/json',
         )
@@ -443,7 +502,7 @@ class IncidentAPITest(APITestCase):
 
     def test_dynamic_fields(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': self.version}),
             {'fields': 'city,state'},
             HTTP_ACCEPT='application/json',
         )

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -88,7 +88,10 @@ class HomePageCSVTestCase(TestCase):
 
     def setUp(self):
         self.response = self.client.get(
-            reverse('incidentpage-homepage_csv'),
+            reverse(
+                'incidentpage-homepage_csv',
+                kwargs={'version': 'edge'},
+            ),
             HTTP_ACCEPT='text/csv',
         )
         content_lines = self.response.content.splitlines()
@@ -166,7 +169,10 @@ class FilteredHomePageCSVTestCase(TestCase):
 
     def setUp(self):
         self.response = self.client.get(
-            reverse('incidentpage-homepage_csv'),
+            reverse(
+                'incidentpage-homepage_csv',
+                kwargs={'version': 'edge'},
+            ),
             {
                 'date_lower': '2022-01-15',
                 'date_upper': '2022-02-15',

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -51,7 +51,7 @@ class MinimalIncidentCSVTestCase(TestCase):
 
     def setUp(self):
         self.response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'format': 'csv'},
         )
 
@@ -240,7 +240,7 @@ class IncidentCSVTestCase(TestCase):
 
     def test_csv_requests_are_successful(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'format': 'csv'},
         )
         self.assertEqual(response.status_code, 200)
@@ -248,7 +248,7 @@ class IncidentCSVTestCase(TestCase):
     def test_csv_data_is_not_paginated(self):
         IncidentPageFactory.create_batch(30)
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'format': 'csv'},
         )
         content_lines = response.content.splitlines()
@@ -263,10 +263,10 @@ class IncidentCSVTestCase(TestCase):
 
     def test_csv_columns_are_in_same_order_as_json_keys(self):
         json_response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
         )
         csv_response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'format': 'csv'},
         )
 
@@ -279,7 +279,7 @@ class IncidentCSVTestCase(TestCase):
 
     def test_csv_supports_dynamic_fields(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'fields': 'city,state', 'format': 'csv'},
         )
         content_lines = response.content.splitlines()
@@ -291,7 +291,7 @@ class IncidentCSVTestCase(TestCase):
 
     def test_results(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'format': 'csv'},
         )
         content_lines = response.content.splitlines()
@@ -375,7 +375,7 @@ class IncidentCSVTestCase(TestCase):
 
     def test_result_headers(self):
         response = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'format': 'csv'},
         )
         content_lines = response.content.splitlines()

--- a/incident/api/tests/test_pagination.py
+++ b/incident/api/tests/test_pagination.py
@@ -35,7 +35,7 @@ class IncidentListPaginationTestCase(APITestCase):
 
     def test_pagination_header_links_present(self):
         response1 = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'limit': '3'},
         )
         links = humanize_links(response1)
@@ -74,7 +74,7 @@ class IncidentListPaginationTestCase(APITestCase):
 
     def test_pagination_envelope_can_be_enabled_on_demand(self):
         response1 = self.client.get(
-            reverse('incidentpage-list'),
+            reverse('incidentpage-list', kwargs={'version': 'edge'}),
             {'envelope': '1', 'limit': '3'},
         )
         response1_data = response1.json()

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -1,3 +1,4 @@
+from django.urls import re_path, include
 from rest_framework import routers
 
 from incident.api import views
@@ -15,4 +16,9 @@ router.register(r'venues', views.VenueViewSet)
 router.register(r'equipment', views.EquipmentViewSet)
 router.register(r'categories', views.CategoryViewSet, basename='category')
 
-urlpatterns = router.urls
+urlpatterns = [
+    re_path(
+        r'^api/(?P<version>(edge))/',
+        include(router.urls),
+    ),
+]

--- a/incident/api/urls.py
+++ b/incident/api/urls.py
@@ -15,4 +15,4 @@ router.register(r'venues', views.VenueViewSet)
 router.register(r'equipment', views.EquipmentViewSet)
 router.register(r'categories', views.CategoryViewSet, basename='category')
 
-api_urls = router.urls
+urlpatterns = router.urls

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -150,7 +150,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         return incidents.with_most_recent_update().with_public_associations()
 
     @action(detail=False, renderer_classes=[HomePageCSVRenderer], url_name='homepage_csv')
-    def homepage_csv(self, request):
+    def homepage_csv(self, request, version=None):
         lower_bound = request.GET.get('date_lower')
         upper_bound = request.GET.get('date_upper')
 

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -8,6 +8,9 @@ from django.db.models import (
     Subquery,
 )
 from rest_framework.decorators import action
+from drf_spectacular.utils import (
+    extend_schema,
+)
 from rest_framework import viewsets
 from rest_framework.settings import api_settings
 from rest_framework.pagination import CursorPagination
@@ -24,7 +27,7 @@ from incident.api.serializers import (
     FlatIncidentSerializer,
 )
 from incident import models
-from incident.utils.incident_filter import IncidentFilter
+from incident.utils.incident_filter import IncidentFilter, get_openapi_parameters
 
 if TYPE_CHECKING:
     from django.http import HttpResponse
@@ -86,6 +89,12 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = IncidentSerializer
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES) + (PaginatedCSVRenderer,)
     pagination_class = IncidentCursorPagination
+
+    @extend_schema(
+        parameters=get_openapi_parameters()
+    )
+    def list(self, *args, **kwargs):
+        return super().list(*args, **kwargs)
 
     def dispatch(self, *args, **kwargs) -> 'HttpResponse':
         response = super().dispatch(*args, **kwargs)

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -108,12 +108,12 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         return context
 
     def get_serializer_class(self):
-        if self.request.accepted_renderer.format == 'csv':
+        if getattr(self.request, 'accepted_renderer', None) and self.request.accepted_renderer.format == 'csv':
             return FlatIncidentSerializer
         return super().get_serializer_class()
 
     def paginate_queryset(self, queryset):
-        if self.request.accepted_renderer.format == 'csv':
+        if getattr(self.request, 'accepted_renderer', None) and self.request.accepted_renderer.format == 'csv':
             return None
         return super().paginate_queryset(queryset)
 

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -10,6 +10,7 @@ from django.db.models import (
 from rest_framework.decorators import action
 from drf_spectacular.utils import (
     extend_schema,
+    OpenApiParameter,
 )
 from rest_framework import viewsets
 from rest_framework.settings import api_settings
@@ -91,7 +92,23 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = IncidentCursorPagination
 
     @extend_schema(
-        parameters=get_openapi_parameters()
+        parameters=get_openapi_parameters() + [
+            OpenApiParameter(
+                name='fields',
+                type={
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                        'enum': list(IncidentSerializer().fields),
+                    }
+                },
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description='Specify which incident fields are given on the result data.',
+                style='form',
+                explode=False,
+            )
+        ]
     )
     def list(self, *args, **kwargs):
         return super().list(*args, **kwargs)

--- a/incident/tests/factories.py
+++ b/incident/tests/factories.py
@@ -26,6 +26,7 @@ from incident.models import (
     TargetedJournalist,
     GovernmentWorker,
     TopicPage,
+    Venue,
 )
 from common.tests.factories import (
     CategoryPageFactory,
@@ -79,6 +80,13 @@ class ItemFactory(factory.django.DjangoModelFactory):
                 lambda n: 'Title {n}'.format(n=n)
             )
         )
+
+
+class VenueFactory(ItemFactory):
+    class Meta:
+        model = Venue
+
+    title = factory.Sequence(lambda n: f'Venue {n}')
 
 
 class LawEnforcementOrganizationFactory(factory.django.DjangoModelFactory):

--- a/incident/tests/test_get_openapi_parameters.py
+++ b/incident/tests/test_get_openapi_parameters.py
@@ -1,0 +1,59 @@
+import itertools
+
+from django.test import TestCase
+from drf_spectacular.utils import OpenApiParameter
+from wagtail.core.models import Site
+
+from common.models.pages import CategoryPage
+from common.models.settings import IncidentFilterSettings, GeneralIncidentFilter
+from common.tests.factories import CategoryPageFactory
+from incident.models import IncidentPage
+from incident.utils.incident_filter import (
+    get_openapi_parameters,
+    IncidentFilter,
+    SearchFilter,
+)
+
+
+class GetOpenApiParametersTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        GeneralIncidentFilter.objects.all().delete()
+        CategoryPage.objects.all().delete()
+
+    def setUp(self):
+        self.site = Site.objects.get(is_default_site=True)
+        self.settings = IncidentFilterSettings.for_site(self.site)
+        self.addTypeEqualityFunc(OpenApiParameter, self._assert_param_equal)
+
+    def _assert_param_equal(self, lhs, rhs, msg):
+        self.assertDictEqual(lhs.__dict__, rhs.__dict__, msg)
+
+    def test_get_openapi_params_includes_search(self):
+        params = get_openapi_parameters()
+
+        self.assertEqual(len(params), 1)
+        for actual, expected in zip(params, SearchFilter().openapi_parameters()):
+            self.assertEqual(actual, expected)
+
+    def test_get_openapi_params_general_and_category_fields(self):
+        CategoryPageFactory(incident_filters=['arrest_status'])
+        GeneralIncidentFilter.objects.create(
+            incident_filter_settings=self.settings,
+            incident_filter='city',
+        )
+
+        params = get_openapi_parameters()
+
+        expected_params = itertools.chain(
+            SearchFilter().openapi_parameters(),
+            IncidentFilter._get_filter(
+                IncidentPage._meta.get_field('city')
+            ).openapi_parameters(),
+            IncidentFilter._get_filter(
+                IncidentPage._meta.get_field('arrest_status')
+            ).openapi_parameters()
+        )
+
+        for actual, expected in zip(params, expected_params):
+            self.assertEqual(actual, expected)

--- a/incident/tests/test_get_openapi_parameters.py
+++ b/incident/tests/test_get_openapi_parameters.py
@@ -1,5 +1,7 @@
 import itertools
+from unittest import mock
 
+from django.db.utils import ProgrammingError
 from django.test import TestCase
 from drf_spectacular.utils import OpenApiParameter
 from wagtail.core.models import Site
@@ -57,3 +59,8 @@ class GetOpenApiParametersTest(TestCase):
 
         for actual, expected in zip(params, expected_params):
             self.assertEqual(actual, expected)
+
+    @mock.patch('common.models.CategoryPage')
+    def test_returns_empty_list_if_db_error(self, MockCategoryPage):
+        MockCategoryPage.objects.live.side_effect = ProgrammingError
+        self.assertEqual(get_openapi_parameters(), [])

--- a/incident/tests/test_incident_filter.py
+++ b/incident/tests/test_incident_filter.py
@@ -35,6 +35,7 @@ class FilterToOpenApiParametersTest(TestCase):
         self.assertEqual(param.type, OpenApiTypes.BOOL)
         self.assertEqual(param.location, OpenApiParameter.QUERY)
         self.assertEqual(param.required, False)
+        self.assertEqual(param.style, None)
         self.assertEqual(param.description, 'Filter by "Search warrant obtained?"')
 
     def test_integer_field(self):
@@ -76,6 +77,23 @@ class FilterToOpenApiParametersTest(TestCase):
         self.assertEqual(upper.location, OpenApiParameter.QUERY)
         self.assertEqual(upper.required, False)
         self.assertEqual(upper.description, 'Filter by "date is before"')
+
+    def test_choice_filter(self):
+        field = IncidentPage._meta.get_field('arrest_status')
+        fltr = IncidentFilter._get_filter(field)
+        param, = fltr.openapi_parameters()
+
+        self.assertEqual(param.name, 'arrest_status')
+        self.assertEqual(param.enum, fltr.get_choices())
+
+    def test_multichoice_filter(self):
+        field = IncidentPage._meta.get_field('subpoena_statuses')
+        fltr = IncidentFilter._get_filter(field)
+        param, = fltr.openapi_parameters()
+
+        self.assertEqual(param.name, 'subpoena_statuses')
+        self.assertEqual(param.style, 'form')
+        self.assertEqual(param.enum, fltr.get_choices())
 
 
 class SerializeFilterTest(TestCase):

--- a/incident/tests/test_incident_filter.py
+++ b/incident/tests/test_incident_filter.py
@@ -95,6 +95,15 @@ class FilterToOpenApiParametersTest(TestCase):
         self.assertEqual(param.style, 'form')
         self.assertEqual(param.enum, fltr.get_choices())
 
+    def test_many_relation_filter(self):
+        field = IncidentPage._meta.get_field('politicians_or_public_figures_involved')
+        fltr = IncidentFilter._get_filter(field)
+        param, = fltr.openapi_parameters()
+
+        self.assertEqual(param.name, 'politicians_or_public_figures_involved')
+        self.assertEqual(param.style, 'form')
+        self.assertEqual(param.explode, False)
+
 
 class SerializeFilterTest(TestCase):
     def test_field_with_verbose_name(self):

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -399,6 +399,12 @@ class ManyRelationValue:
 
 class ManyRelationFilter(Filter):
     serialized_type = 'autocomplete'
+    openapi_style = 'form'
+    openapi_explode = False
+    openapi_type = {
+        'type': 'array',
+        'items': {'oneOf': [{'type': 'string'}, {'type': 'integer'}]},
+    }
 
     def __init__(self, name, model_field, lookup=None, verbose_name=None, text_fields=[]):
         self.text_fields = text_fields

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ django-storages[google]
 django-webpack-loader
 django-widget-tweaks==1.4.12
 djangorestframework-csv
+drf-spectacular>=0.20.2
 docutils
 factory_boy>=3.2.0
 gunicorn

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ django-storages[google]
 django-webpack-loader
 django-widget-tweaks==1.4.12
 djangorestframework-csv
-drf-spectacular>=0.20.2
+drf-spectacular[sidecar]>=0.22.1
 docutils
 factory_boy>=3.2.0
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,7 @@ django==3.2.13 \
     #   django-treebeard
     #   djangorestframework
     #   drf-spectacular
+    #   drf-spectacular-sidecar
     #   wagtail
 django-anymail==8.5 \
     --hash=sha256:2325932f56f914d96e0a54db850f2b246ed2277b753f75319620d051a51551e2 \
@@ -116,10 +117,14 @@ draftjs-exporter==2.1.7 \
     --hash=sha256:5839cbc29d7bce2fb99837a404ca40c3a07313f2a20e2700de7ad6aa9a9a18fb \
     --hash=sha256:d415a9964690a2cddb66a31ef32dd46c277e9b80434b94e39e3043188ed83e33
     # via wagtail
-drf-spectacular==0.22.1 \
+drf-spectacular[sidecar]==0.22.1 \
     --hash=sha256:17ac5e31e5d6150dd5fa10843b429202f4f38069202acc44394cc5a771de63d9 \
     --hash=sha256:866e16ddaae167a1234c76cd8c351161373551db994ce9665b347b32d5daf38b
     # via -r requirements.in
+drf-spectacular-sidecar==2022.6.1 \
+    --hash=sha256:917ba08197573c37b7ee23726cffaf5e12f4fe6d9771cd428a4263042c2bee47 \
+    --hash=sha256:91bf519651c45ca3df606bc2e073681b8a786f4a3b1abec9abb6d097dfa08e7f
+    # via drf-spectacular
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,10 @@ asgiref==3.5.0 \
     --hash=sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0 \
     --hash=sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9
     # via django
+attrs==21.4.0 \
+    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
+    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+    # via jsonschema
 beautifulsoup4==4.9.3 \
     --hash=sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35 \
     --hash=sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25 \
@@ -45,6 +49,7 @@ django==3.2.13 \
     #   django-taggit
     #   django-treebeard
     #   djangorestframework
+    #   drf-spectacular
     #   wagtail
 django-anymail==8.5 \
     --hash=sha256:2325932f56f914d96e0a54db850f2b246ed2277b753f75319620d051a51551e2 \
@@ -98,6 +103,7 @@ djangorestframework==3.13.1 \
     --hash=sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa
     # via
     #   djangorestframework-csv
+    #   drf-spectacular
     #   wagtail
 djangorestframework-csv==2.1.1 \
     --hash=sha256:aa0ee4c894fe319c68e042b05c61dace43a9fb6e6872e1abe1724ca7ea4d15f7
@@ -110,6 +116,10 @@ draftjs-exporter==2.1.7 \
     --hash=sha256:5839cbc29d7bce2fb99837a404ca40c3a07313f2a20e2700de7ad6aa9a9a18fb \
     --hash=sha256:d415a9964690a2cddb66a31ef32dd46c277e9b80434b94e39e3043188ed83e33
     # via wagtail
+drf-spectacular==0.22.1 \
+    --hash=sha256:17ac5e31e5d6150dd5fa10843b429202f4f38069202acc44394cc5a771de63d9 \
+    --hash=sha256:866e16ddaae167a1234c76cd8c351161373551db994ce9665b347b32d5daf38b
+    # via -r requirements.in
 et-xmlfile==1.1.0 \
     --hash=sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c \
     --hash=sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
@@ -210,10 +220,18 @@ idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
     --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
     # via requests
+inflection==0.5.1 \
+    --hash=sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417 \
+    --hash=sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2
+    # via drf-spectacular
 jinja2==3.1.1 \
     --hash=sha256:539835f51a74a69f41b848a9645dbdc35b4f20a3b601e2d9a7e22947b15ff119 \
     --hash=sha256:640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9
     # via -r requirements.in
+jsonschema==4.4.0 \
+    --hash=sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83 \
+    --hash=sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823
+    # via drf-spectacular
 l18n==2021.3 \
     --hash=sha256:1956e890d673d17135cc20913253c154f6bc1c00266c22b7d503cc1a5a42d848 \
     --hash=sha256:78495d1df95b6f7dcc694d1ba8994df709c463a1cbac1bf016e1b9a5ce7280b9
@@ -442,6 +460,29 @@ pyparsing==3.0.7 \
     # via
     #   -r requirements.in
     #   packaging
+pyrsistent==0.18.1 \
+    --hash=sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c \
+    --hash=sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc \
+    --hash=sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e \
+    --hash=sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26 \
+    --hash=sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec \
+    --hash=sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286 \
+    --hash=sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045 \
+    --hash=sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec \
+    --hash=sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8 \
+    --hash=sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c \
+    --hash=sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca \
+    --hash=sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22 \
+    --hash=sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a \
+    --hash=sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96 \
+    --hash=sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc \
+    --hash=sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1 \
+    --hash=sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07 \
+    --hash=sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6 \
+    --hash=sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b \
+    --hash=sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5 \
+    --hash=sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6
+    # via jsonschema
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
@@ -458,6 +499,41 @@ pytz==2022.1 \
     #   django-modelcluster
     #   djangorestframework
     #   l18n
+pyyaml==6.0 \
+    --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \
+    --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b \
+    --hash=sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57 \
+    --hash=sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b \
+    --hash=sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4 \
+    --hash=sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07 \
+    --hash=sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba \
+    --hash=sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9 \
+    --hash=sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287 \
+    --hash=sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513 \
+    --hash=sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0 \
+    --hash=sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0 \
+    --hash=sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92 \
+    --hash=sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f \
+    --hash=sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2 \
+    --hash=sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc \
+    --hash=sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c \
+    --hash=sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86 \
+    --hash=sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4 \
+    --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c \
+    --hash=sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34 \
+    --hash=sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b \
+    --hash=sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c \
+    --hash=sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb \
+    --hash=sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737 \
+    --hash=sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3 \
+    --hash=sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d \
+    --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53 \
+    --hash=sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78 \
+    --hash=sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803 \
+    --hash=sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a \
+    --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
+    --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
+    # via drf-spectacular
 requests==2.27.1 \
     --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
     --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d
@@ -521,6 +597,10 @@ unittest-xml-reporting==3.2.0 \
     --hash=sha256:edd8d3170b40c3a81b8cf910f46c6a304ae2847ec01036d02e9c0f9b85762d28 \
     --hash=sha256:f3d7402e5b3ac72a5ee3149278339db1a8f932ee405f48bcb9c681372f2717d5
     # via -r requirements.in
+uritemplate==4.1.1 \
+    --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
+    --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
+    # via drf-spectacular
 urllib3==1.26.9 \
     --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
     --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -85,6 +85,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_spectacular',
 ]
 
 MIDDLEWARE = [
@@ -267,6 +268,7 @@ CSP_STYLE_SRC = (
     "'self'",
     # For Wagtail Admin and Twitter Widgets.
     "'unsafe-inline'",
+    'https://cdn.jsdelivr.net',
 )
 CSP_FRAME_SRC = (
     "'self'",
@@ -294,6 +296,7 @@ CSP_IMG_SRC = [
     "https://pbs.twimg.com",
     "https://ton.twimg.com",
     "data:",
+    'https://cdn.jsdelivr.net',
 ]
 CSP_OBJECT_SRC = ["'self'"]
 CSP_MEDIA_SRC = ["'self'"]
@@ -344,3 +347,14 @@ RANDOM_SEED = 876394101
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 WAGTAILADMIN_COMMENTS_ENABLED = False
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Press Freedom Tracker API',
+    'DESCRIPTION': 'Programmatic access to up-to-date data.',
+    'VERSION': '1.0.0',
+    'SERVE_URLCONF': 'incident.api.urls',
+}

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -350,11 +350,12 @@ WAGTAILADMIN_COMMENTS_ENABLED = False
 
 REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
 }
 
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Press Freedom Tracker API',
     'DESCRIPTION': 'Programmatic access to up-to-date data.',
-    'VERSION': '1.0.0',
+    'VERSION': '',
     'SERVE_URLCONF': 'incident.api.urls',
 }

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'drf_spectacular',
+    'drf_spectacular_sidecar',
 ]
 
 MIDDLEWARE = [
@@ -354,6 +355,9 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
+    'SWAGGER_UI_DIST': 'SIDECAR',
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
     'TITLE': 'Press Freedom Tracker API',
     'DESCRIPTION': 'Programmatic access to up-to-date data.',
     'VERSION': '',

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -10,7 +10,7 @@ from wagtailautocomplete.views import objects, search
 from charts.urls import urlpatterns as chart_urls
 from common import views as common_views
 from emails import urls as emails_urls
-from incident.api.urls import api_urls
+from incident.api.urls import urlpatterns as api_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -25,7 +25,6 @@ autocomplete_public_urls = [
 urlpatterns = [
     path('django-admin/', admin.site.urls),
 
-    path('api/edge/', include(api_urls)),
     path('autocomplete/', include(autocomplete_public_urls)),
     path('admin/autocomplete/', include(autocomplete_admin_urls)),
     path('admin/', include(wagtailadmin_urls)),
@@ -39,11 +38,12 @@ urlpatterns = [
 
     path('charts/', include(chart_urls)),
 
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/', SpectacularAPIView.as_view(api_version='edge'), name='schema'),
     # Schema UI:
     path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 
+    path(r'', include(api_urls)),
     path(r'', include(wagtail_urls)),
 ]
 

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.conf import settings
 from django.urls import include, path, re_path
 from django.contrib import admin
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from wagtailautocomplete.urls.admin import urlpatterns as autocomplete_admin_urls
 from wagtailautocomplete.views import objects, search
 
@@ -37,6 +38,11 @@ urlpatterns = [
     path('health/version/', common_views.health_version),
 
     path('charts/', include(chart_urls)),
+
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    # Schema UI:
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 
     path(r'', include(wagtail_urls)),
 ]


### PR DESCRIPTION
Refs #1117
 
I'm making a PR for this to get some additional eyes on the Swagger. I'd say this is ready for review but I'm not totally sure it's ready to merge, if that makes any sense. I guess this PR is looking for feedback moreso than it's looking for fast-track-to-production. But if we think it's ready then, sure, let's merge it.

Anyway, this PR adds:

* A markdown file containing some initial static documentation. I wrote this _before_ going down the rabbit hole of auto-schema generation
* DRF Spectacular, a version < 1.0 package for introspecting a schema out of a Django Rest Framework configuration. This schema is compatible with OpenAPI 3.0.x (notably _not_ OpenAPI 3.1) and can be used by various frontend UIs for browsing this "live" piece of documentation. (Though I will say the "liveness" is slightly compromised by our setup, see consideration 3 below). 
* A Swagger URL for our API at http://localhost:8000/api/schema/swagger-ui
* A Redoc URL for our API at http://localhost:8000/api/schema/redoc (these are both "included" with DRF spectacular, which is nice, but ultimately we probably only want one of them).
* A raw schema URL for our API at http://localhost:8000/api/schema/
* Some code for converting between our Incident filters and the OpenAPI formatted [parameter objects](https://swagger.io/specification/#parameter-object). This is slightly tricky, and probably took the most time out of everything I worked on for this PR because I was trying to coax a nice UI for choosing valid parameters out of Swagger, and only in some cases I was able to succeed. Particularly, we are now allowing relationship filters (such as "state") to accept values of either the name of a state or its database ID. It doesn't seem like Swagger or ReDoc have a great way for inputting this type of "either or" value. The attitude is more like: "here's a text box."
* Proper versioning for our API. Previously we were using a static URL prefix, but now we are taking advantage of DRF's actual versioning features. This lets our schema express the version correctly.

Further considerations:

1. I'm pretty sure that right now the Swagger code is being pulled from a CDN. According to the docs, it's possible to self host these static files but that's not in this PR. See the documentation: https://drf-spectacular.readthedocs.io/en/latest/readme.html#self-contained-ui-installation
2. There is definitely more "explanatory" documentation that could be added to the Swagger UI, akin to the `help_text` fields on the wagtail UI, but I have not had time to sit down and write any. So looking at the API explorer right now is somewhat utilitarian.
3. Our filters are not actually static, and cannot be determined simply from the DRF configuration. They depend on the Wagtail site settings, which is stored in the database. I think one consequence of this is that changes made to the database after the schema is computed will not be reflected immediately. In practice, I had to restart the server. It seems to me that the schema is calculated during the Django startup phase. I am not completely sure about this and some more investigation can be done.