### PR TITLE
Fixes recent incidents regression in style

### DIFF
--- a/client/common/sass/components/_article-carousel.sass
+++ b/client/common/sass/components/_article-carousel.sass
@@ -33,3 +33,14 @@
 
 		+mobile-down
 			flex: 0 0 328px
+
+		// The "Latest Incidents" carousel collapses to multiple rows
+		// over smaller viewport sizes
+		&--latest
+			grid-column: 1 / -1	// span the entire grid
+
+			+tablet-up
+				grid-column: span 4	// ½ of grid
+
+			+desktop-up
+				grid-column: span 3	// ¼ of grid

--- a/home/templates/home/_recent_incidents_section.html
+++ b/home/templates/home/_recent_incidents_section.html
@@ -3,9 +3,9 @@
 <h2 class="homepage-section-header">{{ label|default:"Recent Incidents" }}</h2>
 
 {% with incidents=search_page.get_incidents|slice:count %}
-	<ul class="article-carousel">
+	<ul class="article-carousel__items">
 		{% for incident in incidents %}
-			<li class="article-carousel-item article-carousel-item--latest">
+			<li class="article-carousel__item article-carousel__item--latest">
 				{% include "incident/_incident_card.html" with size="small" incident=incident photo=incident.teaser_image only %}
 			</li>
 		{% endfor %}


### PR DESCRIPTION
While merging of the article scroller logic in the #1261 , some of the style codes for the latest incidents were lost, resulting in the recent incidents not appearing correctly. This PR fixes that.