### PR TITLE
Fixes guidelines for the show more button

### DIFF
--- a/styleguide/templates/styleguide/index.html
+++ b/styleguide/templates/styleguide/index.html
@@ -146,7 +146,7 @@
 		</code>
 		<h4 class="heading-regular">Show More/Less</h4>
 		<code>
-			&lt;a&gt; or class="text-link":
+			&lbrace;% include 'common/_disclose.html' with content="Show more text here" %&rbrace; :
 			{% include 'common/_disclose.html' with content="Show more text here" %}
 		</code>
 	</details>


### PR DESCRIPTION
I noticed after the deploy that some copy-paste text was left in the guidelines for the show more button. Fixing it here.