### PR TITLE
Menus

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
 		"window": true,
 		"HTMLInputElement": true,
 		"fetch": true,
+		"document": true,
 	},
 
 	"rules": {

--- a/client/common/icons/icon-menu-close.svg
+++ b/client/common/icons/icon-menu-close.svg
@@ -1,0 +1,5 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 31L30.9706 14.0294" stroke="black" stroke-width="3"/>
+<path d="M14 14L21.0711 21.0711" stroke="black" stroke-width="3"/>
+<path d="M21 21L30.8995 30.8995" stroke="black" stroke-width="3"/>
+</svg>

--- a/client/common/icons/icon-menu-open.svg
+++ b/client/common/icons/icon-menu-open.svg
@@ -1,0 +1,5 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 10H20" stroke="black" stroke-width="3"/>
+<path d="M10 22H34" stroke="black" stroke-width="3"/>
+<path d="M10 34H24" stroke="black" stroke-width="3"/>
+</svg>

--- a/client/common/js/common.js
+++ b/client/common/js/common.js
@@ -1,2 +1,2 @@
 import '../sass/common.sass'
-import './menu.js'
+import './menu'

--- a/client/common/js/common.js
+++ b/client/common/js/common.js
@@ -1,1 +1,2 @@
 import '../sass/common.sass'
+import './menu.js'

--- a/client/common/js/menu.js
+++ b/client/common/js/menu.js
@@ -1,0 +1,12 @@
+const topNavBar = document.querySelector(".top-nav-bar")
+const navToggle = document.querySelector(".mobile-nav-toggle")
+
+navToggle.addEventListener("click", () => {
+	if (topNavBar.dataset.visible === "false") {
+		topNavBar.dataset.visible = "true"
+		navToggle.setAttribute("aria-expanded", "true")
+	} else if (topNavBar.dataset.visible === "true") {
+		topNavBar.dataset.visible = "false"
+		navToggle.setAttribute("aria-expanded", "false")
+	}
+})

--- a/client/common/js/menu.js
+++ b/client/common/js/menu.js
@@ -1,17 +1,17 @@
-const topNavBar = document.querySelector(".top-nav-bar")
-const navToggle = document.querySelector(".mobile-nav-toggle")
-const header = document.querySelector(".header")
+const topNavBar = document.querySelector('.top-nav-bar')
+const navToggle = document.querySelector('.mobile-nav-toggle')
+const header = document.querySelector('.header')
 
-navToggle.addEventListener("click", () => {
-	if (topNavBar.dataset.visible === "false") {
-		document.body.classList.add("overflow-hidden")
-		header.classList.add("menu-expanded")
-		topNavBar.dataset.visible = "true"
-		navToggle.setAttribute("aria-expanded", "true")
-	} else if (topNavBar.dataset.visible === "true") {
-		header.classList.remove("menu-expanded")
-		document.body.classList.remove("overflow-hidden")
-		topNavBar.dataset.visible = "false"
-		navToggle.setAttribute("aria-expanded", "false")
+navToggle.addEventListener('click', () => {
+	if (topNavBar.dataset.visible === 'false') {
+		document.body.classList.add('overflow-hidden')
+		header.classList.add('menu-expanded')
+		topNavBar.dataset.visible = 'true'
+		navToggle.setAttribute('aria-expanded', 'true')
+	} else if (topNavBar.dataset.visible === 'true') {
+		header.classList.remove('menu-expanded')
+		document.body.classList.remove('overflow-hidden')
+		topNavBar.dataset.visible = 'false'
+		navToggle.setAttribute('aria-expanded', 'false')
 	}
 })

--- a/client/common/js/menu.js
+++ b/client/common/js/menu.js
@@ -1,11 +1,16 @@
 const topNavBar = document.querySelector(".top-nav-bar")
 const navToggle = document.querySelector(".mobile-nav-toggle")
+const header = document.querySelector(".header")
 
 navToggle.addEventListener("click", () => {
 	if (topNavBar.dataset.visible === "false") {
+		document.body.classList.add("overflow-hidden")
+		header.classList.add("menu-expanded")
 		topNavBar.dataset.visible = "true"
 		navToggle.setAttribute("aria-expanded", "true")
 	} else if (topNavBar.dataset.visible === "true") {
+		header.classList.remove("menu-expanded")
+		document.body.classList.remove("overflow-hidden")
 		topNavBar.dataset.visible = "false"
 		navToggle.setAttribute("aria-expanded", "false")
 	}

--- a/client/common/sass/_responsive.sass
+++ b/client/common/sass/_responsive.sass
@@ -11,3 +11,7 @@ $desktop-min: $tablet-max + 1px
 =desktop-up
     @media(min-width: $desktop-min)
         @content
+
+=tablet-down
+    @media(max-width: $desktop-min)
+        @content

--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -20,3 +20,4 @@
 @import components/emails-signup
 @import components/citation
 @import components/search-bar
+@import components/menu

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -3,6 +3,30 @@
 	align-items: center
 	gap: 1rem
 
+.site-title-link
+	z-index: 1010
+	margin: 1.5rem
+	text-decoration: none
+	font-weight: 700
+
+.mobile-nav-toggle
+	display: none
+	+tablet-down
+		display: block
+		position: absolute
+		z-index: 9999
+		background-color: transparent
+		background-image: url(../icons/icon-menu-open.svg)
+		background-repeat: no-repeat
+		border: 0
+		width: 3rem
+		top: 1rem
+		right: 2rem
+		aspect-ratio: 1
+
+		&[aria-expanded="true"]
+			background-image: url(../icons/icon-menu-close.svg)
+
 .top-nav-bar
 	box-sizing: border-box
 	display: flex
@@ -15,12 +39,17 @@
 		flex-direction: column
 		align-items: stretch
 		position: fixed
+		z-index: 1000
 		inset: 0
-		padding: 1rem
+		padding: 10rem 1rem 0 1rem
 		max-width: 100%
 		max-height: 100vh
 
+		transform: translateY(-100%)
+		transition: transform 350ms ease-out
 
+		&[data-visible="true"]
+			transform: translateY(0%)
 
 .primary-navigation
 	display: flex
@@ -61,3 +90,6 @@
 		// for some reason I need this to account for the :after
 		// element on these buttons.
 		margin-right: calc(1.5rem + 19px)
+
+.overflow-hidden
+	overflow: hidden

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -1,0 +1,43 @@
+.header
+	display: flex
+	align-items: center
+	gap: 1rem
+
+.top-nav-bar
+	box-sizing: border-box
+	display: flex
+	width: 100%
+	align-items: center
+	justify-content: space-between
+
+	+tablet-down
+		background: #F8F8F8
+		flex-direction: column
+		align-items: stretch
+		position: fixed
+		inset: 0
+		padding: 1rem
+		max-width: 100%
+		max-height: 100vh
+
+.primary-navigation
+	display: flex
+	gap: 1rem
+	list-style: none
+	margin: 0
+	padding: 0
+
+	+tablet-down
+		flex-direction: column
+
+.secondary-navigation
+	display: flex
+	gap: 1rem
+	list-style: none
+	margin: 0
+	padding: 0
+
+	.btn-primary
+		// for some reason I need this to account for the :after
+		// element on these buttons.
+		margin-right: calc(1.5rem + 19px)

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -12,6 +12,7 @@
 .site-title-link
 	z-index: 1010
 	margin: 1.5rem
+	min-width: 11.5rem
 	text-decoration: none
 	font-weight: 700
 

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -2,13 +2,12 @@
 	display: flex
 	align-items: center
 	gap: 1rem
-	background-color: white
+	background-color: #FFF
 	transition: background-color 350ms ease-out
 	z-index: 1000
 
 	&.menu-expanded
 		background-color: #F8F8F8
-
 
 .site-title-link
 	z-index: 1010
@@ -21,6 +20,7 @@
 
 .mobile-nav-toggle
 	display: none
+
 	+tablet-down
 		display: block
 		position: absolute
@@ -34,7 +34,8 @@
 		right: 2rem
 		aspect-ratio: 1
 
-		&[aria-expanded="true"]
+	&[aria-expanded="true"]
+		+tablet-down
 			background-image: url(../icons/icon-menu-close.svg)
 
 .top-nav-bar
@@ -58,7 +59,8 @@
 
 		transition: max-height 350ms ease-out
 
-		&[data-visible="true"]
+	&[data-visible="true"]
+		+tablet-down
 			max-height: 100vh
 			background-color: #F8F8F8
 

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -20,6 +20,8 @@
 		max-width: 100%
 		max-height: 100vh
 
+
+
 .primary-navigation
 	display: flex
 	gap: 1rem
@@ -29,6 +31,24 @@
 
 	+tablet-down
 		flex-direction: column
+
+		a
+			display: flex
+			text-decoration: none
+			justify-content: space-between
+			border-bottom: solid 1px #c1c1c1
+			font-weight: 700
+
+			&:hover
+				background-color: transparent
+
+	a > span
+		display: none
+
+		+tablet-down
+			display: inline
+			font-weight: 400
+			color: $gray-text
 
 .secondary-navigation
 	display: flex

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -2,12 +2,22 @@
 	display: flex
 	align-items: center
 	gap: 1rem
+	background-color: white
+	transition: background-color 350ms ease-out
+	z-index: 1000
+
+	&.menu-expanded
+		background-color: #F8F8F8
+
 
 .site-title-link
 	z-index: 1010
 	margin: 1.5rem
 	text-decoration: none
 	font-weight: 700
+
+	&:hover
+		background-color: transparent
 
 .mobile-nav-toggle
 	display: none
@@ -35,21 +45,22 @@
 	justify-content: space-between
 
 	+tablet-down
-		background: #F8F8F8
 		flex-direction: column
+		background-color: #F8F8F8
 		align-items: stretch
 		position: fixed
 		z-index: 1000
 		inset: 0
-		padding: 10rem 1rem 0 1rem
+		padding: 0 1rem 0 1rem
 		max-width: 100%
-		max-height: 100vh
+		max-height: 0
+		overflow: hidden
 
-		transform: translateY(-100%)
-		transition: transform 350ms ease-out
+		transition: max-height 350ms ease-out
 
 		&[data-visible="true"]
-			transform: translateY(0%)
+			max-height: 100vh
+			background-color: #F8F8F8
 
 .primary-navigation
 	display: flex
@@ -59,6 +70,7 @@
 	padding: 0
 
 	+tablet-down
+		margin-top: 10rem
 		flex-direction: column
 
 		a

--- a/styleguide/templates/styleguide/index.html
+++ b/styleguide/templates/styleguide/index.html
@@ -10,6 +10,15 @@
 		border: 1px dashed black;
 		padding: 1.5rem
 	}
+	hr {
+		max-width: 100%;
+	}
+	pre {
+		overflow: auto;
+	}
+	img {
+		max-width: 100%;
+	}
 </style>
 	<h1 class="page-title">PFT Styleguide</h1>
 
@@ -174,27 +183,27 @@
 	<details id="cards" open>
 		<summary><h2 class="heading">Cards</h2></summary>
 		<h4 class="heading-regular">Incident Card (Big, No Photo)</h4>
-		<code>
-            &lbrace;% include 'incident/incident_card.html' with incident=incident size='big' only %&rbrace;
-		</code>
+		<code><pre>
+    &lbrace;% include 'incident/incident_card.html' with incident=incident size='big' only %&rbrace;
+		</pre></code>
 		{% include "incident/incident_card.html" with incident=incident size="big" only %}
 
 		<h4 class="heading-regular">Incident Card (Big, Photo)</h4>
-		<code>
-            &lbrace;% include 'incident/incident_card.html' with incident=incident size='big' photo=incident.teaser_image only %&rbrace;
-		</code>
+		<code><pre>
+    &lbrace;% include 'incident/incident_card.html' with incident=incident size='big' photo=incident.teaser_image only %&rbrace;
+		</pre></code>
 		{% include "incident/incident_card.html" with incident=incident size="big" photo=incident.teaser_image only %}
 
 		<h4 class="heading-regular">Incident Card (Small, No Photo)</h4>
-		<code>
-            &lbrace;% include 'incident/incident_card.html' with incident=incident size='small' only %&rbrace;
-		</code>
+		<code><pre>
+    &lbrace;% include 'incident/incident_card.html' with incident=incident size='small' only %&rbrace;
+		</pre></code>
 		{% include "incident/incident_card.html" with incident=incident size="small" only %}
 
 		<h4 class="heading-regular">Incident Card (Small, Photo)</h4>
-		<code>
-            &lbrace;% include 'incident/incident_card.html' with incident=incident size='small' photo=incident.teaser_image only %&rbrace;
-		</code>
+		<code><pre>
+    &lbrace;% include 'incident/incident_card.html' with incident=incident size='small' photo=incident.teaser_image only %&rbrace;
+		</pre></code>
 		{% include "incident/incident_card.html" with incident=incident size="small" photo=incident.teaser_image only %}
 
 		<h4 class="heading-regular">Blog Card (Big, No Photo)</h4>

--- a/tracker/templates/menu.html
+++ b/tracker/templates/menu.html
@@ -1,0 +1,18 @@
+<header class="header">
+	<a href="/">
+		US Press Freedom Tracker
+	</a>
+
+	<nav class="top-nav-bar">
+		<ul id="primary-navigation" class="primary-navigation">
+			<li><a href="#">Incidents Database</a></li>
+			<li><a href="#">Blog</a></li>
+			<li><a href="#">FAQ</a></li>
+			<li><a href="#">About</a></li>
+		</ul>
+		<ul id="secondary-navigation" class="secondary-navigation">
+			<li><a href="#" class="btn btn-primary">Donate</a></li>
+			<li><a href="#" class="btn btn-primary">Submit an Incident</a></li>
+		</ul>
+	</nav>
+</header>

--- a/tracker/templates/menu.html
+++ b/tracker/templates/menu.html
@@ -1,9 +1,13 @@
 <header class="header">
-	<a href="/">
-		US Press Freedom Tracker
+	<a class="site-title-link" href="/">
+		U.S Press Freedom Tracker
 	</a>
 
-	<nav class="top-nav-bar">
+	<button class="mobile-nav-toggle" aria-controls="primary-navigation" aria-expanded="false">
+		<span class="sr-only">Menu</span>
+	</button>
+
+	<nav class="top-nav-bar" data-visible="false">
 		<ul id="primary-navigation" class="primary-navigation">
 			<li>
 				<a href="#">

--- a/tracker/templates/menu.html
+++ b/tracker/templates/menu.html
@@ -5,10 +5,30 @@
 
 	<nav class="top-nav-bar">
 		<ul id="primary-navigation" class="primary-navigation">
-			<li><a href="#">Incidents Database</a></li>
-			<li><a href="#">Blog</a></li>
-			<li><a href="#">FAQ</a></li>
-			<li><a href="#">About</a></li>
+			<li>
+				<a href="#">
+					Incidents Database
+					<span>Go to the page &rarr;</span>
+				</a>
+			</li>
+			<li>
+				<a href="#">
+					Blog
+					<span>Go to the page &rarr;</span>
+				</a>
+			</li>
+			<li>
+				<a href="#">
+					FAQ
+					<span>Go to the page &rarr;</span>
+				</a>
+			</li>
+			<li>
+				<a href="#">
+					About
+					<span>Go to the page &rarr;</span>
+				</a>
+			</li>
 		</ul>
 		<ul id="secondary-navigation" class="secondary-navigation">
 			<li><a href="#" class="btn btn-primary">Donate</a></li>

--- a/tracker/templates/super.html
+++ b/tracker/templates/super.html
@@ -24,7 +24,7 @@
 
 			{% block css %}
 				{% render_bundle 'common' 'css' %}
-				{% render_bundle 'common' 'js' %}
+				{% render_bundle 'common' 'js' attrs='defer'%}
 				{% endblock %}
 
 			{% block meta %}

--- a/tracker/templates/super.html
+++ b/tracker/templates/super.html
@@ -45,7 +45,9 @@
 
 	<body class="{% block body_class %}{% endblock %}">
 		{% include "menu.html" %}
-		{% block body %}
+		<main id="main">
+			{% block body %}
+		</main>
 		{% endblock %}
 	</body>
 </html>

--- a/tracker/templates/super.html
+++ b/tracker/templates/super.html
@@ -44,6 +44,7 @@
 	</head>
 
 	<body class="{% block body_class %}{% endblock %}">
+		{% include "menu.html" %}
 		{% block body %}
 		{% endblock %}
 	</body>


### PR DESCRIPTION
Fixes #1171 

This PR implements the mobile, tablet, and desktop top site menu as outlined in the issue/design. I've put the menu in the styleguide, as there's not really any other page to apply it to, so please go there to test it out.

Potential issues I know about:

1. There is no animation for the open/close icon changing state. Right now it just changes. I have not really looked into how to make that animation between two SVGs work, and I don't know how I'd go about it. Might be worth making into another issue.
2. The mobile/tablet menu list does not have a hover state. I was looking at the design document for this and it seems slightly tricky and like it might want to become its own component (e.g., it needs to be able to display logos on hover), so I have basically implemented the minimum necessary for this PR. Also potentially it doesn't matter since mobile/tablet interfaces don't really support a hover state (that I'm aware of).
3. The Styleguide page has horizontal scrollbars at mobile widths, which affects the menu. My assumption is that when more of the page layout code is complete this kind of thing will be prevented, so I have not attempted to provide my own slapdash fix for the Styleguide page. 
4. When the viewport is around 770-800 pixels wide, the buttons are a bit scrunched. My opinion here is we might want to think a little bit about how wide we consider a "tablet" for the purposes of our media queries. According to Firefox, the iPad's effective pixel width is 810 pixels, and right now that width is being shown the "desktop" layout (smaller than this and the scrunch starts to occur). This could also happen if the number/size of the menu items changes (see below).

So, if you have thoughts on any of the above, or if you have feedback about the implementation markup, SASS, Javascript, please let me know. I've tried to take into account relevant attributes for assistive technologies, ~added a `sr-only` class that we might want to use elsewhere (I just copied it from what was on the site before)~, and made the "vertical wipe" animation in the simplest way I could figure out. There might be other ways though. Any and all comments welcome regarding all of this: I want these foundational elements to be the best they can be.

Open question:

Are the menu items intended to be hard-coded or loaded from Wagtail settings? They are hard-coded right now, but we do have a system for allowing admins to input menu items. We would have to change that system a little bit, I think, to incorporate the ideas of "primary" and "secondary" navigation. 