### PR TITLE
Fix category page rendering

### DIFF
--- a/common/templates/common/_category_methodology_section.html
+++ b/common/templates/common/_category_methodology_section.html
@@ -2,10 +2,10 @@
 
 <h2 class="methodology-section-header">Data Tracked For This Category</h2>
 
-<div class="methodology-summary rich-text">{{ methodology|richtext }}</div>
+<div class="methodology-summary rich-text">{{ methodology_summary|richtext }}</div>
 
 <dl class="methodology-details-table">
-	{% for item in methodology.data_items %}
+	{% for item in items %}
 	<div class="details-table__row">
 		<dt class="details-table__label details-table__label--bold">
 			{{ item.label }}

--- a/common/templates/common/category_page.html
+++ b/common/templates/common/category_page.html
@@ -23,10 +23,10 @@
 		</div>
 	</section>
 
-	{% if methodology.description or methodology.data_items %}
+	{% if page.methodology or page.methodology_items.all %}
 		<section class="categorypage-section categorypage-section--gray">
 			<div class="categorypage-section-inner">
-				{% include "common/_category_methodology_section.html" %}
+				{% include "common/_category_methodology_section.html" with items=page.methodology_items.all methodology_summary=page.methodology only %}
 			</div>
 		</section>
 	{% endif %}

--- a/common/tests/test_category_page.py
+++ b/common/tests/test_category_page.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.urls import reverse
@@ -136,7 +134,6 @@ class IncidentFilterTest(TestCase):
             incident_filter.clean()
 
 
-@unittest.skip("Skipping till templates have been added")
 class CategoryPageTest(TestCase):
     def setUp(self):
         Page.objects.filter(slug='home').delete()
@@ -189,6 +186,7 @@ class CategoryPageTest(TestCase):
         post_data = {
             'slug': self.category_page.slug,
             'title': 'ABC',
+            'methodology': '{}',
             'quick_facts-TOTAL_FORMS': 0,
             'quick_facts-INITIAL_FORMS': 0,
             'quick_facts-MIN_NUM_FORMS': 0,
@@ -197,6 +195,18 @@ class CategoryPageTest(TestCase):
             'statistics_items-INITIAL_FORMS': 0,
             'statistics_items-MIN_NUM_FORMS': 0,
             'statistics_items-MAX_NUM_FORMS': 1000,
+            'featured_incidents-TOTAL_FORMS': 0,
+            'featured_incidents-INITIAL_FORMS': 0,
+            'featured_incidents-MIN_NUM_FORMS': 0,
+            'featured_incidents-MAX_NUM_FORMS': 1000,
+            'featured_blogs-TOTAL_FORMS': 0,
+            'featured_blogs-INITIAL_FORMS': 0,
+            'featured_blogs-MIN_NUM_FORMS': 0,
+            'featured_blogs-MAX_NUM_FORMS': 1000,
+            'methodology_items-TOTAL_FORMS': 0,
+            'methodology_items-INITIAL_FORMS': 0,
+            'methodology_items-MIN_NUM_FORMS': 0,
+            'methodology_items-MAX_NUM_FORMS': 1000,
             'incident_filters-TOTAL_FORMS': 0,
             'incident_filters-INITIAL_FORMS': 0,
             'incident_filters-MIN_NUM_FORMS': 0,
@@ -219,7 +229,6 @@ class CategoryPageTest(TestCase):
         self.assertEqual(response.context['page'], self.category_page)
 
 
-@unittest.skip("Skipping till templates have been added")
 class CategoryPageMethodologyStatisticsTest(WagtailPageTests):
     @classmethod
     def setUpTestData(cls):
@@ -253,6 +262,9 @@ class CategoryPageMethodologyStatisticsTest(WagtailPageTests):
             'page_symbol': 'arrest',
             'quick_facts': inline_formset([]),
             'statistics_items': inline_formset([]),
+            'featured_incidents': inline_formset([]),
+            'featured_blogs': inline_formset([]),
+            'methodology_items': inline_formset([]),
             'incident_filters': inline_formset([]),
         }
 


### PR DESCRIPTION
This PR fixes the 500 error on category pages. 

I'll note that this problem would have been caught earlier by tests, but we had marked the ones that would have caught it as `skip`, so they were not being run :sweat_smile: 
