### PR TITLE
Initial search bar component

### DIFF
--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -17,3 +17,4 @@
 @import components/footer-info
 @import components/emails-signup
 @import components/citation
+@import components/search-bar

--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -3,7 +3,10 @@
 
 .search-button
 	position: absolute
-	right: 4px
-	top: 5px
+	right: 2px
+	top: 3.5px
 	border: 0
-	font-weight: 700
+	font-weight: 500
+
+	&:focus
+		top: 1px

--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -1,0 +1,9 @@
+.search-form
+	position: relative
+
+.search-button
+	position: absolute
+	right: 4px
+	top: 5px
+	border: 0
+	font-weight: 700

--- a/client/common/sass/components/_text-field.sass
+++ b/client/common/sass/components/_text-field.sass
@@ -19,3 +19,10 @@
 			border: 3px solid
 			background: $tag-inactive-bg
 			outline: none
+
+	&--search-bar
+		width: 100%
+		border: 2px solid
+		padding: 13px 24px
+		font-style: italic
+		font-size: $font-size-small-p

--- a/incident/templates/incident/search_bar.html
+++ b/incident/templates/incident/search_bar.html
@@ -1,0 +1,19 @@
+<div class="search-bar">
+	<form class="search-form">
+		<label for="primary-search-bar" class="sr-only">
+			Search incidents by text, date, location, tags...
+		</label>
+		<input
+			id="primary-search-bar"
+			placeholder="Search incidents by text, date, location, tags..."
+			spellcheck="false"
+			autocomplete="off"
+			type="search"
+			class="text-field--search-bar"
+		>
+		<button type="submit" class="btn btn-ghost search-button" value="Search">
+			Search
+		</button>
+
+	</form>
+</div>

--- a/styleguide/templates/styleguide/index.html
+++ b/styleguide/templates/styleguide/index.html
@@ -87,6 +87,11 @@
 				<input class="text-field--single" placeholder="Text">
 			</div>
 		</code>
+
+		<code>
+            &lbrace;% include 'incident/_search_bar.html' %&rbrace; :
+			{% include "incident/search_bar.html" %}
+		</code>
 	</details>
 
 	<hr/>


### PR DESCRIPTION
This pull request adds the initial scaffolding and styles for the search bar component. Here's what it looks like in the styleguide:

![image](https://user-images.githubusercontent.com/561931/148259931-c769ddc9-f06c-4a41-99e9-499702f73878.png)

I recognize that this component is destined to gain its fancy search-hints functionality via React, but the specifications for that don't really exist yet, and the fallback for non-JS users will be a plain HTML form, which is what I've done here.