### PR TITLE
Adds skiplink and title id to all h1

### DIFF
--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -4,7 +4,7 @@
 
 {% block main %}
 
-	<h1 class="page-title">
+	<h1 class="page-title" id="title">
 		Blog
 	</h1>
 

--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 
 {% block main %}
-	<h1 class="article-title">{{ page.title }}</h1>
+	<h1 class="article-title" id="title">{{ page.title }}</h1>
 
 	<article class="article-content">
 		<!-- Details table-->

--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -4,6 +4,7 @@
 @import grid
 
 @import components/sr-only
+@import components/skip-link
 @import components/page-title
 @import components/article-carousel
 @import components/article-title

--- a/client/common/sass/components/_skip-link.sass
+++ b/client/common/sass/components/_skip-link.sass
@@ -1,0 +1,23 @@
+.skip-link
+	position: absolute
+	background: $black
+	padding: 1.5rem 3rem
+	font-weight: 700
+	line-height: 1
+	z-index: 1011
+
+	&:link,
+	&:visited
+		color: $white
+		text-decoration: none
+
+	&:not(:focus)
+		white-space: nowrap
+		width: 1px
+		height: 1px
+		overflow: hidden
+		border: 0
+		padding: 0
+		clip: rect(0 0 0 0)
+		clip-path: inset(50%)
+		margin: -1px

--- a/common/templates/common/_menu.html
+++ b/common/templates/common/_menu.html
@@ -1,3 +1,4 @@
+<a href="#title" class="skip-link">Skip to content</a>
 <header class="header">
 	<a class="site-title-link text-link" href="/">
 		U.S Press Freedom Tracker

--- a/common/templates/common/simple_page.html
+++ b/common/templates/common/simple_page.html
@@ -3,7 +3,7 @@
 {% load wagtailcore_tags %}
 
 {% block main %}
-    <h1 class="page-title">{{ page.title }}</h1>
+    <h1 class="page-title" id="title">{{ page.title }}</h1>
 
     <section class="simplepage-body">
 

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -3,7 +3,7 @@
 {% load pageurl richtext from wagtailcore_tags %}
 {% block main %}
 
-	<h1 class="page-title">
+	<h1 class="page-title" id="title">
 		The U.S. Press Freedom Tracker
 	</h1>
 

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -3,7 +3,7 @@
 {% load webpack_loader humanize %}
 
 {% block main %}
-	<h1 class="page-title">Incidents Database</h1>
+	<h1 class="page-title" id="title">Incidents Database</h1>
 	<button class="mobile-filter-toggle" aria-controls="database-filters" aria-expanded="false">
 		Filters
 	</button>

--- a/incident/templates/incident/incident_page.html
+++ b/incident/templates/incident/incident_page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block main %}
-	<h1 class="category category-{{ main_category.page_symbol }} article-title">{{ page.title }}</h1>
+	<h1 class="category category-{{ main_category.page_symbol }} article-title" id="title">{{ page.title }}</h1>
 
 	<section class="incident-tags">
 		{% include 'incident/_incident_tags.html' with incident=page %}


### PR DESCRIPTION
For testing, load any of the pages, press tab, and "Skip to content" button should appear. Unless tabbed, it stays hidden. When tabbed, it's the first focusable item. All the "Skip to content" buttons link to `#title`. I have added `id="title"` in all the `<h1>` tags in the page templates. The purpose of this link is to skip through the links in the menu and jump to the content. This is a [WCAG AA requirement](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html)