### PR TITLE
Aligns value numbers in statistics table to right

### DIFF
--- a/client/common/sass/components/_statistics-table.sass
+++ b/client/common/sass/components/_statistics-table.sass
@@ -22,5 +22,7 @@
 		text-decoration: none
 
 	&__col--right
+		text-align: right
+
 		+tablet-up
 			grid-column: 3


### PR DESCRIPTION
The numbers in the statistics table in the design were right aligned, missed adding the text alignment in #1271 