### PR TITLE
Updates `minimist` from version 1.2.5 to 1.2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: |
             mkdir -p test-results
             npm ci
-            $(npm bin)/npm-audit-plus --xml --ignore 803,1067259,1006864,1006886 > test-results/audit.xml
+            $(npm bin)/npm-audit-plus --xml > test-results/audit.xml
 
       - store_test_results:
           path: ~/tracker/test-results/

--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,12 @@ bandit: ## Runs bandit static code analysis in Python3 container.
 
 .PHONY: npm-audit
 npm-audit: ## Checks NodeJS NPM dependencies for vulnerabilities
-	@docker-compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus --ignore 803,1067259'
+	@docker-compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus'
 
 .PHONY: ci-npm-audit
 ci-npm-audit:
 	@mkdir -p test-results # Creates necessary test-results folder
-	@docker-compose run --entrypoint "/bin/ash -c" node 'npm ci && $$(npm bin)/npm-audit-plus --xml --ignore 803,1067259 > test-results/audit.xml'
+	@docker-compose run --entrypoint "/bin/ash -c" node 'npm ci && $$(npm bin)/npm-audit-plus --xml > test-results/audit.xml'
 
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -10428,9 +10428,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -21720,9 +21720,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {


### PR DESCRIPTION
Fixes a vulnerability described here:

https://github.com/advisories/GHSA-xvch-5gv4-984h

Also removes some items from the npm audit ignore list that are no
longer needing to be ignored.