### PR TITLE
Add setting to toggle the django debug toolbar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,18 @@ Second, attach to the running Django container.  This must be done in a shell, a
 
 Once you have done this, you can load the page that will run the code with your ``import ipdb`` and the debugger will activate in the shell you attached.  To detach from the shell without stopping the container press ``Control+P`` followed by ``Control+Q``.
 
+Debug Toolbar
++++++++++++++
+
+Another debugging aid is the `django debug toolbar <https://django-debug-toolbar.readthedocs.io/en/latest/index.html>`_
+It is disabled by default for performance reasons.  To enable it, add
+
+.. code:: python
+
+    ENABLE_DEBUG_TOOLBAR = True
+
+To ``tracker/settings/local.py`` (you may need to create this file if it does not exist in your local working copy).  After reloading the page, there should be a tab in the upper-right corner of the page to open the toolbar.
+
 
 Profiling
 ---------

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage>=5.5
 django-cprofile-middleware
-django-debug-toolbar>=2.2.1
+django-debug-toolbar>=3.2.4
 django-silk
 flake8
 ipdb>=0.13.9

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -240,9 +240,9 @@ django-csp==3.7 \
     --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
     --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
     # via -r requirements.txt
-django-debug-toolbar==3.2.2 \
-    --hash=sha256:8c5b13795d4040008ee69ba82dcdd259c49db346cf7d0de6e561a49d191f0860 \
-    --hash=sha256:d7bab7573fab35b0fd029163371b7182f5826c13da69734beb675c761d06a4d3
+django-debug-toolbar==3.2.4 \
+    --hash=sha256:644bbd5c428d3283aa9115722471769cac1bec189edf3a0c855fd8ff870375a9 \
+    --hash=sha256:6b633b6cfee24f232d73569870f19aa86c819d750e7f3e833f2344a9eb4b4409
     # via -r dev-requirements.in
 django-filter==2.4.0 \
     --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -29,6 +29,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 DEBUG = False
 STYLEGUIDE = False
+ENABLE_DEBUG_TOOLBAR = False
 
 # Application definition
 

--- a/tracker/settings/dev.py
+++ b/tracker/settings/dev.py
@@ -132,6 +132,22 @@ if DEBUG:
         MIDDLEWARE.append('django_cprofile_middleware.middleware.ProfilerMiddleware')
         DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF = False
 
+    # Disable caching of webpack stats files (can prevent node/django
+    # container race condition).
+    WEBPACK_LOADER['DEFAULT']['CACHE'] = False  # noqa: F405
+
+    # Include the wagtail styleguide
+    INSTALLED_APPS.append('wagtail.contrib.styleguide')  # noqa: F405
+
+
+if ENABLE_DEBUG_TOOLBAR:  # noqa: F405
+    # Obtain the default gateway from docker, needed for
+    # debug toolbar whitelisting
+    INTERNAL_IPS = [get_default_gateway_linux()]
+    INSTALLED_APPS.append('debug_toolbar')  # noqa: F405
+    # Needs to be injected relatively early in the MIDDLEWARE list
+    MIDDLEWARE.insert(4, 'debug_toolbar.middleware.DebugToolbarMiddleware')  # noqa: F405
+
     # Fix for https://github.com/jazzband/django-debug-toolbar/issues/950
     DEBUG_TOOLBAR_CONFIG = {
         'SKIP_TEMPLATE_PREFIXES': (
@@ -145,19 +161,6 @@ if DEBUG:
             'debug_toolbar.panels.redirects.TemplatesPanel'
         },
     }
-
-    # Disable caching of webpack stats files (can prevent node/django
-    # container race condition).
-    WEBPACK_LOADER['DEFAULT']['CACHE'] = False  # noqa: F405
-
-    # Obtain the default gateway from docker, needed for
-    # debug toolbar whitelisting
-    INTERNAL_IPS = [get_default_gateway_linux()]
-    INSTALLED_APPS.append('debug_toolbar')  # noqa: F405
-    # Needs to be injected relatively early in the MIDDLEWARE list
-    MIDDLEWARE.insert(4, 'debug_toolbar.middleware.DebugToolbarMiddleware')  # noqa: F405
-    # Include the wagtail styleguide
-    INSTALLED_APPS.append('wagtail.contrib.styleguide')  # noqa: F405
 
 
 if 'DJANGO_NO_DB' in os.environ:

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -34,8 +34,6 @@ urlpatterns = [
 
     path('health/ok/', common_views.health_ok),
     path('health/version/', common_views.health_version),
-
-    path(r'', include(wagtail_urls)),
 ]
 
 
@@ -47,18 +45,15 @@ if settings.DEBUG:
     urlpatterns = staticfiles_urlpatterns() + urlpatterns
     urlpatterns = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + urlpatterns
 
-    # Debugtoolbar isnt always installed in prod, but sometimes i need to
-    # toggle debug mode there.
-    try:
-        import debug_toolbar
-        urlpatterns = [path('styleguide/', include('styleguide.urls')),
-                       path('__debug__/', include(debug_toolbar.urls))
-                       ] + urlpatterns
-    except ImportError:
-        pass
+
+if settings.ENABLE_DEBUG_TOOLBAR:
+    urlpatterns.append(path('__debug__/', include('debug_toolbar.urls')))
+
 
 if settings.STYLEGUIDE:
     urlpatterns = [path('styleguide/', include('styleguide.urls'))] + urlpatterns
 
 if apps.is_installed('silk'):
     urlpatterns = [path('silk/', include('silk.urls', namespace='silk'))] + urlpatterns
+
+urlpatterns.append(path(r'', include(wagtail_urls)))


### PR DESCRIPTION
This pull request updates the version of the django debug toolbar, disables it by default, and provides a setting to turn it on locally.

Fixes #1213 