### PR TITLE
Incident card details alignment

### DIFF
--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -107,7 +107,6 @@
 	&__value
 		margin-left: 0
 		font-size: $font-size-small-p
-		white-space: nowrap
 		line-height: 1.43
 
 	&__list

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -875,3 +875,21 @@ class IncidentPage(MetadataPageMixin, Page):
     @cached_property
     def get_tags(self):
         return self.tags.all()
+
+    @cached_property
+    def get_all_targets_for_display(self):
+        items = []
+        targeted_journalists = (
+            self.targeted_journalists
+            .select_related('journalist', 'institution')
+            .order_by('journalist__title')
+            .all()
+        )
+        for tj in targeted_journalists:
+            if tj.institution:
+                items.append(f'{tj.journalist.title} ({tj.institution.title})')
+            else:
+                items.append(f'{tj.journalist.title}')
+        for institution in self.targeted_institutions.all():
+            items.append(f'{institution.title}')
+        return ', '.join(items)

--- a/incident/templates/incident/_incident_card.html
+++ b/incident/templates/incident/_incident_card.html
@@ -31,33 +31,40 @@
 			{% endfor %}
 		</ol>
 
-		<dl class="dl-inline">
+		<dl class="database-card-table__incident-details">
 			{% if incident.latest_update and incident.updates.all.exists %}
-				<dt>Updated on</dt>
-				<dd>
-					<time datetime="{{ incident.latest_update|date:"c" }}">
-						{{ incident.latest_update|date:"F j, Y" }}
+				<div class="database-card-table__row">
+					<dt class="database-card-table__label database-card-table__label--bold">Updated on</dt>
+					<dd class="database-card-table__value">
+						<time datetime="{{ incident.latest_update|date:"c" }}">
+							{{ incident.latest_update|date:"F j, Y" }}
+						</time>
+					</dd>
+				</div>
+			{% endif %}
+
+			<div class="database-card-table__row">
+				<dt class="database-card-table__label database-card-table__label--bold">
+					Date of Incident
+				</dt>
+				<dd class="database-card-table__value">
+					<time datetime="{{ incident.date|date:"c" }}">
+						{{ incident.date|date:"F j, Y" }}
 					</time>
 				</dd>
-			{% endif %}
-			<dt>Date of Incident</dt>
-			<dd>
-				<time datetime="{{ incident.date|date:"c" }}">
-					{{ incident.date|date:"F j, Y" }}
-				</time>
-			</dd>
-			<dt>Location</dt>
-			<dd>{{ incident.city }}, {{ incident.state.name }}</dd>
-			{% if incident.targeted_journalists.all or incident.targeted_institutions.all %}
-				<dt>Targets</dt>
-				{% for journalist in incident.targeted_journalists.all %}
-					<dd>
-						{{ journalist.journalist.title }}{% if journalist.institution %} ({{ journalist.institution.title }}){% endif %}
+			</div>
+			<div class="database-card-table__row">
+				<dt class="database-card-table__label database-card-table__label--bold">Location</dt>
+				<dd class="database-card-table__value">{{ incident.city }}, {{ incident.state.name }}</dd>
+			</div>
+			{% if incident.get_all_targets_for_display %}
+				<div class="database-card-table__row">
+					<dt class="database-card-table__label database-card-table__label--bold">Targets</dt>
+
+					<dd class="database-card-table__value">
+						{{ incident.get_all_targets_for_display }}
 					</dd>
-				{% endfor %}
-				{% for institution in incident.targeted_institutions.all %}
-					<dd>{{ institution.title }}</dd>
-				{% endfor %}
+				</div>
 			{% endif %}
 		</dl>
 		{% include 'incident/_incident_tags.html' %}

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -36,6 +36,8 @@ from .factories import (
     IncidentUpdateFactory,
     TopicPageFactory,
     StateFactory,
+    InstitutionFactory,
+    TargetedJournalistFactory,
 )
 
 
@@ -1033,3 +1035,24 @@ class IncidentPageTests(TestCase):
         incident_index.add_child(instance=incident)
         self.assertEqual(incident.longitude, geoname.longitude)
         self.assertEqual(incident.latitude, geoname.latitude)
+
+    def test_gets_unified_list_of_all_targets(self):
+        inst = InstitutionFactory()
+        inc = IncidentPageFactory(
+            parent=self.incident_index,
+        )
+        inc.targeted_institutions = [inst]
+        inc.save()
+        tj1 = TargetedJournalistFactory(
+            journalist__title='Alex Aardvark',
+            institution=None,
+            incident=inc,
+        )
+        tj2 = TargetedJournalistFactory(
+            journalist__title='Benny Bird',
+            incident=inc,
+        )
+        self.assertEqual(
+            inc.get_all_targets_for_display,
+            f'{tj1.journalist.title}, {tj2.journalist.title} ({tj2.institution.title}), {inst.title}'
+        )

--- a/styleguide/tests/test_views.py
+++ b/styleguide/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from incident.tests.factories import IncidentPageFactory
 from common.models import CustomImage, CustomRendition
 from common.tests.factories import CustomImageFactory
 
@@ -15,6 +16,7 @@ class StyleguideTestCase(TestCase):
             file__color='green',
             collection__name='Photos',
         )
+        IncidentPageFactory()
 
     def tearDown(self):
         # Needed because the page the image is attached to is not

--- a/styleguide/views.py
+++ b/styleguide/views.py
@@ -1,11 +1,9 @@
-import datetime
-
 from django.views.generic import TemplateView
 
-from common.devdata import CommonTagFactory, CategoryPageFactory
+from common.devdata import CategoryPageFactory
 from common.models.pages import CategoryPage
 from common.choices import CATEGORY_SYMBOL_CHOICES
-from incident.devdata import MultimediaIncidentPageFactory, InstitutionFactory, TargetedJournalistFactory, IncidentCategorizationFactory
+from incident.models import IncidentPage
 from blog.tests.factories import BlogPageFactory
 
 
@@ -17,24 +15,7 @@ class StyleguideView(TemplateView):
 
         # Create sample incident for the styleguide without touching
         # the database.
-        inc = MultimediaIncidentPageFactory.build()
-        inc.latest_update = datetime.datetime.utcnow()
-        inc.tags = CommonTagFactory.build_batch(5)
-        inc.targeted_institutions = InstitutionFactory.build_batch(2)
-        inc.targeted_journalists = TargetedJournalistFactory.build_batch(
-            2,
-            # We are creating the incident relationship using
-            # modelcluster directly, tell the factory not to generate
-            # an incident.
-            incident=None,
-        )
-        inc.categories = IncidentCategorizationFactory.build_batch(
-            2,
-            # We are creating the incident relationship using
-            # modelcluster directly, tell the factory not to generate
-            # an incident.
-            incident_page=None,
-        )
+        inc = IncidentPage.objects.first()
         all_categories = []
         for category_value, category_name in CATEGORY_SYMBOL_CHOICES:
             all_categories.append(


### PR DESCRIPTION
Refs #1257 

Addresses potential cramped text and other discrepancies from the spec on the "Incident Card" component. Basically I have reformatted the incident details so they match the "database card" component. This looks more like the [Figma design](https://www.figma.com/file/H3uTXxT88ofhdebUFgzEo9/PFT-%E2%80%93-Hand-off-Guide?node-id=3897%3A60123) in terms of alignment and font size, and as a result looks less cramped. Though I don't know if it fixes all the issues regarding the overall presentation of these cards raised in issue #1257 