### PR TITLE
Improve docker signal handling

### DIFF
--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -24,4 +24,4 @@ RUN mkdir /django-logs /deploy && \
 
 EXPOSE 8000
 USER ${USERID}
-CMD django-start.sh
+CMD [ "django-start.sh" ]

--- a/devops/docker/django-start.sh
+++ b/devops/docker/django-start.sh
@@ -32,7 +32,7 @@ django_start() {
     fi
     if [ "${DEPLOY_ENV}" == "dev" ]; then
         ./devops/scripts/version-file.sh
-        ./manage.py runserver 0.0.0.0:8000
+        exec ./manage.py runserver 0.0.0.0:8000
     else
         gunicorn -c /etc/gunicorn/gunicorn.py "${DJANGO_APP_NAME}.wsgi"
     fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ networks:
 services:
   postgresql:
     image: postgres:13
+    init: true
     ports:
       - "127.0.0.1::5432"
     volumes:
@@ -29,6 +30,7 @@ services:
           - selenium
 
   node:
+    init: true
     build:
       context: .
       dockerfile: devops/docker/NodeDockerfile
@@ -43,6 +45,7 @@ services:
       - app
 
   django:
+    init: true
     stdin_open: true
     tty: true
     build:


### PR DESCRIPTION
This pull request makes some changes to our development docker configuration that improves how our setup handles signals sent to it, specifically SIGTERM. The purpose of this is to improve graceful shutdown of our containers.

Before these changes, on my system, `docker-compose` took about 10 seconds to stop, and with these changes it takes about one second. I tested this by running `docker-compose up`, then opening another terminal and running `time docker-compose stop` there. 

See commit messages for further documentation and information about specifically what was changed.