### PR TITLE
Database page sorting

### DIFF
--- a/client/common/icons/check.svg
+++ b/client/common/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="11" viewBox="0 0 14 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 4.31368L5.78049 9.49887L13.5 0.5" stroke="white"/>
+</svg>

--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -15,7 +15,17 @@
 		margin-top: 0
 
 	&__title-link
+		color: $black
 		text-decoration: none
+
+		&:hover
+			text-decoration: underline
+
+		&:focus
+			outline-width: 0
+			display: inline-block
+			border: 3px solid
+			border-color: $black
 
 	&__section
 		flex: 1 1

--- a/client/common/sass/components/_incident-index.sass
+++ b/client/common/sass/components/_incident-index.sass
@@ -136,6 +136,11 @@
 	text-decoration: none
 	font-size: $font-size-p
 
+	&--selected::before
+		content: url(../icons/check.svg)
+		position: absolute
+		left: 0.5rem
+
 .incident-index__sort-selection
 	display: none
 

--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -199,6 +199,15 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
         context['entries_page'] = entries
         context['paginator'] = paginator
         context['summary_table'] = incident_filter.get_summary()
+
+        get_data = request.GET.copy()
+        context['sort_choices'] = []
+        for value, label in IncidentFilter.SortOptions.choices:
+            get_data['sort'] = value
+            context['sort_choices'].append(
+                (get_data.urlencode(), label, value == incident_filter.sort.value)
+            )
+        context['selected_sort'] = incident_filter.sort
         context['incident_count'] = len(incident_qs)
 
         if request.is_ajax():

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -36,6 +36,21 @@
 		</div>
 	</section>
 	<section class="incident-index__body">
+
+
+		<div id="database-filters" class="incident-index__filters" data-visible="false">
+			<div class="incident-index__filters-wrapper">
+				{% include 'incident/_filters.html' %}
+			</div>
+			<div class="incident-index__filters-mobile-controls">
+				<a class="incident-index__filters-mobile-clear" href="{{ page.url }}">Clear All</a>
+				</button>
+				<button class="btn btn-secondary">
+					Show {{ incident_count|intcomma }} incidents
+				</button>
+			</div>
+		</div>
+
 		<div class="incident-index__body-header">
 			<div class="incident-index__body-header-controls">
 				<p class="paragraph-subtitle">
@@ -69,20 +84,6 @@
 			<div class="incident-index__column-header incident-index__column-header--incident">Incident</div>
 			<div class="incident-index__column-header incident-index__column-header--incident-details">Incident Details</div>
 			<div class="incident-index__column-header incident-index__column-header--category-details">Category Details</div>
-			</div>
-		</div>
-
-		<div id="database-filters" class="incident-index__filters" data-visible="false">
-			<div class="incident-index__filters-wrapper">
-				{% include 'incident/_filters.html' %}
-			</div>
-			<div class="incident-index__filters-mobile-controls">
-				<a class="incident-index__filters-mobile-clear" href="{{ page.url }}">Clear All</a>
-				</button>
-				<button class="btn btn-secondary">
-					Show {{ incident_count|intcomma }} incidents
-				</button>
-			</div>
 		</div>
 
 		<div class="incident-index__results">

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -45,7 +45,7 @@
 					<summary class="btn incident-index__sort-button">
 						Sort by
 						<div>
-							&udarr; <span class="incident-index__sort-selection">Newest incident date</span>
+							&udarr; <span class="incident-index__sort-selection">{{ selected_sort.label }}</span>
 						</div>
 					</summary>
 					<div class="incident-index__sort-menu">
@@ -56,15 +56,11 @@
 								</h3>
 							</header>
 							<div class="incident-index__sort-list">
-								<button class="incident-index__sort-item">
-									Recently updated
-								</button>
-								<button class="incident-index__sort-item">
-									Newest incident date
-								</button>
-								<button class="incident-index__sort-item">
-									Oldest incident date
-								</button>
+								{% for choice in sort_choices %}
+									<a class="incident-index__sort-item{% if choice.2 %} incident-index__sort-item--selected{% endif %}" href="?{{ choice.0 }}">
+										{{ choice.1 }}
+									</a>
+								{% endfor %}
 							</div>
 						</div>
 					</div>

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -16,8 +16,10 @@ from django.db.models import (
     ManyToManyField,
     OuterRef,
     PositiveSmallIntegerField,
+    F,
     Q,
     Subquery,
+    TextChoices,
     TextField,
     Value,
 )
@@ -590,6 +592,11 @@ class IncidentFilter(object):
         'latitude',
     }
 
+    class SortOptions(TextChoices):
+        RECENTLY_UPDATED = 'RECENTLY_UPDATED', 'Recently updated'
+        NEWEST_DATE = 'NEWEST', 'Newest incident date'
+        OLDEST_DATE = 'OLDEST', 'Oldest incident date'
+
     def __init__(self, data):
         self.data = data
         self.cleaned_data = None
@@ -690,6 +697,17 @@ class IncidentFilter(object):
             self.search_filter,
         ]
 
+        # Extract sort choice from data.
+        sort_data = self.data.get('sort')
+        if sort_data:
+            try:
+                self.sort = self.SortOptions(sort_data)
+            except ValueError:
+                self.sort = self.SortOptions.NEWEST_DATE
+                errors.append(f'Invalid sort option: "{sort_data}"')
+        else:
+            self.sort = self.SortOptions.NEWEST_DATE
+
         # Collect filters for categories. If categories are selected,
         # use their filters; otherwise use filters for all categories.
         # Clean categories first so that we can check for category ids.
@@ -740,7 +758,7 @@ class IncidentFilter(object):
         # If strict is true, validate that all given filters are valid
         # and raise ValidationError if there are any errors.
         if strict:
-            allowed_parameters = set()
+            allowed_parameters = {'sort'}
             for f in self.filters:
                 allowed_parameters |= f.get_allowed_parameters()
 
@@ -792,10 +810,21 @@ class IncidentFilter(object):
             if cleaned_value is not None:
                 queryset = f.filter(queryset, cleaned_value)
 
+        queryset = self._sort_queryset(queryset)
         return queryset.distinct()
 
     def get_queryset(self):
-        return self._get_queryset().order_by('-date', 'path').distinct()
+        return self._get_queryset().distinct()
+
+    def _sort_queryset(self, queryset):
+        if self.sort == self.SortOptions.OLDEST_DATE:
+            return queryset.order_by('date', 'path')
+        elif self.sort == self.SortOptions.RECENTLY_UPDATED:
+            return queryset.with_most_recent_update().order_by(
+                F('latest_update').desc(nulls_last=True)
+            )
+        else:
+            return queryset.order_by('-date', 'path')
 
     def get_summary(self):
         """


### PR DESCRIPTION
Part of #1220 
This branch is based off https://github.com/freedomofpress/pressfreedomtracker.us/tree/database-page-layout and should be merged after #1249 

This PR adds search functionality to the incident filters code and hooks that up to the database page sort dropdown menu via HTML links and directly managing the query-string parameters for those links. This enables it to work without javascript.