### PR TITLE
Filter form UI improvements

### DIFF
--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -94,6 +94,8 @@
 
 	&-ghost
 		transition: color 0.01s ease-in 0.08s
+		border: none
+		background-color: transparent
 
 		&:not([disabled])::before
 			content: ''

--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -94,7 +94,7 @@
 
 	&-ghost
 		transition: color 0.01s ease-in 0.08s
-		border: none
+		border-width: 0
 		background-color: transparent
 
 		&:not([disabled])::before

--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -2,7 +2,7 @@
 	select
 		max-width: 200px
 
-	button
+	&--submit
 		width: 50%
 		margin: 1rem auto
 		display: block

--- a/incident/templates/incident/_filters.html
+++ b/incident/templates/incident/_filters.html
@@ -2,7 +2,7 @@
 	<header class="filters__header">
 		Filters
 
-		<a class="text-link" href="{{ page.url }}">Clear All</a>
+		<button class="btn btn-ghost" type="reset">Clear All</button>
 	</header>
 	{% for item in filters %}
 		<details class="filters__group" role="group" aria-labelledby="{{ item.title|slugify }}"{% if item.has_changed %}open{% endif %}>
@@ -22,5 +22,5 @@
 			{% endfor %}
 		</details>
 	{% endfor %}
-	<button class="btn btn-secondary" type="submit">Apply filters</button>
+	<button class="btn btn-secondary filters__form--submit" type="submit">Apply filters</button>
 </form>

--- a/incident/templates/incident/_filters.html
+++ b/incident/templates/incident/_filters.html
@@ -5,7 +5,7 @@
 		<a class="text-link" href="{{ page.url }}">Clear All</a>
 	</header>
 	{% for item in filters %}
-		<details class="filters__group" role="group" aria-labelledby="{{ item.title|slugify }}">
+		<details class="filters__group" role="group" aria-labelledby="{{ item.title|slugify }}"{% if item.has_changed %}open{% endif %}>
 			<summary id="{{ item.title|slugify }}" class="filters__form-summary">
 				{{ item.title }}
 			</summary>

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -73,7 +73,9 @@ class FilterForm(forms.Form):
 
                 if _type == 'date':
                     field = forms.DateField
-                    kwargs['widget'] = forms.DateInput
+                    kwargs['widget'] = forms.DateInput(
+                        attrs={'type': 'date'}
+                    )
                     kwargs['label'] = label.replace('between', 'before')
                     self.fields[f'{name}_upper'] = field(**kwargs)
                     kwargs['label'] = label.replace('between', 'after')


### PR DESCRIPTION
This pull request:

1. Sets date-input filter form fields to use `type="date"` and thereby use the built-in browser date picking UI.
2. Keeps the details element containing a given form field open when it's been modified by the user, so that after the filter form is submitted, when the page loads again the panels containing their active filters will still be open. I think this is helpful.

This PR is based on https://github.com/freedomofpress/pressfreedomtracker.us/pull/1277 and should be reviewed and merged after that one.