### PR TITLE
Update rich text rendering

### DIFF
--- a/blog/tests/factories.py
+++ b/blog/tests/factories.py
@@ -56,6 +56,7 @@ class BlogPageFactory(wagtail_factories.PageFactory):
                     'styled_text',
                     'blockquote',
                     'styled_text',
+                    'aside',
                     'list',
                     'styled_text',
                 ],

--- a/client/common/sass/components/_aside.sass
+++ b/client/common/sass/components/_aside.sass
@@ -6,8 +6,12 @@
 		*
 			color: inherit
 
+		a
+			color: $white
+
 		a:focus
 			border-color: $white
 
 		a:hover
+			background-color: $accent-color
 			color: $black

--- a/client/common/sass/components/_citation.sass
+++ b/client/common/sass/components/_citation.sass
@@ -1,7 +1,13 @@
 .citation
+	border-top: 5px solid
+	border-color: $black
+
+	&--inner
+		padding: 32px 0
+		+constrain-to-desktop
+
+	&-content
+		max-width: 670px
+
 	&-link
 		text-align: right
-
-		.btn-primary
-			position: relative
-			right: 46px

--- a/client/common/sass/components/_emails-signup.sass
+++ b/client/common/sass/components/_emails-signup.sass
@@ -1,4 +1,14 @@
 .emails-signup
+	border-top: 1px solid
+	border-color: $black
+
+	&--inner
+		padding: 32px 0
+		+constrain-to-desktop
+
+	&-content
+		max-width: 670px
+
 	&__input-container
 		margin-bottom: 1rem
 

--- a/client/common/sass/components/_footer-info.sass
+++ b/client/common/sass/components/_footer-info.sass
@@ -6,7 +6,11 @@
 		color: $white
 
 		&:hover
+			background-color: $accent-color
 			color: $black
+
+			svg
+				filter: invert(1)
 
 		&:focus
 			border-color: $white

--- a/client/common/sass/components/_footer-info.sass
+++ b/client/common/sass/components/_footer-info.sass
@@ -1,6 +1,10 @@
 .footer-info
+	background-color: $black
 	color: $gray-text
-	+constrain-to-desktop
+	padding: 32px 0
+
+	&--inner
+		+constrain-to-desktop
 
 	a
 		color: $white

--- a/client/common/sass/components/_footer.sass
+++ b/client/common/sass/components/_footer.sass
@@ -1,3 +1,3 @@
 .footer
-	background-color: $black
-	padding: 32px 0
+	+desktop-up
+		margin-top: 136px

--- a/client/common/sass/components/_media.sass
+++ b/client/common/sass/components/_media.sass
@@ -17,3 +17,13 @@
 
 			&:first-of-type
 				margin-top: 0.25em
+
+		a
+			color: $black
+
+			&:focus
+				outline: $black solid 3px
+				outline-offset: 2px
+
+			&:hover
+				background-color: $accent-color

--- a/client/common/sass/components/_site-summary.sass
+++ b/client/common/sass/components/_site-summary.sass
@@ -11,5 +11,15 @@
 		max-width: 100%
 		height: auto
 
+	a
+		color: $black
+
+		&:focus
+			outline: $black solid 3px
+			outline-offset: 2px
+
+		&:hover
+			background-color: $accent-color
+
 	&--blog
 		font-size: 1.125rem

--- a/common/devdata.py
+++ b/common/devdata.py
@@ -22,7 +22,7 @@ from common.models import (
     TaxonomyCategoryPage,
     TaxonomySettings,
 )
-from common.tests.utils import StreamfieldProvider
+from common.tests.utils import StreamfieldProvider, make_html_string
 
 
 factory.Faker.add_provider(StreamfieldProvider)
@@ -136,6 +136,7 @@ class CategoryPageFactory(wagtail_factories.PageFactory):
     methodology_text = factory.Faker('paragraph', nb_sentences=5)
 
     title = factory.Sequence(lambda n: 'Category {n}'.format(n=n))
+    description = factory.LazyAttribute(lambda _: make_html_string())
     methodology = factory.LazyAttribute(lambda o: RichText(o.methodology_text))
     taxonomy = factory.RelatedFactory(TaxonomyCategoryPageFactory, 'category')
     page_symbol = factory.Iterator(CATEGORY_SYMBOL_CHOICES, getter=lambda c: c[0])

--- a/common/devdata.py
+++ b/common/devdata.py
@@ -19,6 +19,7 @@ from common.models import (
     PersonPage,
     OrganizationPage,
     OrganizationIndexPage,
+    SiteSettings,
     TaxonomyCategoryPage,
     TaxonomySettings,
 )
@@ -35,6 +36,20 @@ class DevelopmentSiteFactory(wagtail_factories.SiteFactory):
     port = 8000
     is_default_site = True
     root_page = None
+
+
+class SiteSettingsFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = SiteSettings
+        django_get_or_create = ('site',)
+
+    site = factory.SubFactory(DevelopmentSiteFactory)
+    incident_sidebar_note = factory.Faker('streamfield', fields=[
+        'heading',
+        'rich_text_line',
+    ])
+    homepage_only = True
+    banner_content = None
 
 
 class CategoryIncidentFilterFactory(factory.django.DjangoModelFactory):

--- a/common/management/commands/createcategories.py
+++ b/common/management/commands/createcategories.py
@@ -7,6 +7,7 @@ from common.devdata import (
     CategoryPageFactory,
     DevelopmentSiteFactory,
 )
+from common.tests.utils import make_html_string
 from home.tests.factories import HomePageFactory
 
 
@@ -80,7 +81,10 @@ class Command(BaseCommand):
         Page.objects.filter(slug='home').delete()
 
         root_page = Page.objects.get(slug='root')
-        home_page = HomePageFactory(parent=root_page)
+        home_page = HomePageFactory(
+            parent=root_page,
+            about=make_html_string(),
+        )
         DevelopmentSiteFactory(root_page=home_page)
 
         self.stdout.write('Creating categories', ending='')

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -24,9 +24,10 @@ from common.models import (
 )
 from common.devdata import (
     PersonPageFactory, CustomImageFactory, OrganizationIndexPageFactory,
-    SimplePageFactory,
+    SimplePageFactory, SiteSettingsFactory,
 )
 from common.tests.utils import make_html_string
+from emails.devdata import EmailSettingsFactory
 from forms.models import FormPage
 from forms.tests.factories import FormPageFactory
 from home.models import HomePage, FeaturedBlogPost, FeaturedIncident
@@ -458,6 +459,8 @@ class Command(BaseCommand):
         if footer_menu:
             footer_settings.menu = footer_menu
         footer_settings.save()
+        SiteSettingsFactory(site=site)
+        EmailSettingsFactory(site=site)
 
         # Create superuser
         if not User.objects.filter(is_superuser=True).exists():

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -26,7 +26,9 @@ from common.devdata import (
     PersonPageFactory, CustomImageFactory, OrganizationIndexPageFactory,
     SimplePageFactory,
 )
+from common.tests.utils import make_html_string
 from forms.models import FormPage
+from forms.tests.factories import FormPageFactory
 from home.models import HomePage, FeaturedBlogPost, FeaturedIncident
 from incident.models import IncidentIndexPage, IncidentPage
 from incident.devdata import IncidentIndexPageFactory, IncidentLinkFactory, MultimediaIncidentUpdateFactory, MultimediaIncidentPageFactory
@@ -204,8 +206,14 @@ class Command(BaseCommand):
 
         # SUBMIT INCIDENT FORM
         FormPage.objects.filter(slug='submit-incident').delete()
-        incident_form = FormPage(title='Submit an incident', slug='submit-incident')
-        home_page.add_child(instance=incident_form)
+        incident_form = FormPageFactory(
+            title='Submit an incident',
+            slug='submit-incident',
+            intro=make_html_string(),
+            thank_you_text=make_html_string(),
+            outro_text=make_html_string(),
+            parent=home_page,
+        )
 
         # BLOG RELATED PAGES
         BlogIndexPage.objects.filter(slug='fpf-blog').delete()

--- a/common/templates/common/_category_methodology_section.html
+++ b/common/templates/common/_category_methodology_section.html
@@ -2,7 +2,7 @@
 
 <h2 class="methodology-section-header">Data Tracked For This Category</h2>
 
-<div class="methodology-summary">{{ methodology.description|richtext }}</div>
+<div class="methodology-summary">{{ methodology.description }}</div>
 
 <dl class="methodology-details-table">
 	{% for item in methodology.data_items %}

--- a/common/templates/common/_citation.html
+++ b/common/templates/common/_citation.html
@@ -2,15 +2,19 @@
 
 {% if settings.common.SiteSettings.incident_sidebar_note %}
 	<section class="citation">
-		{% for block in settings.common.SiteSettings.incident_sidebar_note %}
-			{% if block.block_type == 'heading' %}
-				<h2 class="paragraph-subtitle">{{ block.value.content }}</h2>
-			{% else %}
-				<div class="citation-body">{% include_block block %}</div>
-			{% endif %}
-		{% endfor %}
-		<div class="citation-link">
-			<a href="#" class="btn btn-primary">Contact us</a>
+		<div class="citation--inner">
+			<div class="citation-content">
+				{% for block in settings.common.SiteSettings.incident_sidebar_note %}
+					{% if block.block_type == 'heading' %}
+						<h2 class="paragraph-subtitle">{{ block.value.content }}</h2>
+					{% else %}
+						<div class="citation-body">{% include_block block %}</div>
+					{% endif %}
+				{% endfor %}
+				<div class="citation-link">
+					<a href="#" class="btn btn-primary">Contact us</a>
+				</div>
+			</div>
 		</div>
 	</section>
 {% endif %}

--- a/common/templates/common/_citation.html
+++ b/common/templates/common/_citation.html
@@ -8,7 +8,7 @@
 					{% if block.block_type == 'heading' %}
 						<h2 class="paragraph-subtitle">{{ block.value.content }}</h2>
 					{% else %}
-						<div class="citation-body">{% include_block block %}</div>
+						<div class="rich-text citation-body">{% include_block block %}</div>
 					{% endif %}
 				{% endfor %}
 				<div class="citation-link">

--- a/common/templates/common/_email_signup.html
+++ b/common/templates/common/_email_signup.html
@@ -1,57 +1,61 @@
 {% with email_settings=settings.emails.EmailSettings %}
 	{% for group in email_settings.mailchimp_groups.all %}
 		<section class="emails-signup">
-			<h2 class="paragraph-subtitle">{{ email_settings.signup_prompt }}</h2>
-			<form action="https://press.us6.list-manage.com/subscribe/post?u=19b87eae477821267dea69438&amp;id=c8d8f610fb" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate emails-signup__form" target="_blank" novalidate>
-				{% if email_settings.mailchimp_collect_name %}
-					<div class="emails-signup__input-container">
-						<label for="mce-MMERGE6" class="sr-only">Full Name</label>
-						<input
-							type="text"
-							value=""
-							name="FULLNAME"
-							class="emails-signup__input text-field--single"
-							id="mce-MMERGE6"
-							placeholder="Your name"
-						>
-					</div>
-				{% endif %}
-				<div class="emails-signup__input-container">
-					{% if email_settings.mailchimp_collect_name %}
-						<label
-							for="mce-EMAIL"
-							class="sr-only"
-						>
-							Email address
-						</label>
-					{% endif %}
+			<div class="emails-signup--inner">
+				<div class="emails-signup-content">
+					<h2 class="paragraph-subtitle">{{ email_settings.signup_prompt }}</h2>
+					<form action="https://press.us6.list-manage.com/subscribe/post?u=19b87eae477821267dea69438&amp;id=c8d8f610fb" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate emails-signup__form" target="_blank" novalidate>
+						{% if email_settings.mailchimp_collect_name %}
+							<div class="emails-signup__input-container">
+								<label for="mce-MMERGE6" class="sr-only">Full Name</label>
+								<input
+									type="text"
+									value=""
+									name="FULLNAME"
+									class="emails-signup__input text-field--single"
+									id="mce-MMERGE6"
+									placeholder="Your name"
+								>
+							</div>
+						{% endif %}
+						<div class="emails-signup__input-container">
+							{% if email_settings.mailchimp_collect_name %}
+								<label
+									for="mce-EMAIL"
+									class="sr-only"
+								>
+									Email address
+								</label>
+							{% endif %}
 
-					<input
-						type="email"
-						class="emails-signup__input text-field--single"
-						id="mce-EMAIL"
-						placeholder="Your email address"
-						name="EMAIL"
-					/>
-					</div>
+							<input
+								type="email"
+								class="emails-signup__input text-field--single"
+								id="mce-EMAIL"
+								placeholder="Your email address"
+								name="EMAIL"
+							/>
+							</div>
 
-				<div style="display:none" class="mc-field-group input-group">
-					<ul>
-						<li>
-							<input type="checkbox" value="{{ group.group_id }}" name="group[{{ group.category_id }}][{{ group.group_id }}]" id="mce-group[{{ group.category_id }}]-{{ group.category_id }}-0" checked>
-						</li>
-					</ul>
+						<div style="display:none" class="mc-field-group input-group">
+							<ul>
+								<li>
+									<input type="checkbox" value="{{ group.group_id }}" name="group[{{ group.category_id }}][{{ group.group_id }}]" id="mce-group[{{ group.category_id }}]-{{ group.category_id }}-0" checked>
+								</li>
+							</ul>
+						</div>
+						<div id="mce-responses" class="clear">
+							<div class="response" id="mce-error-response" style="display:none"></div>
+							<div class="response" id="mce-success-response" style="display:none"></div>
+						</div>
+						<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+						<input type="hidden" name="b_19b87eae477821267dea69438_c8d8f610fb" tabindex="-1" value="">
+						<div class="emails-signup__submit-btn">
+							<button type="submit" name="subscribe" id="mc-embedded-subscribe" class="btn btn-secondary">Sign up</button>
+						</div>
+					</form>
 				</div>
-				<div id="mce-responses" class="clear">
-					<div class="response" id="mce-error-response" style="display:none"></div>
-					<div class="response" id="mce-success-response" style="display:none"></div>
-				</div>
-				<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-				<input type="hidden" name="b_19b87eae477821267dea69438_c8d8f610fb" tabindex="-1" value="">
-				<div class="emails-signup__submit-btn">
-					<button type="submit" name="subscribe" id="mc-embedded-subscribe" class="btn btn-secondary">Sign up</button>
-				</div>
-			</form>
+			</div>
 		</section>
 	{% endfor %}
 {% endwith %}

--- a/common/templates/common/_footer_info.html
+++ b/common/templates/common/_footer_info.html
@@ -2,40 +2,42 @@
 
 {% with footer=settings.common.FooterSettings %}
 	<section class="footer-info">
-		<div class="footer-info__body">
-			{{ footer.body|richtext|typogrify }}
-		</div>
+		<div class="footer-info--inner">
+			<div class="footer-info__body">
+				{{ footer.body|richtext|typogrify }}
+			</div>
 
-		<nav class="footer-info__nav" aria-label="Footer links">
-			<ul class="footer-info__nav-list">
-				{% for item in footer.menu.menu_items.all %}
-				<li class="footer-info__nav-item {{ item.html_classes }}">
-					<a class="footer-info__nav-link" href="{{ item.url }}">
-						{{ item.text }}
-					</a>
-				</li>
-				{% endfor %}
-			</ul>
-			<ul class="footer-info__nav-list">
-				<li class="footer-info__nav-item">
-					<a
-						class="footer-info__nav-link"
-						href="https://www.facebook.com/uspressfreedomtracker/"
-						aria-label="Facebook link for U.S. Press Freedom Tracker"
-					>
-						{% include 'common/facebook.svg' %}
-					</a>
-				</li>
-				<li class="footer-info__nav-item">
-					<a
-						class="footer-info__nav-link"
-						href="https://twitter.com/uspresstracker"
-						aria-label="Twitter link for U.S. Press Freedom Tracker"
-					>
-						{% include 'common/twitter.svg' %}
-					</a>
-				</li>
-			</ul>
-		</nav>
+			<nav class="footer-info__nav" aria-label="Footer links">
+				<ul class="footer-info__nav-list">
+					{% for item in footer.menu.menu_items.all %}
+					<li class="footer-info__nav-item {{ item.html_classes }}">
+						<a class="footer-info__nav-link" href="{{ item.url }}">
+							{{ item.text }}
+						</a>
+					</li>
+					{% endfor %}
+				</ul>
+				<ul class="footer-info__nav-list">
+					<li class="footer-info__nav-item">
+						<a
+							class="footer-info__nav-link"
+							href="https://www.facebook.com/uspressfreedomtracker/"
+							aria-label="Facebook link for U.S. Press Freedom Tracker"
+						>
+							{% include 'common/facebook.svg' %}
+						</a>
+					</li>
+					<li class="footer-info__nav-item">
+						<a
+							class="footer-info__nav-link"
+							href="https://twitter.com/uspresstracker"
+							aria-label="Twitter link for U.S. Press Freedom Tracker"
+						>
+							{% include 'common/twitter.svg' %}
+						</a>
+					</li>
+				</ul>
+			</nav>
+		</div>
 	</section>
 {% endwith %}

--- a/common/templates/common/_video_or_image.html
+++ b/common/templates/common/_video_or_image.html
@@ -9,7 +9,7 @@
         {% endif %}
         {% if caption or image.attribution %}
             <figcaption class="media-caption">
-				{{ caption|richtext }}
+				<div class="rich-text">{{ caption|richtext }}</div>
 				{% if image.attribution %}
 					<span
 						class="media-attribution"

--- a/common/templates/common/blocks/blockquote.html
+++ b/common/templates/common/blocks/blockquote.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 
 <blockquote class="blockquote" {% if self.source_url %}cite="{{ self.source_url }}"{% endif%}>
-	{{ self.text|richtext }}
+	<div class="rich-text">{{ self.text|richtext }}</div>
 	{% if self.source_text and self.source_url %}
 		<cite class="blockquote__citation">
 			<a class="blockquote__link text-link" href="{{ self.source_url}}">

--- a/common/templates/common/blocks/styled_text_full_bleed.html
+++ b/common/templates/common/blocks/styled_text_full_bleed.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
 
 <div class="styled-text">
-    {{ value.text|richtext }}
+    <div class="rich-text">{{ value.text|richtext }}</div>
 </div>

--- a/common/templates/common/category_page.html
+++ b/common/templates/common/category_page.html
@@ -13,7 +13,7 @@
 					Total Incidents: {{ total_incidents }}
 				</a>
 			{% endwith %}
-			<div class="categorypage-summary">
+			<div class="categorypage-summary rich-text">
 				{{ page.description|richtext }}
 			</div>
 

--- a/common/tests/utils.py
+++ b/common/tests/utils.py
@@ -44,7 +44,7 @@ def generate_styled_text(as_type='text'):
     text_align = choice([c[0] for c in StyledTextBlock.TEXT_ALIGN_CHOICES])
     font_size = choice([c[0] for c in StyledTextBlock.FONT_SIZE_CHOICES])
     font_family = choice([c[0] for c in StyledTextBlock.FONT_FAMILY_CHOICES])
-    text = fake.text()
+    text = make_html_string()
     return generate_field(
         as_type,
         {
@@ -151,12 +151,12 @@ def generate_raw_html():
     return generate_field('raw_html', body.format(fuel=randrange(0, 101), progress=randrange(0, 101)))
 
 
-def generate_aligned_captioned_image():
+def generate_aligned_captioned_image(as_type='aligned_image'):
     image = choice(CustomImage.objects.filter(collection__name='Photos')).pk
-    caption = '<p>{}</p>'.format(' '.join(fake.words(nb=5)))
-    alignment = choice(ALIGNMENT_CHOICES)
+    caption = make_html_string()
+    alignment = choice(ALIGNMENT_CHOICES)[0]
     return generate_field(
-        'image', {'image': image, 'caption': caption, 'alignment': alignment}
+        as_type, {'image': image, 'caption': caption, 'alignment': alignment}
     )
 
 

--- a/common/tests/utils.py
+++ b/common/tests/utils.py
@@ -171,6 +171,10 @@ def generate_block_quote():
     )
 
 
+def generate_aside():
+    return generate_field('aside', {'text': make_html_string()})
+
+
 def generate_list():
     return generate_field('list', fake.words())
 
@@ -327,6 +331,7 @@ class StreamfieldProvider(BaseProvider):
             'info_table_emails': generate_info_table_emails,
             'info_table_external_links': generate_info_table_external_links,
             'info_table_plain_text': generate_info_table_plain_text,
+            'aside': generate_aside,
         }
 
         streamfield_data = []

--- a/common/tests/utils.py
+++ b/common/tests/utils.py
@@ -1,4 +1,4 @@
-from random import choice, randrange
+from random import choice, randrange, shuffle
 import json
 
 from faker import Faker
@@ -10,6 +10,29 @@ from common.choices import BACKGROUND_COLOR_CHOICES
 from common.blocks import StyledTextBlock, ALIGNMENT_CHOICES
 
 fake = Faker()
+
+
+def make_words(minimum=3, maximum=11):
+    return ' '.join(fake.words(nb=randrange(minimum, maximum)))
+
+
+def make_html_string():
+    sentence1 = fake.sentence()
+    pieces = [
+        '<strong>{}</strong>',
+        '<em>{}</em>',
+        '<a href="{url}">{{}}</a>'.format(
+            url=fake.url(schemes=['https']),
+        ),
+    ]
+    words = [make_words().capitalize(), make_words(), make_words()]
+    shuffle(pieces)
+
+    sentence2 = ', '.join([
+        piece.format(word)
+        for piece, word in zip(pieces, words)
+    ])
+    return f'{sentence1} {sentence2}.'
 
 
 def generate_field(field_type, value):

--- a/common/tests/utils.py
+++ b/common/tests/utils.py
@@ -1,4 +1,5 @@
 from random import choice, randrange, shuffle
+import functools
 import json
 
 from faker import Faker
@@ -102,6 +103,10 @@ def generate_rich_text_paragraph():
     return generate_field('rich_text', paragraph)
 
 
+def generate_rich_text_line():
+    return generate_field('rich_text', make_html_string())
+
+
 def generate_rich_text():
     paragraphs = (
         '<h3>{}</h3>'.format(fake.sentence()),
@@ -123,22 +128,9 @@ def generate_rich_text():
     return generate_field('rich_text', ''.join(paragraphs))
 
 
-def generate_heading1_field():
-    content = ' '.join(fake.words())
-
-    return generate_field('heading_1', {'content': content})
-
-
-def generate_heading2_field():
-    content = ' '.join(fake.words())
-
-    return generate_field('heading_2', {'content': content})
-
-
-def generate_heading3_field():
-    content = ' '.join(fake.words())
-
-    return generate_field('heading_3', {'content': content})
+def generate_heading_field(as_type='heading'):
+    content = ' '.join(fake.words()).title()
+    return generate_field(as_type, {'content': content})
 
 
 def generate_raw_html():
@@ -186,10 +178,10 @@ def generate_twitter_embed():
 
 
 def generate_tabs():
-    block_fns = [generate_heading2_field, generate_rich_text_paragraph]
+    block_fns = [functools.partial(generate_heading_field, as_type='heading_2'), generate_rich_text_paragraph]
     default_tab = {
         'value': [
-            generate_heading2_field(),
+            generate_heading_field(as_type='heading_2'),
             generate_rich_text_paragraph(),
             generate_twitter_embed(),
             generate_raw_html()
@@ -313,11 +305,13 @@ def generate_info_table_external_links():
 class StreamfieldProvider(BaseProvider):
     def streamfield(self, fields=None):
         valid_fields = {
-            'heading1': generate_heading1_field,
-            'heading2': generate_heading2_field,
-            'heading3': generate_heading3_field,
+            'heading1': functools.partial(generate_heading_field, as_type='heading_1'),
+            'heading2': functools.partial(generate_heading_field, as_type='heading_2'),
+            'heading3': functools.partial(generate_heading_field, as_type='heading_3'),
+            'heading': generate_heading_field,
             'rich_text': generate_rich_text,
             'rich_text_paragraph': generate_rich_text_paragraph,
+            'rich_text_line': generate_rich_text_line,
             'bare_image': generate_bare_image,
             'aligned_captioned_image': generate_aligned_captioned_image,
             'raw_html': generate_raw_html,

--- a/emails/devdata.py
+++ b/emails/devdata.py
@@ -1,0 +1,19 @@
+import factory
+
+from .models import EmailSettings, MailchimpGroup
+
+
+class MailchimpGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = MailchimpGroup
+
+    category_id = 0
+    group_id = 0
+
+
+class EmailSettingsFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = EmailSettings
+
+    mailchimp_collect_name = True
+    group1 = factory.RelatedFactory(MailchimpGroupFactory, 'page')

--- a/forms/templates/forms/form_page.html
+++ b/forms/templates/forms/form_page.html
@@ -7,7 +7,7 @@
 
     <section class="formpage-body">
         {% if page.intro %}
-            <div class="styled-text">
+            <div class="styled-text rich-text">
                 {{ page.intro|richtext }}
             </div>
         {% endif %}

--- a/forms/templates/forms/form_page_landing.html
+++ b/forms/templates/forms/form_page_landing.html
@@ -7,7 +7,7 @@
 
     <section class="formpage-body">
         {% if page.thank_you_text %}
-            <div class="styled-text">
+            <div class="styled-text rich-text">
                 {{ page.thank_you_text|richtext }}
             </div>
         {% endif %}

--- a/home/tests/factories.py
+++ b/home/tests/factories.py
@@ -12,7 +12,7 @@ factory.Faker.add_provider(StreamfieldProvider)
 class HomePageFactory(wagtail_factories.PageFactory):
     class Meta:
         model = HomePage
-        exclude = ('about_text')
+        exclude = ('about_text',)
 
     about_text = factory.Faker('paragraph', nb_sentences=10)
 

--- a/incident/devdata.py
+++ b/incident/devdata.py
@@ -542,7 +542,7 @@ class IncidentPageFactory(wagtail_factories.PageFactory):
 
 
 class MultimediaIncidentPageFactory(IncidentPageFactory):
-    body = Faker('streamfield', fields=['rich_text', 'bare_image', 'blockquote', 'raw_html'])
+    body = Faker('streamfield', fields=['rich_text', 'bare_image', 'rich_text', 'aligned_captioned_image', 'blockquote', 'raw_html'])
     teaser_image = Iterator(
         CustomImage.objects.filter(collection__name='Photos')
     )

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -66,8 +66,6 @@ INSTALLED_APPS = [
     'wagtail.images',
     'wagtail.search',
     'wagtail.admin',
-    # See https://docs.wagtail.io/en/stable/reference/contrib/legacy_richtext.html#legacy-richtext
-    'wagtail.contrib.legacy.richtext',
     'wagtail.core',
 
     'modelcluster',


### PR DESCRIPTION
Fixes #1288
Fixes #1276

This pull request:

1. Adds a fair amount of rich-text related content to the dev data, to make it easier to preview exactly how various parts of the site that use rich text will render links.
2. Removes the Wagtail's "legacy rich text" setting from our site, meaning the `richtext` filter will no longer wrap its content in `<div class="rich-text">`
3. Adds that div back in manually, where it can be done and the styles do not need to change.
4. Adds field-specific CSS for parts of the site where rich text requires different styling, namely blog page AsideBlock content and the footer (both of these sections have a dark background color).

See commit messages for more tech details. 