### PR TITLE
Updates django to version 2.2.25

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -194,9 +194,9 @@ dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
     # via -r requirements.txt
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.txt
     #   django-anymail

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 bleach>=4.1.0
 dj-database-url
-Django>=2.2.24,<2.3
+Django>=2.2.25,<2.3
 django-anymail
 django-csp>=3.7
 django-modelcluster

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,9 +27,9 @@ dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
     # via -r requirements.in
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.25 \
+    --hash=sha256:08bad7ef7e90286b438dbe1412c3e633fbc7b96db04735f0c7baadeed52f3fad \
+    --hash=sha256:b1e65eaf371347d4b13eb7e061b09786c973061de95390c327c85c1e2aa2349c
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
Fixes CVE-2021-44420: Potential bypass of an upstream access control
based on URL paths

See https://docs.djangoproject.com/en/4.0/releases/2.2.25/ for more
information.