### PR TITLE
Remove internal fields from incident export data

### DIFF
--- a/incident/models/export.py
+++ b/incident/models/export.py
@@ -49,6 +49,9 @@ EXCLUDED_FIELDS = {
     'unique_date',
     'lawsuit_name',  # Deprecated
     'venue',  # Deprecated
+    'index_entries',
+    'subscribers',
+    'wagtail_admin_comments',
 }
 
 

--- a/incident/tests/test_incidents_export.py
+++ b/incident/tests/test_incidents_export.py
@@ -121,9 +121,6 @@ class IncidentExportTestCase(TestCase):
             'politicians_or_public_figures_involved',
             'longitude',
             'latitude',
-            'index_entries',
-            'wagtail_admin_comments',
-            'subscribers',
         }
         self.assertEqual(headers, expected_headers)
 

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -159,7 +159,7 @@ class TestExportPage(TestCase):
         csv_line = next(reader)
         # Last elem in these lists is GenericRelatedObjectManager which will have different
         # IDs
-        self.assertEqual(to_row(inc)[:-1], csv_line[:-1])
+        self.assertEqual(to_row(inc), csv_line)
         for line in content_lines:
             self.assertNotIn('Unpublished incident', line.decode('utf-8'))
 


### PR DESCRIPTION
Fixes a change to the incident export data introduced in #1190