### PR TITLE
Tweak spacing issues around tags on incident cards

### DIFF
--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -30,9 +30,6 @@
 		+desktop-up
 			grid-column: span 3
 
-	&__tags
-		line-height: 2.2
-
 	&__details-title
 		+desktop-up
 			display: none

--- a/client/common/sass/components/_tag-list.sass
+++ b/client/common/sass/components/_tag-list.sass
@@ -9,5 +9,5 @@
 	align-content: flex-start
 
 	li
-		margin: 0.5rem 0.5rem 0 0
+		margin: 0 .5rem .5rem 0
 		padding: 0

--- a/client/common/sass/components/_tag-list.sass
+++ b/client/common/sass/components/_tag-list.sass
@@ -4,6 +4,7 @@
 	list-style-type: none
 	margin: 0
 	padding: 0
+	margin-top: .5rem
 	text-indent: 0
 	align-items: flex-start
 	align-content: flex-start

--- a/client/common/sass/components/_tag-list.sass
+++ b/client/common/sass/components/_tag-list.sass
@@ -4,11 +4,11 @@
 	list-style-type: none
 	margin: 0
 	padding: 0
-	margin-top: .5rem
+	margin-top: 0.5rem
 	text-indent: 0
 	align-items: flex-start
 	align-content: flex-start
 
 	li
-		margin: 0 .5rem .5rem 0
+		margin: 0 0.5rem 0.5rem 0
 		padding: 0


### PR DESCRIPTION
Apologies @SaptakS - I know you just reviewed and merged a tweak for these!

After doing some browser testing I've tweaked a couple of CSS properties for a better layout of these tags.