### PR TITLE
Site title fixes

### DIFF
--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -11,10 +11,12 @@
 	&.menu-expanded
 		background-color: #F8F8F8
 
+	&__title-wrapper
+		min-width: 11.5rem
+		display: inline-block
+
 .site-title-link
 	z-index: 1010
-	line-height: 27px
-	min-width: 11.5rem
 	text-decoration: none
 	font-weight: 700
 

--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -12,8 +12,8 @@
 		background-color: #F8F8F8
 
 	&__title-wrapper
-		min-width: 11.5rem
 		display: inline-block
+		flex-shrink: 0
 
 .site-title-link
 	z-index: 1010

--- a/common/templates/common/_menu.html
+++ b/common/templates/common/_menu.html
@@ -3,7 +3,7 @@
 <header class="header">
 	<div class="header__title-wrapper">
 		<a class="site-title-link text-link" href="/">
-			U.S Press Freedom Tracker
+			{{ self.get_site.site_name|default:"U.S Press Freedom Tracker" }}
 		</a>
 	</div>
 

--- a/common/templates/common/_menu.html
+++ b/common/templates/common/_menu.html
@@ -1,9 +1,11 @@
 {% load get_menu %}
 <a href="#title" class="skip-link">Skip to content</a>
 <header class="header">
-	<a class="site-title-link text-link" href="/">
-		U.S Press Freedom Tracker
-	</a>
+	<div class="header__title-wrapper">
+		<a class="site-title-link text-link" href="/">
+			U.S Press Freedom Tracker
+		</a>
+	</div>
 
 	<button class="mobile-nav-toggle" aria-controls="primary-navigation" aria-expanded="false">
 		<span class="sr-only">Menu</span>


### PR DESCRIPTION
This pull request:

1. Fixes the slight misalignment of the site title link WRT the top nav menu items (fixes #1294)
2. Removes the hard-coded site title text and replaces it with the actual title of the Wagtail site object, allowing the link text to be stored in the DB and edited in the admin.
3. Prevents the site title link from wrapping in a way that supports longer titles (the title should not wrap at all now, even if it's set to something longer than before).