### PR TITLE
Ensure chart redirects to filter with YYYY-MM-DD format and correct date ranges

### DIFF
--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -44,8 +44,9 @@ function getFilteredUrl(databasePath, filtersApplied, currentDate) {
 			: currentDate.getUTCMonth() > 6 || monthNumber <= 6
 			? currentDate.getUTCFullYear()
 			: currentDate.getUTCFullYear() - 1
-		const firstDayMonth = `${year}-${monthNumber}-1`
-		const lastDayMonth = `${year}-${monthNumber}-${new Date(year, monthNumber, 0).getDate()}`
+		const paddedMonthNumber = String(monthNumber).padStart(2, '0')
+		const firstDayMonth = `${year}-${paddedMonthNumber}-01`
+		const lastDayMonth = `${year}-${paddedMonthNumber}-${new Date(year, monthNumber, 0).getDate()}`
 		parameters.push(`date_lower=${firstDayMonth}&date_upper=${lastDayMonth}`)
 	}
 
@@ -54,22 +55,19 @@ function getFilteredUrl(databasePath, filtersApplied, currentDate) {
 	}
 
 	if (filtersApplied.year !== null && filtersApplied.monthName === undefined) {
-		parameters.push(`date_lower=${filtersApplied.year}-1-1&date_upper=${filtersApplied.year}-12-31`)
+		parameters.push(`date_lower=${filtersApplied.year}-01-01&date_upper=${filtersApplied.year}-12-31`)
 	}
 
 	if (filtersApplied.sixMonths && filtersApplied.monthName === undefined) {
 		const currentMonth = currentDate.getUTCMonth()
 		const currentYear = currentDate.getUTCFullYear()
-		const previousYear = currentDate.getUTCFullYear() - 1
-		const firstDate = `${currentMonth > 5 ? currentYear : previousYear}-${
-			currentMonth > 5 ? currentMonth - 5 : 11 - (5 - currentMonth)
-		}-1`
-		const lastDate = `${currentYear}-${currentMonth}-${new Date(
-			currentYear,
-			currentMonth,
-			0
-		).getDay()}`
-		parameters.push(`date_lower=${firstDate}&date_upper=${lastDate}`)
+
+		const lastDate = new Date(currentYear, currentMonth + 1, 0)  // last day of the current month
+		const firstDate = new Date(currentYear, currentMonth - 5, 1)  // first day of the month five months ago
+		const firstDateFormatted = firstDate.toISOString().substring(0, 10)  // Extract the date portion of the ISO datetime
+		const lastDateFormatted = lastDate.toISOString().substring(0, 10)
+
+		parameters.push(`date_lower=${firstDateFormatted}&date_upper=${lastDateFormatted}`)
 	}
 
 	if (filtersApplied.tag !== null) {


### PR DESCRIPTION
This PR updates the range and date format used when someone clicks on an element of the home page chart and is redirected to a filtered view of the database page containing details on the same subset of data.

This format is required by the `<input type="date">` fields in the sidebar, and while the backend filter properly parses the date, the value supplied to the form will not be understood or populated in that field when the page renders.  This PR fixes that.

I've also fixed what I think is a logic bug in the "six month" date range.  The previous version of this code did not include the current month in the filter range, even though the chart includes that month. I've changed that code so that the database page is filtered to include the only same six months that are shown on the right-side bar graph.