### PR TITLE
CI cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           command: |
             mkdir -p test-results
             npm ci
-            $(npm bin)/npm-audit-plus --xml --ignore 803,1006864,1006886 > test-results/audit.xml
+            $(npm bin)/npm-audit-plus --xml --ignore 803,1067259,1006864,1006886 > test-results/audit.xml
 
       - store_test_results:
           path: ~/tracker/test-results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,14 @@ jobs:
           pattern: ^package-lock.json$
 
       - run:
+          name: Upgrade NPM to consistent version with dev environment
+          command: sudo npm install -g npm@7.24.1
+
+      - run:
           name: Check node dependencies for vulnerabilities
           command: |
             mkdir -p test-results
-            npm ci --no-optional
+            npm ci
             $(npm bin)/npm-audit-plus --xml --ignore 803,1067259,1006864,1006886 > test-results/audit.xml
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Check node dependencies for vulnerabilities
           command: |
             mkdir -p test-results
-            npm ci
+            npm ci --no-optional
             $(npm bin)/npm-audit-plus --xml --ignore 803,1067259,1006864,1006886 > test-results/audit.xml
 
       - store_test_results:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"extends": "airbnb",
 
-	"ignorePatterns": ["client/statistics/js/searchstats.js"],
+	"ignorePatterns": ["client/statistics/js/searchstats.js", "client/charts/"],
 
 	"plugins": [
 		"react"

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -3,11 +3,11 @@ extends:
     - stylelint-config-recommended
     - stylelint-config-sass-guidelines
 customSyntax: postcss-sass
+ignoreFiles:
+  - 'node_modules/**/*'
 files:
     include:
         - '**/*.s+(a|c)ss'
-    ignore:
-        - 'node_modules/**/*'
 rules:
     indentation: null
     selector-max-compound-selectors: null

--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,12 @@ bandit: ## Runs bandit static code analysis in Python3 container.
 
 .PHONY: npm-audit
 npm-audit: ## Checks NodeJS NPM dependencies for vulnerabilities
-	@docker-compose run --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus --ignore 803'
+	@docker-compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus --ignore 803,1067259'
 
 .PHONY: ci-npm-audit
 ci-npm-audit:
 	@mkdir -p test-results # Creates necessary test-results folder
-	@docker-compose run --entrypoint "/bin/ash -c" node 'npm ci && $$(npm bin)/npm-audit-plus --xml --ignore 803 > test-results/audit.xml'
+	@docker-compose run --entrypoint "/bin/ash -c" node 'npm ci && $$(npm bin)/npm-audit-plus --xml --ignore 803,1067259 > test-results/audit.xml'
 
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities

--- a/client/charts/sass/base.sass
+++ b/client/charts/sass/base.sass
@@ -1,7 +1,12 @@
+=large-screen
+	@media (min-width: 1000px)
+		@content
+
 .chartContainer
 	display: table
 	margin: auto
-	outline: solid 1px blue
+	outline: solid 1px
+	outline-color: #00F
 
 h1,
 h2,
@@ -11,8 +16,8 @@ h5
 	text-align: center
 	font-family: Arial, Helvetica, sans-serif
 
-@media (min-width: 1000px)
-	.hpChartContainer
+.hpChartContainer
+	+large-screen
 		display: flex
 
 .hpChart
@@ -22,12 +27,12 @@ h5
 input[type='radio']
 	appearance: none
 	display: flex
-	background-color: black
+	background-color: #000
 	margin: 0
 	font: inherit
 	width: 1em
 	height: 1em
-	border: 0.1em solid black
+	border: 0.1em solid #000
 	border-radius: 100%
 	transition: 120ms transform ease-in-out
 
@@ -35,7 +40,7 @@ input[type='radio']::before
 	content: ''
 	width: 100%
 	height: 100%
-	background-color: white
+	background-color: #000
 	border-radius: 100%
 	transform: scale(1)
 	transition: 120ms transform ease-in-out
@@ -47,19 +52,19 @@ input[type='radio']:checked
 input[type='checkbox']
 	appearance: none
 	display: flex
-	background-color: black
+	background-color: #000
 	margin: 0
 	font: inherit
 	width: 1em
 	height: 1em
-	border: 0.13em solid black
+	border: 0.13em solid #000
 	transition: 120ms transform ease-in-out
 
 input[type='checkbox']::before
 	content: ''
 	width: 100%
 	height: 100%
-	background-color: white
+	background-color: #000
 	transform: scale(1)
 	transition: 120ms transform ease-in-out
 

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -3,7 +3,7 @@ import random
 import requests
 import time
 import wagtail_factories
-from itertools import combinations, chain, islice
+from itertools import combinations, chain
 
 from django.contrib.auth.models import User
 from django.core import management


### PR DESCRIPTION
This PR changes some of our configuration and code so that CI will pass. The changes are:

1. Fix a small flake8 error.
2. Tell eslint to ignore the `charts` directory javascript. This is a known problem and we don't need to see 200+ problems every time it's run.
3. Ignores the latest [`minimist` vulnerability](https://github.com/advisories/GHSA-xvch-5gv4-984h). See commit message for further elaboration but the short answer is I don't think it's going to go away soon, given how many dependencies of ours it affects.