### PR TITLE
Style cleanup database page

### DIFF
--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -21,6 +21,7 @@
 	background-position: right
 	padding-right: 17px
 	cursor: pointer
+	position: sticky
 
 .filters__group
 	border-bottom: 1px solid rgba(0, 0, 0, 0.1)

--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -15,21 +15,25 @@
 	align-items: center
 
 .filters__form-summary
+	margin: -1rem -2rem
+	padding: 1rem 2rem
 	display: block
-	background-image: url(../icons/arrow-down-thin.svg)
-	background-repeat: no-repeat
-	background-position: right
-	padding-right: 17px
 	cursor: pointer
 	position: sticky
+	top: 0
+	background-color: $section-background
+	&::before
+		float: right
+		content: url('../icons/arrow-down-thin.svg')
 
 .filters__group
 	border-bottom: 1px solid rgba(0, 0, 0, 0.1)
 	padding: 1rem 2rem
 
-	&[open]
-		.filters__form-summary
-			background-image: url(../icons/arrow-up-thin.svg)
+	&[open] .filters__form-summary
+		margin-bottom: 1rem
+		&::before
+			content: url('../icons/arrow-up-thin.svg')
 
 	ul
 		list-style-type: none
@@ -37,3 +41,18 @@
 
 .filters__fieldset
 	border: 0
+
+.filters__field-row
+	margin-bottom: 1.25rem
+
+.filters__field-label
+	margin-bottom: 0.25rem
+	font-size: $font-size-small-ui
+
+.filters__form-actions
+	border-top: 1px solid rgba(0, 0, 0, 0.1)
+	margin: 0 -2rem -1rem
+	padding: 1rem 2rem
+	position: sticky
+	bottom: 0
+	background-color: $section-background

--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -30,5 +30,9 @@
 		.filters__form-summary
 			background-image: url(../icons/arrow-up-thin.svg)
 
+	ul
+		list-style-type: none
+		padding-left: 0
+
 .filters__fieldset
 	border: 0

--- a/client/common/sass/components/_text-field.sass
+++ b/client/common/sass/components/_text-field.sass
@@ -6,19 +6,24 @@
 	border: 2px solid
 
 	&--single
+		box-sizing: border-box
 		width: 100%
 		max-width: 668px
-		height: 24px
 		border-width: 0
-		border-bottom: 1px solid
+		border-bottom: 2px solid
 		font-style: italic
-		font-size: $font-size-p-desktop
+		font-size: $font-size-small-ui
 		line-height: 1.33
+		padding: 0.125rem
 
 		&:focus
-			border: 3px solid
 			background: $tag-inactive-bg
-			outline: none
+			outline: 3px solid #000
+			// Remove the border bottom to make the outline
+			// the only border on the bottom, but add 2px
+			// padding to make up for it
+			border-bottom: 0
+			padding-bottom: calc(0.125rem + 2px)
 
 	&--search-bar
 		width: 100%

--- a/incident/templates/incident/_filters.html
+++ b/incident/templates/incident/_filters.html
@@ -10,16 +10,22 @@
 				{{ item.title }}
 			</summary>
 			{% for field in item %}
-				<div>
+				<div class="filters__field-row">
 					{% if field.widget_type == 'radioselect' or field.widget_type == 'checkboxselectmultiple' %}
-						<p><strong>{{ field.label }}</strong></p>
+						<div class="filters__field-label">
+							{{ field.label }}
+						</div>
 					{% else %}
-    					<p><strong><label for="{{ field.id_for_label }}">{{ field.label }}</label></strong></p>
+						<div class="filters__field-label">
+							<label for="{{ field.id_for_label }}">{{ field.label }}</label>
+						</div>
 					{% endif %}
 					{{ field }}
 				</div>
 			{% endfor %}
 		</details>
 	{% endfor %}
-	<button class="btn btn-secondary filters__form--submit" type="submit">Apply filters</button>
+	<div class="filters__form-actions">
+		<button class="btn btn-secondary filters__form--submit" type="submit">Apply filters</button>
+	</div>
 </form>

--- a/incident/templates/incident/_filters.html
+++ b/incident/templates/incident/_filters.html
@@ -11,11 +11,10 @@
 			</summary>
 			{% for field in item %}
 				<div>
-					{% if field.field_type == 'radio' or field.field_type == 'bool' %}
-						<p>{{ field.title }}</p>
-    					<label for="{{ field.id_for_label }}">{{ field.label }}</label>
+					{% if field.widget_type == 'radioselect' or field.widget_type == 'checkboxselectmultiple' %}
+						<p><strong>{{ field.label }}</strong></p>
 					{% else %}
-    					<p><label for="{{ field.id_for_label }}">{{ field.label }}</label></p>
+    					<p><strong><label for="{{ field.id_for_label }}">{{ field.label }}</label></strong></p>
 					{% endif %}
 					{{ field }}
 				</div>

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -32,6 +32,7 @@ class DatalistField(forms.ChoiceField):
         attrs = super().widget_attrs(widget)
         attrs['list'] = self.list_name
         attrs['class'] = 'text-field--single'
+        attrs['autocomplete'] = 'off'
         return attrs
 
 
@@ -60,7 +61,10 @@ class FilterForm(forms.Form):
                 if _type == 'text':
                     field = forms.CharField
                     kwargs['widget'] = forms.TextInput(
-                        attrs={'class': 'text-field--single'},
+                        attrs={
+                            'class': 'text-field--single',
+                            'autocomplete': 'off',
+                        },
                     )
 
                 if _type == 'autocomplete':

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -31,6 +31,7 @@ class DatalistField(forms.ChoiceField):
     def widget_attrs(self, widget):
         attrs = super().widget_attrs(widget)
         attrs['list'] = self.list_name
+        attrs['class'] = 'text-field--single'
         return attrs
 
 
@@ -58,6 +59,9 @@ class FilterForm(forms.Form):
 
                 if _type == 'text':
                     field = forms.CharField
+                    kwargs['widget'] = forms.TextInput(
+                        attrs={'class': 'text-field--single'},
+                    )
 
                 if _type == 'autocomplete':
                     field = DatalistField


### PR DESCRIPTION
Fixes #1305 

This PR adjusts the styles of the DB page in accordance with the above issue. I also added an additional change to remove browser-level autocomplete from trying to fill in the "City" field on top of the datalist autocomplete options our site provides.

I'm actually not sure what adding position sticky is accomplishing on the section headers. I did some scrolling around the page and they didn't seem to stick for me. Maybe it's because it's already nested in a sticky positioned element? I'm not sure what the overall design goal of that change is either, so I'm slightly at a loss for alternatives.