### PR TITLE
1296 Fix search button hover state

### DIFF
--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -3,7 +3,7 @@
 
 .search-button
 	position: absolute
+	height: 100%
 	right: 2px
-	top: 3.5px
 	border: 0
 	font-weight: 500


### PR DESCRIPTION
Fixes the white top and bottom border on search button hover by removing fixed position and making button 100% height of its container.