### PR TITLE
Adds richtext class to richtext renders for incident content

### DIFF
--- a/incident/templates/incident/_incident.html
+++ b/incident/templates/incident/_incident.html
@@ -5,6 +5,6 @@
 		{{ incident.last_updated|date:"F j, Y" }}
 	</a>
 	{% for block in incident.body %}
-		<div class="article-content__block">{% include_block block %}</div>
+		<div class="article-content__block {% if block.block_type == 'rich_text' %}rich-text{% endif %}">{% include_block block %}</div>
 	{% endfor %}
 </div>

--- a/incident/templates/incident/_incident_update.html
+++ b/incident/templates/incident/_incident_update.html
@@ -7,7 +7,7 @@
 	<h3 class="incident-update__title">{{ update.title }}</h3>
 	<div class="incident-update__description">
 		{% for block in update.body %}
-			<section class="article-content__block">{% include_block block %}</section>
+			<section class="article-content__block {% if block.block_type == 'rich_text' %}rich-text{% endif %}">{% include_block block %}</section>
 		{% endfor %}
 	</div>
 </div>


### PR DESCRIPTION
Fixes #1314 

The incident contents were missing the `rich-text` class after the richtext legacy was removed. I have conditionally added the rich-text class manually by checking the block_type. That seems to fix the isse. Also applied the same fix for the incident updates