### PR TITLE
Correctly display `case_type` field

### DIFF
--- a/incident/templates/incident/_database_card_table.html
+++ b/incident/templates/incident/_database_card_table.html
@@ -92,7 +92,7 @@
 			</dt>
 			<dd class="database-card-table__value">
 				<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_type={{ incident.case_type }}{% endif %}">
-					{{ incident.case_type }}
+					{{ incident.get_case_type_display }}
 				</a>
 			</dd>
 		</div>

--- a/incident/templates/incident/_incident_details_table.html
+++ b/incident/templates/incident/_incident_details_table.html
@@ -92,7 +92,7 @@
 		</dt>
 		<dd class="details-table__value">
 			<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_type={{ incident.case_type }}{% endif %}">
-				{{ incident.case_type }}
+				{{ incident.get_case_type_display }}
 			</a>
 		</dd>
 	</div>


### PR DESCRIPTION
We have been showing the "value" for this field, rather than the display text.