### PR TITLE
Correct error in test assertion

### DIFF
--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -71,7 +71,7 @@ class TestCategoryFieldValuesByField(TestCase):
         value = getattr(self.incident, field_name)
         self.assertIn(f'{field_name}_upper={value:%Y-%m-%d}', output)
         self.assertIn(f'{field_name}_lower={value:%Y-%m-%d}', output)
-        self.assertIn(f'{value:%B %-m, %Y}', output)
+        self.assertIn(f'{value:%B %-d, %Y}', output)
         setattr(self.incident, field_name, None)
         self.assertEqual(render_function(self.incident, field_name), '')
 


### PR DESCRIPTION
Fixes a date-formatting problem in a test assertion.

The only reason this ever passed is that it was written on the second day of the second month :sweat_smile: 