### PR TITLE
Add a check for uniqueness of labels across form field groups

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -897,9 +897,9 @@ unittest-xml-reporting==3.0.4 \
     --hash=sha256:7bf515ea8cb244255a25100cd29db611a73f8d3d0aaf672ed3266307e14cc1ca \
     --hash=sha256:984cebba69e889401bfe3adb9088ca376b3a1f923f0590d005126c1bffd1a695
     # via -r requirements.txt
-urllib3[secure]==1.26.8 \
-    --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
-    --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
+urllib3[secure]==1.26.9 \
+    --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
+    --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
     # via
     #   -r requirements.txt
     #   requests

--- a/forms/tests/test_models.py
+++ b/forms/tests/test_models.py
@@ -106,6 +106,119 @@ class ReplyToFieldsValidatorFormTests(TestCase, WagtailTestUtils):
         self.root_page.add_child(instance=self.home_page)
         self.login()
 
+    def test_does_not_allow_multiple_fields_with_the_same_label_across_groups(self):
+        post_data = nested_form_data({
+            'title': 'Test form page',
+            'slug': 'test-form-page',
+            'intro': rich_text('<p>Test intro</p>'),
+            'form_intro': 'Test form',
+            'thank_you_text': rich_text('<p>Thanks (test)!</p>'),
+            'button_text': 'Test button',
+            'outro_title': 'Test outro',
+            'outro_text': rich_text('<p>Test outro body</p>'),
+            'from_address': 'from@example.com',
+            'to_address': 'to@example.com',
+            'subject': 'Test subject',
+            'field_groups': inline_formset([
+                {
+                    'title': 'Test group',
+                    'description': 'Test description',
+                    'template': 'default',
+                    'form_fields': inline_formset([
+                        {
+                            'label': 'Test label',
+                            'help_text': 'Test',
+                            'required': 'True',
+                            'field_type': 'email',
+                        },
+                        {
+                            'label': 'Test label 1',
+                            'help_text': 'Test',
+                            'required': 'True',
+                            'field_type': 'email',
+                        },
+                    ])
+                },
+                {
+                    'title': 'Test group 2',
+                    'description': 'Test description',
+                    'template': 'default',
+                    'form_fields': inline_formset([
+                        {
+                            'label': 'Test label',
+                            'help_text': 'Test',
+                            'required': 'True',
+                            'field_type': 'email',
+                        },
+                        {
+                            'label': 'Test label 4',
+                            'help_text': 'Test',
+                            'required': 'True',
+                            'field_type': 'email',
+                        },
+                    ])
+                }
+            ])
+        })
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=('forms', 'formpage', self.home_page.pk)
+            ),
+            post_data
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(response, 'The page could not be created')
+        self.assertContains(response, 'There is another field with the label Test label')
+
+    def test_does_not_allow_multiple_fields_with_the_same_label(self):
+        post_data = nested_form_data({
+            'title': 'Test form page',
+            'slug': 'test-form-page',
+            'intro': rich_text('<p>Test intro</p>'),
+            'form_intro': 'Test form',
+            'thank_you_text': rich_text('<p>Thanks (test)!</p>'),
+            'button_text': 'Test button',
+            'outro_title': 'Test outro',
+            'outro_text': rich_text('<p>Test outro body</p>'),
+            'from_address': 'from@example.com',
+            'to_address': 'to@example.com',
+            'subject': 'Test subject',
+            'field_groups': inline_formset([
+                {
+                    'title': 'Test group',
+                    'description': 'Test description',
+                    'template': 'default',
+                    'form_fields': inline_formset([
+                        {
+                            'label': 'Test label',
+                            'help_text': 'Test',
+                            'required': 'True',
+                            'field_type': 'email',
+                        },
+                        {
+                            'label': 'Test label',
+                            'help_text': 'Test',
+                            'required': 'True',
+                            'field_type': 'email',
+                        },
+                    ])
+                }
+            ])
+        })
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=('forms', 'formpage', self.home_page.pk)
+            ),
+            post_data
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(response, 'The page could not be created')
+        self.assertContains(response, 'There is another field with the label Test label')
+
     def test_does_not_allow_multiple_reply_to_fields(self):
         post_data = nested_form_data({
             'title': 'Test form page',

--- a/requirements.txt
+++ b/requirements.txt
@@ -486,9 +486,9 @@ unittest-xml-reporting==3.0.4 \
     --hash=sha256:7bf515ea8cb244255a25100cd29db611a73f8d3d0aaf672ed3266307e14cc1ca \
     --hash=sha256:984cebba69e889401bfe3adb9088ca376b3a1f923f0590d005126c1bffd1a695
     # via -r requirements.in
-urllib3==1.26.8 \
-    --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed \
-    --hash=sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
+urllib3==1.26.9 \
+    --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
+    --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
     # via requests
 wagtail==2.15.2 \
     --hash=sha256:0086c8bf7fb93e456f15f230f0bfcb3d3945420aa663a8a962c404051da96d46 \


### PR DESCRIPTION
If the labels are not unique, the display code for the form breaks.
If two fields have the same label, then one of the fields with the
label will be rendered twice, and the other one will not be rendered
at all.  This fixes that.

Also upgrades urllib3, which I had to do to get CI to pass (not entirely sure why).