### PR TITLE
Adds STYLEGUIDE variable to control showing styleguide

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ omit =
     */tests/*.py
     tracker/settings/*.py
     incident/devdata.py
+    */urls.py
 skip_empty = True
 show_missing = True
 

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -28,6 +28,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 DEBUG = False
+STYLEGUIDE = False
 
 # Application definition
 

--- a/tracker/settings/production-styleguide.py
+++ b/tracker/settings/production-styleguide.py
@@ -1,0 +1,6 @@
+from .production import *  # noqa: F403, F401
+
+
+# Enable styleguide on production-like systems that are not actually
+# production.
+STYLEGUIDE = True

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -57,5 +57,8 @@ if settings.DEBUG:
     except ImportError:
         pass
 
+if settings.STYLEGUIDE:
+    urlpatterns = [path('styleguide/', include('styleguide.urls'))] + urlpatterns
+
 if apps.is_installed('silk'):
     urlpatterns = [path('silk/', include('silk.urls', namespace='silk'))] + urlpatterns


### PR DESCRIPTION
Adds a `production-styleguide.py` with STYLEGUIDE = True. This STYLEGUIDE variable is being used by to turn on just styleguide path without using the rest of DEBUG settings. 