### PR TITLE
Fixes category block hover effect in homepage

### DIFF
--- a/client/common/sass/components/_categories-block.sass
+++ b/client/common/sass/components/_categories-block.sass
@@ -17,6 +17,6 @@
 		margin-top: -3px
 		font-weight: 700
 
-	&:hover
-		span::before
-			filter: invert(1)
+		&:hover
+			span::before
+				filter: invert(1)


### PR DESCRIPTION
After I updated the category icons in the redesign website, I noticed that the category block section was showing some weird hover effects. The icons were inverting color on hovering the parent block instead of the individual link items. Updated the sass to invert icon color on hovering an individual category link instead of the entire parent block.