### PR TITLE
Fix category page slugs

### DIFF
--- a/common/devdata.py
+++ b/common/devdata.py
@@ -84,7 +84,7 @@ class CategoryPageFactory(wagtail_factories.PageFactory):
         arrest = factory.Trait(
             title='Arrest / Criminal Charge',
             plural_name='Arrests and Criminal Charges',
-            slug='arrest',
+            slug='arrest-criminal-charge',
             page_symbol='arrest',
         )
         border_stop = factory.Trait(
@@ -96,13 +96,13 @@ class CategoryPageFactory(wagtail_factories.PageFactory):
         denial_of_access = factory.Trait(
             title='Denial of Access',
             plural_name='Denials of Access',
-            slug='denial-of-access',
+            slug='denial-access',
             page_symbol='denial_of_access',
         )
         equipment_search = factory.Trait(
             title='Equipment Search or Seizure',
             plural_name='Equipment Searches, Seizures and Damage',
-            slug='equipment-search',
+            slug='equipment-search-seizure-or-damage',
             page_symbol='equipment_search',
         )
         physical_attack = factory.Trait(

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -82,11 +82,27 @@ FACTORY_ARGS_BY_CATEGORY = {
     }
 }
 
+# mapping of Trait parameters on the CategoryPageFactory to slugs
+# belonging to actual CategoryPage objects.
+PARAM_TO_SLUG_MAP = {
+    'arrest': 'arrest-criminal-charge',
+    'border_stop': 'border-stop',
+    'denial_of_access': 'denial-access',
+    'equipment_search': 'equipment-search-seizure-or-damage',
+    'physical_attack': 'physical-attack',
+    'leak_case': 'leak-case',
+    'subpoena': 'subpoena',
+    'equipment_damage': 'equipment-damage',
+    'other_incident': 'other-incident',
+    'chilling_statement': 'chilling-statement',
+    'prior_restraint': 'prior-restraint',
+}
+
 
 def lookup_category(key):
-    key = key.replace("_", "-")
+    slug = PARAM_TO_SLUG_MAP[key]
     try:
-        return CategoryPage.objects.get(slug=key)
+        return CategoryPage.objects.get(slug=slug)
     except CategoryPage.DoesNotExist:
         raise CommandError(f'Could not find category with slug `{key}`')
 
@@ -337,13 +353,13 @@ class Command(BaseCommand):
             main_menu=True,
             title='All Incidents',
         )
-        for category_slugs in generate_variations():
+        for category_keys in generate_variations():
             category_pages = []
             kwargs = {}
-            for slug in category_slugs:
-                category_pages.append(lookup_category(slug))
+            for key in category_keys:
+                category_pages.append(lookup_category(key))
                 kwargs.update(
-                    FACTORY_ARGS_BY_CATEGORY.get(slug, {})
+                    FACTORY_ARGS_BY_CATEGORY.get(key, {})
                 )
             n = random.random()
             if n < 0.25:

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -64,7 +64,7 @@ class CategoryPageFactory(wagtail_factories.PageFactory):
         arrest = factory.Trait(
             title='Arrest / Criminal Charge',
             plural_name='Arrests and Criminal Charges',
-            slug='arrest'
+            slug='arrest-criminal-charge'
         )
         border_stop = factory.Trait(
             title='Border Stop',
@@ -74,12 +74,12 @@ class CategoryPageFactory(wagtail_factories.PageFactory):
         denial_of_access = factory.Trait(
             title='Denial of Access',
             plural_name='Denials of Access',
-            slug='denial-of-access',
+            slug='denial-access',
         )
         equipment_search = factory.Trait(
             title='Equipment Search or Seizure',
             plural_name='Equipment Searches, Seizures and Damage',
-            slug='equipment-search',
+            slug='equipment-search-seizure-or-damage',
         )
         physical_attack = factory.Trait(
             title='Physical Attack',

--- a/incident/models/category_fields.py
+++ b/incident/models/category_fields.py
@@ -37,7 +37,7 @@ from incident.utils.category_field_values import (
 )
 
 CATEGORY_FIELD_MAP = {
-    'arrest': [
+    'arrest-criminal-charge': [
         ('arrest_status', 'Arrest Status'),
         ('status_of_charges', 'Status of Charges'),
         ('arresting_authority', 'Arresting Authority'),
@@ -50,7 +50,7 @@ CATEGORY_FIELD_MAP = {
     'equipment-damage': [
         ('equipment_broken', 'Equipment Broken'),
     ],
-    'equipment-search': [
+    'equipment-search-seizure-or-damage': [
         ('equipment_seized', 'Equipment Seized'),
         ('status_of_seized_equipment', 'Status of Seized Equipment'),
         ('is_search_warrant_obtained', 'Search Warrant Obtained'),
@@ -87,7 +87,7 @@ CATEGORY_FIELD_MAP = {
     'prior-restraint': [
         ('status_of_prior_restraint', 'Status of Prior Restraint'),
     ],
-    'denial-of-access': [
+    'denial-access': [
         ('politicians_or_public_figures_involved', 'Politicians or Public Figures Involved'),
     ],
 }


### PR DESCRIPTION
Update the category page slugs we have defined in the code to match the values on the actual pages in production. If these do not match, the corresponding fields will not be shown on the DB incident cards.