### PR TITLE
Basic topic page

### DIFF
--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -55,3 +55,4 @@
 @import components/article-content
 @import components/filters
 @import components/anim-table
+@import components/topicpage

--- a/client/common/sass/components/_topicpage.sass
+++ b/client/common/sass/components/_topicpage.sass
@@ -1,0 +1,31 @@
+.topicpage
+	+constrain-to-desktop
+
+	&__inner
+		+desktop-up
+			max-width: 908px
+			margin: auto
+
+	&__block
+		+desktop-up
+			max-width: 673px
+			margin-left: auto
+			margin-right: 0
+
+	img
+		max-width: 100%
+
+.topicpage-body
+	+grid-container
+
+	&__content
+		grid-column: 1 / -1
+
+		+tablet-up
+			grid-column: 1 / 9
+
+	&__sidebar
+		grid-column: 1 / -1
+
+		+tablet-up
+			grid-column: 9 / -1

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -32,7 +32,7 @@ from forms.models import FormPage
 from forms.tests.factories import FormPageFactory
 from home.models import HomePage, FeaturedBlogPost, FeaturedIncident
 from incident.models import IncidentIndexPage, IncidentPage
-from incident.devdata import IncidentIndexPageFactory, IncidentLinkFactory, MultimediaIncidentUpdateFactory, MultimediaIncidentPageFactory
+from incident.devdata import IncidentIndexPageFactory, IncidentLinkFactory, MultimediaIncidentUpdateFactory, MultimediaIncidentPageFactory, TopicPageFactory
 from menus.models import Menu, MenuItem
 
 
@@ -372,6 +372,17 @@ class Command(BaseCommand):
             MultimediaIncidentUpdateFactory(page=incident)
             IncidentLinkFactory.create_batch(3, page=incident)
         home_page.save()
+
+        topic_page = TopicPageFactory(
+            parent=home_page,
+            incident_index_page=incident_index_page,
+            title='Important Animals Topic Page',
+            incident_tag__title='Important Animals',
+        )
+        tag = topic_page.incident_tag
+        tag.tagged_items.add(
+            *random.sample(list(IncidentPage.objects.all()), 20)
+        )
 
         # CREATE MENUS
         if not Menu.objects.filter(slug='primary-navigation').exists():

--- a/common/templates/common/blocks/button.html
+++ b/common/templates/common/blocks/button.html
@@ -1,0 +1,3 @@
+<a href="{{ self.url }}" class="btn btn-secondary">
+	{{ self.text }}
+</a>

--- a/incident/templates/incident/topic_page.html
+++ b/incident/templates/incident/topic_page.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+
+{% load wagtailcore_tags %}
+{% load richtext_inline from common_tags %}
+
+{% block main %}
+	<h1 class="article-title">{{ page.title }}</h1>
+
+	<article class="topicpage">
+		{% if page.description %}
+			{{ page.description|richtext_inline }}
+		{% endif %}
+
+		<section class="topicpage__inner">
+			{% include 'common/_video_or_image.html' with image=page.photo caption=page.photo_caption %}
+		</section>
+
+		<div class="topicpage-body">
+		<section class="topicpage-body__content">
+			{% for block in page.content %}
+				<div class="topicpage__block">{% include_block block %}</div>
+			{% endfor %}
+
+			<div class="topicpage__block">
+				<a class="btn btn-secondary" href="{% pageurl page.incident_index_page %}?tags={{ page.incident_tag.title }}">
+					View incidents in database
+				</a>
+			</div>
+		</section>
+
+		<section class="topicpage-body__sidebar">
+			{% for block in page.sidebar %}
+				{% if block.block_type == 'heading_2' %}
+					{% include_block block with classname='topic-sidebar__heading'%}
+				{% else %}
+					<section class="topic-sidebar__{{ block.block_type }}">{% include_block block %}</section>
+				{% endif %}
+			{% endfor %}
+		</section>
+		</div>
+	</article>
+
+{% endblock %}


### PR DESCRIPTION
This pull request creates a basic topic page template that renders the image, content and sidebar data, and adds a link to the relevant incidents on the DB page.

Extremely, extremely basic layout. Please feel free to critique and/or just make changes here, whoever is looking at this.