### PR TITLE
Filter autocomplete fields and other improvements

### DIFF
--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -20,6 +20,7 @@
 	background-repeat: no-repeat
 	background-position: right
 	padding-right: 17px
+	cursor: pointer
 
 .filters__group
 	border-bottom: 1px solid rgba(0, 0, 0, 0.1)

--- a/incident/templates/incident/_filters.html
+++ b/incident/templates/incident/_filters.html
@@ -2,7 +2,7 @@
 	<header class="filters__header">
 		Filters
 
-		<a href="{{ page.url }}">Clear All</a>
+		<a class="text-link" href="{{ page.url }}">Clear All</a>
 	</header>
 	{% for item in filters %}
 		<details class="filters__group" role="group" aria-labelledby="{{ item.title|slugify }}">

--- a/incident/templates/incident/datalist.html
+++ b/incident/templates/incident/datalist.html
@@ -1,0 +1,6 @@
+{% include "django/forms/widgets/input.html" %}
+<datalist id="{{ widget.attrs.list }}"{% include "django/forms/widgets/attrs.html" %}>
+	{% for value in widget.choices %}
+		<option value="{{ value }}">
+	{% endfor %}
+</datalist>

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -58,6 +58,9 @@
 			<div class="incident-index__body-header-controls">
 				<p class="paragraph-subtitle">
 					{{ incident_count|intcomma }} incident{{ incident_count|pluralize }} recorded
+					{% if search_value %}
+						for &lsquo;{{ search_value }}&rsquo;
+					{% endif %}
 				</p>
 				<details class="incident-index__sort-details">
 					<summary class="btn incident-index__sort-button">

--- a/incident/tests/test_incident_filter_forms.py
+++ b/incident/tests/test_incident_filter_forms.py
@@ -1,7 +1,12 @@
 from django.test import RequestFactory, TestCase
 from django import forms
 
-from incident.utils.forms import FilterForm, get_filter_forms
+from incident.utils.forms import (
+    FilterForm,
+    get_filter_forms,
+    Datalist,
+    DatalistField,
+)
 from incident.models.choices import MAYBE_BOOLEAN
 from incident.tests.factories import LawEnforcementOrganizationFactory
 
@@ -127,9 +132,8 @@ class FilterFormTest(TestCase):
         leo2 = LawEnforcementOrganizationFactory.create(title='Org 2')
 
         expected_choices = [
-            ('', '------'),
-            (str(leo1.pk), leo1.title),
-            (str(leo2.pk), leo2.title),
+            leo1.title,
+            leo2.title,
         ]
         item = {
             'filters': [
@@ -144,8 +148,8 @@ class FilterFormTest(TestCase):
         }
         form = FilterForm(request.GET, data=item)
 
-        self.assertIsInstance(form.fields.get(name), forms.ChoiceField)
-        self.assertIsInstance(form.fields.get(name).widget, forms.Select)
+        self.assertIsInstance(form.fields.get(name), DatalistField)
+        self.assertIsInstance(form.fields.get(name).widget, Datalist)
         self.assertEqual(form.fields.get(name).choices, expected_choices)
 
     def test_filter_type_radio(self):

--- a/incident/tests/test_incident_filter_forms.py
+++ b/incident/tests/test_incident_filter_forms.py
@@ -3,6 +3,7 @@ from django import forms
 
 from incident.utils.forms import FilterForm, get_filter_forms
 from incident.models.choices import MAYBE_BOOLEAN
+from incident.tests.factories import LawEnforcementOrganizationFactory
 
 
 def capitalize_choice_labels(choices):
@@ -118,6 +119,34 @@ class FilterFormTest(TestCase):
         self.assertIsInstance(form.fields.get(name), forms.ChoiceField)
         self.assertIsInstance(form.fields.get(name).widget, forms.Select)
         self.assertEqual(form.fields.get(name).choices, capitalized)
+
+    def test_filter_type_autocomplete_single(self):
+        request = RequestFactory().get('/')
+        name = 'arresting_authority'
+        leo1 = LawEnforcementOrganizationFactory.create(title='Org 1')
+        leo2 = LawEnforcementOrganizationFactory.create(title='Org 2')
+
+        expected_choices = [
+            ('', '------'),
+            (str(leo1.pk), leo1.title),
+            (str(leo2.pk), leo2.title),
+        ]
+        item = {
+            'filters': [
+                {
+                    'title': 'Arresting authority',
+                    'type': 'autocomplete',
+                    'name': name,
+                    'autocomplete_type': 'incident.LawEnforcementOrganization',
+                    'many': False
+                },
+            ]
+        }
+        form = FilterForm(request.GET, data=item)
+
+        self.assertIsInstance(form.fields.get(name), forms.ChoiceField)
+        self.assertIsInstance(form.fields.get(name).widget, forms.Select)
+        self.assertEqual(form.fields.get(name).choices, expected_choices)
 
     def test_filter_type_radio(self):
         request = RequestFactory().get('/')

--- a/incident/tests/test_incident_filter_forms.py
+++ b/incident/tests/test_incident_filter_forms.py
@@ -75,7 +75,7 @@ class FilterFormTest(TestCase):
 
         self.assertIsInstance(form.fields.get(name), forms.ChoiceField)
         self.assertIsInstance(form.fields.get(name).widget, forms.RadioSelect)
-        self.assertEqual(form.fields.get(name).choices, [('Yes', 'Yes',), ('No', 'No',)])
+        self.assertEqual(form.fields.get(name).choices, [('1', 'Yes',), ('0', 'No',)])
 
     def test_filter_type_checkbox(self):
         request = RequestFactory().get('/')

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -63,6 +63,11 @@ class TestPages(TestCase):
             site.root_page = cls.home_page
             site.save()
 
+        incident_filter_settings = IncidentFilterSettings.for_site(site)
+        GeneralIncidentFilter.objects.create(
+            incident_filter_settings=incident_filter_settings,
+            incident_filter='state',
+        )
         cls.index = IncidentIndexPageFactory(
             parent=site.root_page, slug='incidents')
         cls.incident = IncidentPageFactory(parent=cls.index, slug='one')

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.apps import apps
 
 from incident.models import choices
 
@@ -25,8 +26,22 @@ class FilterForm(forms.Form):
                     'label': label,
                 }
 
-                if _type == 'text' or _type == 'autocomplete':
+                if _type == 'text':
                     field = forms.CharField
+
+                if _type == 'autocomplete':
+                    field = forms.ChoiceField
+                    app_label, model_name = item['autocomplete_type'].split('.')
+                    model = apps.get_model(app_label, model_name)
+                    autocomplete_choices = [('', '------')]
+                    for choice in model.objects.all():
+                        value = str(choice.pk)
+                        title_field = getattr(model, 'autocomplete_search_field', 'title')
+                        title = getattr(choice, title_field)
+                        autocomplete_choices.append(
+                            (value, title)
+                        )
+                    kwargs['choices'] = autocomplete_choices
 
                 if _type == 'date':
                     field = forms.DateField

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -84,7 +84,7 @@ class FilterForm(forms.Form):
                 if _type == 'bool':
                     field = forms.ChoiceField
                     kwargs['widget'] = forms.RadioSelect
-                    kwargs['choices'] = [('Yes', 'Yes',), ('No', 'No',)]
+                    kwargs['choices'] = [('1', 'Yes',), ('0', 'No',)]
 
                 if _type == 'checkbox':
                     field = forms.MultipleChoiceField


### PR DESCRIPTION
This pull request:

1. Updates the filter sidebar on the database page to use `<intput>` and `<datalist>` elements with for autocomplete filters.
2. Updates the cursor to become a pointer when hovering over the expandable filter headers 
3. Adds a number of autocompletable items to the `createdevdata` command, so that we can more easily test that functionality locally.
4. Fixes a bug where boolean fields submitted from the filter sidebar would not actually work.
5. Adds the search text to the search results header (as shown in the Figma design).

Originally this PR used `<select>` elements for autocomplete filters, and I think the intput/datalist is nicer, but either one is an enhancement over what is on the redesign branch now. I think this should be merged and we should discuss further improvements to this and see what is feasible for launch.

Note: with the datalist elements, we expect the page size to be larger. For me, locally, it is 177kB with the following counts:

| Item | Count |
| ----- | ----- |
| States | 57 |
| Targeted Journalists | 139 |
| Tags | 925 |
| Venues | 92 |
| Law-enforcement organizations | 113 |
| Charges | 153 |
| Nationalities | 89 |
| Politicians/public figures | 225 |
| Equipment | 14 |