### PR TITLE
Enable tag links on incident pages

### DIFF
--- a/incident/templates/incident/_incident_database_card.html
+++ b/incident/templates/incident/_incident_database_card.html
@@ -12,7 +12,7 @@
 		{% if incident.tags.all %}
 			<ul class="incident-database-card__tags tag-list">
 				{% for tag in incident.tags.all %}
-					<li><a href="{% pageurl index %}?tags={{ tag.pk }}" class="btn btn-tag">#{{ tag.title }}</a></li>
+					<li><a href="{% pageurl index %}?tags={{ tag.title|urlencode }}" class="btn btn-tag">#{{ tag.title }}</a></li>
 				{% endfor %}
 			</ul>
 		{% endif %}

--- a/incident/templates/incident/_incident_tags.html
+++ b/incident/templates/incident/_incident_tags.html
@@ -1,7 +1,10 @@
-{% if incident.get_tags %}
-    <ul class="tag-list">
-        {% for tag in incident.get_tags %}
-            <li><a href="#" class="btn btn-tag">#{{ tag.title }}</a></li>
-        {% endfor %}
-    </ul>
+{% load pageurl from wagtailcore_tags %}
+{% if incident.get_tags and incident.get_parent %}
+	{% with parent=incident.get_parent %}
+		<ul class="tag-list">
+			{% for tag in incident.get_tags %}
+				<li><a href="{% pageurl parent %}?tags={{ tag.title|urlencode }}" class="btn btn-tag">#{{ tag.title }}</a></li>
+			{% endfor %}
+		</ul>
+	{% endwith %}
 {% endif %}


### PR DESCRIPTION
This PR makes the tags on incident pages clickable (they link to the DB page filtered by that tag), and makes the existing tag links on incident cards compatible with the text-based form fields on the DB page as well.