### PR TITLE
Blog card components

### DIFF
--- a/blog/templates/blog/blog_card.html
+++ b/blog/templates/blog/blog_card.html
@@ -32,5 +32,6 @@
 					{{ post.author.title }}
 				</dd>
 			{% endif %}
+		</dl>
 	</article>
 {% endwith %}

--- a/blog/templates/blog/blog_card.html
+++ b/blog/templates/blog/blog_card.html
@@ -10,16 +10,16 @@
 			>
 		{% endif %}
 		<a class="text-link--card" href="{% pageurl post %}">
-			<h3 class="card-title-{{ size }}">
+			<h3 class="card-title-{{ size }} blog-card--title">
 				{{ post.title }}
 			</h3>
 		</a>
 		{% if not photo %}
-			<p>
+			<p class="blog-card--teaser">
 				{{ post.teaser_text }}
 			</p>
 		{% endif %}
-		<dl class="dl-inline">
+		<dl class="dl-inline blog-card--info">
 			<dt>Published</dt>
 			<dd>
 				<time datetime="{{ post.publication_datetime|date:"c" }}">

--- a/blog/templates/blog/blog_card.html
+++ b/blog/templates/blog/blog_card.html
@@ -1,0 +1,36 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+{% with size=size|default:"big" %}
+	<article class="blog-card">
+		{% if photo %}
+			{% image photo fill-655x440 %}
+			<img
+				class="card-image-{{ size }}"
+				alt="{{ x1.alt }}"
+				src="{{ x1.url }}"
+			>
+		{% endif %}
+		<a class="text-link--card" href="{% pageurl post %}">
+			<h3 class="card-title-{{ size }}">
+				{{ post.title }}
+			</h3>
+		</a>
+		{% if not photo %}
+			<p>
+				{{ post.teaser_text }}
+			</p>
+		{% endif %}
+		<dl class="dl-inline">
+			<dt>Published</dt>
+			<dd>
+				<time datetime="{{ post.publication_datetime|date:"c" }}">
+					{{ post.publication_datetime|date:"F j, Y" }}
+				</time>
+			</dd>
+			{% if post.author %}
+				<dt>Written by</dt>
+				<dd>
+					{{ post.author.title }}
+				</dd>
+			{% endif %}
+	</article>
+{% endwith %}

--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -13,6 +13,7 @@
 @import components/buttons
 @import components/disclose
 @import components/incident-card
+@import components/blog-card
 @import components/text-field
 @import components/footer
 @import components/footer-info

--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -6,6 +6,7 @@
 @import components/page-title
 @import components/article-title
 @import components/card-title
+@import components/card-image
 @import components/heading
 @import components/paragraph
 @import components/text-link

--- a/client/common/sass/components/_blog-card.sass
+++ b/client/common/sass/components/_blog-card.sass
@@ -1,0 +1,14 @@
+.blog-card
+	border-top: 1px solid
+	border-color: $black
+	padding-top: 2rem
+
+	&--info
+		margin-top: 12px
+
+	&--teaser
+		margin-top: 12px
+		margin-bottom: 12px
+
+	&--title
+		margin-bottom: 0

--- a/client/common/sass/components/_card-image.sass
+++ b/client/common/sass/components/_card-image.sass
@@ -1,0 +1,6 @@
+.card-image
+	&-big
+		display: block
+
+	&-small
+		display: block

--- a/styleguide/templates/styleguide/index.html
+++ b/styleguide/templates/styleguide/index.html
@@ -191,6 +191,30 @@
             &lbrace;% include 'incident/incident_card.html' with incident=incident size='small' photo=incident.teaser_image only %&rbrace;
 		</code>
 		{% include "incident/incident_card.html" with incident=incident size="small" photo=incident.teaser_image only %}
+
+		<h4 class="heading-regular">Blog Card (Big, No Photo)</h4>
+		<code>
+            &lbrace;% include 'blog/blog_card.html' with post=blog_page size='big' only %&rbrace;
+		</code>
+		{% include "blog/blog_card.html" with post=blog_page size="big" only %}
+
+		<h4 class="heading-regular">Blog Card (Big, Photo)</h4>
+		<code>
+            &lbrace;% include 'blog/blog_card.html' with post=blog_page size='big' photo=incident.teaser_image only %&rbrace;
+		</code>
+		{% include "blog/blog_card.html" with post=blog_page size="big" photo=blog_page.teaser_image only %}
+
+		<h4 class="heading-regular">Blog Card (Small, No Photo)</h4>
+		<code>
+            &lbrace;% include 'blog/blog_card.html' with post=blog_page size='small' only %&rbrace;
+		</code>
+		{% include "blog/blog_card.html" with post=blog_page size="small" only %}
+
+		<h4 class="heading-regular">Blog Card (Small, Photo)</h4>
+		<code>
+            &lbrace;% include 'blog/blog_card.html' with post=blog_page size='small' photo=incident.teaser_image only %&rbrace;
+		</code>
+		{% include "blog/blog_card.html" with post=blog_page size="small" photo=blog_page.teaser_image only %}
 	</details>
 
 	<hr/>

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -4,6 +4,7 @@ from django.views.generic import TemplateView
 
 from common.devdata import CommonTagFactory
 from incident.devdata import MultimediaIncidentPageFactory, InstitutionFactory, TargetedJournalistFactory, IncidentCategorizationFactory
+from blog.tests.factories import BlogPageFactory
 
 
 class StyleguideView(TemplateView):
@@ -33,5 +34,8 @@ class StyleguideView(TemplateView):
             incident_page=None,
         )
         context['incident'] = inc
+
+        blog_page = BlogPageFactory.build(with_image=True)
+        context['blog_page'] = blog_page
 
         return context


### PR DESCRIPTION
This PR adds blog card components mostly based off of the model already established by the incident card components. I have added some additional helper styles for the images so that they don't end up on the same line as the card title when the width of the card is very wide (which might not happen anywhere besides the styleguide, but it's good to be prepared).

The component is demonstrated in the styleguide as well.