### PR TITLE
Horizontal incident cards

### DIFF
--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -32,3 +32,5 @@
 @import components/media
 @import components/quote
 @import components/aside
+@import components/incident-index
+@import components/incident-database-card

--- a/client/common/sass/components/_details-table.sass
+++ b/client/common/sass/components/_details-table.sass
@@ -1,6 +1,5 @@
 .details-table
 	position: relative
-	+constrain-to-desktop
 
 	&__incident-details
 		margin-top: 0

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -29,6 +29,10 @@
 		margin-top: 0
 		margin-bottom: 0
 
+	&__category-details
+		margin-top: 0
+		margin-bottom: 0
+
 	&__row
 		padding: 0.5rem 0
 		border-bottom: 1px solid
@@ -41,6 +45,15 @@
 		+desktop-up
 			padding: 0.25rem 2rem
 			border: none
+
+		&--inline
+			display: block
+			padding-left: 19px
+
+			dt, dd
+				margin-right: 0.25rem
+				display: inline
+				white-space: normal
 
 	&__label
 		font-size: $font-size-small-p
@@ -66,10 +79,13 @@
 		margin: 0
 		border-bottom: 1px solid
 		border-color: $black
-		padding: 0.25rem 2rem
+		padding: 0.25rem 0
 
 		+tablet-down
 			padding: 0.5rem 0
+
+		+desktop-up
+			border-bottom: none
 
 	.details-toggle-btn
 		position: absolute

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -3,9 +3,10 @@
 	border-bottom: solid 1px
 	border-color: $black
 	display: flex
-	gap: 2rem
+	flex-direction: column
 
 	+desktop-up
+		gap: 2rem
 		flex-direction: row
 
 	&__section

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -7,9 +7,17 @@
 	+desktop-up
 		flex-direction: row
 
+	&__section
+		flex: 1 1
+
+	&__tags
+		line-height: 2.2
+
 	&__details
 		margin-top: 1rem
 		margin-bottom: 1rem
+		+desktop-up
+			flex: 2 0
 
 	&__details-title
 		+desktop-up
@@ -17,9 +25,13 @@
 
 	&__details-container
 		display: flex
+		flex-wrap: wrap
 
 		+desktop-up
 			flex-direction: row
+
+	&__category-details
+		min-width: 300px
 
 
 .database-card-table
@@ -43,11 +55,11 @@
 			align-items: center
 
 		+desktop-up
-			padding: 0.25rem 2rem
+			padding: 0.25rem 0 0 0
 			border: none
 
 		&--inline
-			display: block
+			//display: block
 			padding-left: 19px
 
 			dt, dd
@@ -79,7 +91,7 @@
 		margin: 0
 		border-bottom: 1px solid
 		border-color: $black
-		padding: 0.25rem 0
+		padding: 0.25rem 0 0 0
 
 		+tablet-down
 			padding: 0.5rem 0

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -1,7 +1,7 @@
 .incident-database-card
 	padding-bottom: 0.5rem
-	border-bottom: solid 1px $black
-
+	border-bottom: solid 1px
+	border-color: $black
 	display: flex
 
 	+desktop-up
@@ -32,7 +32,6 @@
 
 	&__category-details
 		min-width: 300px
-
 
 .database-card-table
 	position: relative
@@ -91,7 +90,7 @@
 		margin: 0
 		border-bottom: 1px solid
 		border-color: $black
-		padding: 0.25rem 0 0 0
+		padding: 0.25rem 0 0
 
 		+tablet-down
 			padding: 0.5rem 0

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -3,6 +3,7 @@
 	border-bottom: solid 1px
 	border-color: $black
 	display: flex
+	gap: 2rem
 
 	+desktop-up
 		flex-direction: row
@@ -16,6 +17,7 @@
 	&__details
 		margin-top: 1rem
 		margin-bottom: 1rem
+		flex: 1
 		+desktop-up
 			flex: 2 0
 
@@ -26,12 +28,16 @@
 	&__details-container
 		display: flex
 		flex-wrap: wrap
+		gap: 2rem
 
 		+desktop-up
 			flex-direction: row
 
+	&__main-details
+		flex: 1
+
 	&__category-details
-		min-width: 300px
+		flex: 1
 
 .database-card-table
 	position: relative

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -1,0 +1,92 @@
+.incident-database-card
+	padding-bottom: 0.5rem
+	border-bottom: solid 1px $black
+
+	display: flex
+
+	+desktop-up
+		flex-direction: row
+
+	&__details
+		margin-top: 1rem
+		margin-bottom: 1rem
+
+	&__details-title
+		+desktop-up
+			display: none
+
+	&__details-container
+		display: flex
+
+		+desktop-up
+			flex-direction: row
+
+
+.database-card-table
+	position: relative
+
+	&__incident-details
+		margin-top: 0
+		margin-bottom: 0
+
+	&__row
+		padding: 0.5rem 0
+		border-bottom: 1px solid
+		border-color: $gray-text
+
+		+tablet-up
+			display: flex
+			align-items: center
+
+		+desktop-up
+			padding: 0.25rem 2rem
+			border: none
+
+	&__label
+		font-size: $font-size-small-p
+		line-height: 1.43
+		white-space: nowrap
+		margin-right: 1rem
+
+		&--bold
+			font-weight: 700
+
+	&__value
+		margin-left: 0
+		font-size: $font-size-small-p
+		white-space: nowrap
+		line-height: 1.43
+
+	&__list
+		list-style-type: none
+		margin: 0
+		padding: 0
+
+	.heading-table
+		margin: 0
+		border-bottom: 1px solid
+		border-color: $black
+		padding: 0.25rem 2rem
+
+		+tablet-down
+			padding: 0.5rem 0
+
+	.details-toggle-btn
+		position: absolute
+		top: 6px
+		right: 24px
+
+		+desktop-up
+			display: none
+
+	.database-card-toggle-btn
+		+desktop-up
+			display: none
+
+	&__container
+		+tablet-down
+			&[data-visible='false']
+				display: none
+
+			&[data-visible='true']
+				display: block

--- a/client/common/sass/components/_incident-index.sass
+++ b/client/common/sass/components/_incident-index.sass
@@ -1,0 +1,2 @@
+.incident-index
+	+constrain-to-desktop

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -777,7 +777,7 @@ class IncidentPage(MetadataPageMixin, Page):
     def get_category_details(self):
         category_details = {}
         for category in self.categories.all():
-            category_fields = CATEGORY_FIELD_MAP[category.category.slug]
+            category_fields = CATEGORY_FIELD_MAP.get(category.category.slug, [])
             category_details[category.category] = []
             for field in category_fields:
                 display_html = CAT_FIELD_VALUES[field[0]](self, field[0])

--- a/incident/templates/incident/_database_card_details.html
+++ b/incident/templates/incident/_database_card_details.html
@@ -1,0 +1,18 @@
+<section class="incident-database-card__details database-card-table">
+	<button class="disclose-summary database-card-toggle-btn" aria-expanded="false" aria-controls="incident-details" id="details-toggle-btn">Show More</button>
+	<div class="incident-database-card__details-container database-card-table__container" id="incident-details" data-visible="false">
+		<div>
+		<h3 class="heading-table incident-database-card__details-title" id="incident-details-title">Incident Details</h3>
+
+		{% include "incident/_database_card_table.html" with incident=incident only %}
+		</div>
+
+		<div>
+		{% for category, category_detail in incident.get_category_details.items %}
+			{% if category_detail %}
+				{% include "incident/_category_table.html" with category=category category_detail=category_detail only %}
+			{% endif %}
+		{% endfor %}
+		</div>
+	</div>
+</section>

--- a/incident/templates/incident/_database_card_details.html
+++ b/incident/templates/incident/_database_card_details.html
@@ -1,18 +1,42 @@
 <section class="incident-database-card__details database-card-table">
-	<button class="disclose-summary database-card-toggle-btn" aria-expanded="false" aria-controls="incident-details" id="details-toggle-btn">Show More</button>
+	<button
+		class="disclose-summary database-card-toggle-btn"
+		aria-expanded="false"
+		aria-controls="incident-details"
+		id="details-toggle-btn"
+	>
+		Show More
+	</button>
 	<div class="incident-database-card__details-container database-card-table__container" id="incident-details" data-visible="false">
-		<div>
-		<h3 class="heading-table incident-database-card__details-title" id="incident-details-title">Incident Details</h3>
+		<div class="incident-database-card__main-details">
+			<h3 class="heading-table incident-database-card__details-title" id="incident-details-title">Incident Details</h3>
 
-		{% include "incident/_database_card_table.html" with incident=incident only %}
+			{% include "incident/_database_card_table.html" with incident=incident only %}
 		</div>
 
-		<div>
-		{% for category, category_detail in incident.get_category_details.items %}
-			{% if category_detail %}
-				{% include "incident/_category_table.html" with category=category category_detail=category_detail only %}
-			{% endif %}
-		{% endfor %}
+		<div class="incident-database-card__category-details">
+				{% for category, category_detail in incident.get_category_details.items %}
+				{% if category_detail %}
+					<dl class="database-card-table__category-details" aria-labelledby="{{ category.slug }}-details-title">
+						<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">
+							{{ category.title }}
+						</h3>
+
+						{% for detail in category_detail %}
+							{% if detail.html %}
+								<div class="database-card-table__row database-card-table__row--inline">
+									<dt class="database-card-table__label">
+										{{ detail.name }} &rarr;
+									</dt>
+									<dd class="database-card-table__value">
+										{{ detail.html | safe }}
+									</dd>
+								</div>
+							{% endif %}
+						{% endfor %}
+					</dl>
+				{% endif %}
+			{% endfor %}
 		</div>
 	</div>
 </section>

--- a/incident/templates/incident/_database_card_table.html
+++ b/incident/templates/incident/_database_card_table.html
@@ -1,0 +1,89 @@
+{% load wagtailcore_tags case_tags %}
+
+<dl class="database-card-table__incident-details" aria-labelledby="incident-details-title">
+	{% with incident.last_updated as last_updated %}
+		{% if last_updated and incident.updates.all.exists %}
+			<div class="database-card-table__row">
+				<dt class="database-card-table__label database-card-table__label--bold">
+					Updated On
+				</dt>
+				<dd class="database-card-table__value">
+					{{ last_updated|date:"F j, Y" }}
+				</dd>
+			</div>
+		{% endif %}
+	{% endwith %}
+
+	<div class="database-card-table__row">
+		<dt class="database-card-table__label database-card-table__label--bold">
+			Date of Incident
+		</dt>
+		<dd class="database-card-table__value">
+			<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?date_lower={{ incident.date|date:'Y-m-d' }}&date_upper={{ incident.date|date:'Y-m-d' }}{% endif %}" class="text-link">
+				{% if incident.exact_date_unknown %}
+					{{ incident.date|date:"F Y" }}
+				{% else %}
+					{{ incident.date|date:"F j, Y" }}
+				{% endif %}
+			</a>
+		</dd>
+	</div>
+
+	{% if incident.city or incident.state %}
+		<div class="database-card-table__row">
+			<dt class="database-card-table__label database-card-table__label--bold">
+				Location
+			</dt>
+			<dd class="database-card-table__value">
+				{% if incident.city %}
+					<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?city={{ incident.city }}{% endif %}" class="text-link">
+						{{ incident.city }}</a>{% if incident.state %},{% endif %}
+				{% endif %}
+				{% if incident.state %}
+					<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?state={{ incident.state.pk }}{% endif %}" class="text-link">{{ incident.state.name }}</a>
+				{% endif %}
+			</dd>
+		</div>
+	{% endif %}
+
+	{% if incident.case_number %}
+		<div class="database-card-table__row">
+			<dt class="database-card-table__label database-card-table__label--bold">
+				Case number
+			</dt>
+			<dd class="database-card-table__value">
+				<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_number={{ incident.case_number }}{% endif %}">
+					{{ incident.case_number }}
+				</a>
+			</dd>
+		</div>
+	{% endif %}
+
+	{% if incident.case_statuses|length > 0 %}
+		<div class="database-card-table__row">
+			<dt class="database-card-table__label database-card-table__label--bold">
+				Case Status
+			</dt>
+			<dd class="database-card-table__value">
+				{% for case_status in incident.case_statuses %}
+					<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_statuses={{ case_status }}{% endif %}">
+						{% get_case_status_display case_status as case_status_display_name %}
+						{{ case_status_display_name|capfirst }}</a>{% if not forloop.last %}, {% endif %}
+				{% endfor %}
+			</dd>
+		</div>
+	{% endif %}
+
+	{% if incident.case_type %}
+		<div class="database-card-table__row">
+			<dt class="database-card-table__label database-card-table__label--bold">
+				Type of case
+			</dt>
+			<dd class="database-card-table__value">
+				<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_type={{ incident.case_type }}{% endif %}">
+					{{ incident.case_type }}
+				</a>
+			</dd>
+		</div>
+	{% endif %}
+</dl>

--- a/incident/templates/incident/_details_table.html
+++ b/incident/templates/incident/_details_table.html
@@ -6,8 +6,10 @@
 	<div class="details-table__container" id="incident-details" data-visible="false">
 		{% include "incident/_incident_details_table.html" with incident=incident only %}
 
-		{% for category, category_detail in category_details.items %}
-			{% include "incident/_category_table.html" with category=category category_detail=category_detail only %}
+		{% for category, category_detail in incident.get_category_details.items %}
+			{% if category_detail %}
+				{% include "incident/_category_table.html" with category=category category_detail=category_detail only %}
+			{% endif %}
 		{% endfor %}
 	</div>
 </section>

--- a/incident/templates/incident/_incident_database_card.html
+++ b/incident/templates/incident/_incident_database_card.html
@@ -7,7 +7,7 @@
 			{{ incident.title }}
 		</h3>
 		{% if incident.tags.all %}
-			<ul class="tag-list">
+			<ul class="incident-database-card__tags tag-list">
 				{% for tag in incident.tags.all %}
 					<li><a href="#" class="btn btn-tag">#{{ tag.title }}</a></li>
 				{% endfor %}

--- a/incident/templates/incident/_incident_database_card.html
+++ b/incident/templates/incident/_incident_database_card.html
@@ -1,0 +1,19 @@
+<article class="incident-database-card">
+	<div class="incident-database-card__section">
+		<h3 class="card-title-database">
+			{% for cat in incident.categories.all %}
+				<span class="category category-{{ cat.category.page_symbol }}"></span>
+			{% endfor %}
+			{{ incident.title }}
+		</h3>
+		{% if incident.tags.all %}
+			<ul class="tag-list">
+				{% for tag in incident.tags.all %}
+					<li><a href="#" class="btn btn-tag">#{{ tag.title }}</a></li>
+				{% endfor %}
+			</ul>
+		{% endif %}
+	</div>
+
+	{% include "incident/_database_card_details.html" with incident=incident only %}
+</article>

--- a/incident/templates/incident/_incident_details_table.html
+++ b/incident/templates/incident/_incident_details_table.html
@@ -37,8 +37,7 @@
 		<dd class="details-table__value">
 			{% if incident.city %}
 				<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?city={{ incident.city }}{% endif %}" class="text-link">
-					{{ incident.city }}{% if incident.state %},{% endif %}
-				</a>
+					{{ incident.city }}</a>{% if incident.state %},{% endif %}
 			{% endif %}
 			{% if incident.state %}
 				<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?state={{ incident.state.pk }}{% endif %}" class="text-link">{{ incident.state.name }}</a>

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -2,8 +2,10 @@
 
 {% load webpack_loader %}
 
-{% block body %}
-	{% for incident in entries_page %}
-		{% include "incident/_incident_card.html" with incident=incident size="small" photo=incident.teaser_image only %}
-	{% endfor %}
+{% block main %}
+	<section class="incident-index">
+		{% for incident in entries_page %}
+			{% include "incident/_incident_database_card.html" with incident=incident only %}
+		{% endfor %}
+	</section>
 {% endblock %}

--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -299,6 +299,20 @@ class TestCategoryFieldValuesByField(TestCase):
         )
 
 
+class CategoryFieldValuesCompleteness(TestCase):
+    def test_all_categories_provide_details(self):
+        index = IncidentIndexPageFactory()
+        for category_name in IncidentPageFactory._meta.parameters.keys():
+            with self.subTest(category_name=category_name):
+                category = CategoryPageFactory(**{category_name: True})
+                incident = IncidentPageFactory(
+                    parent=index,
+                    categories=[category])
+
+                # Should succeed without errors
+                incident.get_category_details()
+
+
 class CategoryFieldValues(TestCase):
     """Category values"""
     def setUp(self):

--- a/incident/utils/category_field_values.py
+++ b/incident/utils/category_field_values.py
@@ -199,7 +199,7 @@ def subpoena_type_html_val(page, field):
 
 
 def subpoena_statuses_html_val(page, field):
-    if not len(getattr(page, field)):
+    if not getattr(page, field):
         return ''
 
     html = []


### PR DESCRIPTION
Resolves #1217 

This PR adds horizontal incident database cards as specified in the issue. Some thoughts:

1. I've tried to get the spacing on the lines to match the design as much as possible, but it's going to depend on the exact content.
2. A lot of the design for this card is similar to, but does not exactly match, the details table component. Rather than try to abstract out those styles and markup, I've basically duplicated that code and changed what needed to be changed. I don't really have a problem with this strategy but if there's a more "elegant" way of doing it, I'd be interested to learn it.
3. That said, I did make some changes to the details table prior to duplicating that code, cleaning up some rough edges, basically.
4. I found that our definition of what a "desktop" view might be a little different than what the design shows. We consider anything viewport with width greater than 768px to be a desktop. This is probably fine (though according to Firefox an iPad has a width of 810px?) but the desktop design for these cards has a width of roughly 1050 pixels, and as you shrink down to 800 or 900 pixels it starts to look a little cramped, so I made an executive decision to modify the layout and "stack" the main incident details and the category details tables if there's not enough room to show them comfortably side-by-side. It looks a little like this:
![image](https://user-images.githubusercontent.com/561931/152863499-286e77ba-c0dc-432c-a339-39c5636b72ed.png)
5. It's not clear to me if these cards as a whole are supposed to be links. If so, I'll need to modify them a little bit to reflect that.