### PR TITLE
Fixes a JS error in blog pagination

### DIFF
--- a/blog/templates/blog/_blog_list.html
+++ b/blog/templates/blog/_blog_list.html
@@ -3,7 +3,7 @@
 <section class="blog-list {% if type %}blog-list--{{ type }}{% endif %}">
 	<h2 class="heading-regular">{{ heading }}</h2>
 
-	<ol class="blog-list__posts {% if type %}blog-list__posts--{{ type }}{% endif %} {% if ajax_load %}js-article-loading-parent{% endif %}">
+	<ol class="blog-list__posts {% if type %}blog-list__posts--{{ type }}{% endif %} {% if ajax_load and blogs.has_other_pages %}js-article-loading-parent{% endif %}">
 		{% for blog in blogs %}
 			<li
 				class="blog-list__item


### PR DESCRIPTION
When the blog list because of some filter has very limited blogs that there is no pagination, it was throwing a JS error. So added a check in the template to see if there are more than one page of blog.