### PR TITLE
1298 Fix spacing incident card

### DIFF
--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -97,7 +97,7 @@
 		font-size: $font-size-small-p
 		line-height: 1.43
 		white-space: nowrap
-		margin-right: 1rem
+		margin-right: 0.5rem
 
 		&--bold
 			font-weight: 700

--- a/client/common/sass/components/_tag-list.sass
+++ b/client/common/sass/components/_tag-list.sass
@@ -9,5 +9,5 @@
 	align-content: flex-start
 
 	li
-		margin: 0 5px
+		margin: 0.5rem 0.5rem 0 0
 		padding: 0


### PR DESCRIPTION
@harrislapiroff 

Regarding these issues from https://github.com/freedomofpress/pressfreedomtracker.us/issues/1298:

**Text sizes still look a little off to me**
I've checked against Figma, and the text is rendering at 14px, which is what the design stipulates. I've not changed anything here.

**Space between keys and values looks too large on live site**
The spacing was 1 rem, where it should have been 0.5 rem (8px) - this has been adjusted.

**Space above tags looks too small on live site**
I've adjusted the margin on the `li` elements to give top and bottom spacing of 0.5 rem, as well as removing the left margin so the first item isn't indented.
