### PR TITLE
Use text for URL parameters when generating DB page filter links

### DIFF
--- a/incident/templates/incident/category_field/_equipment_list_field.html
+++ b/incident/templates/incident/category_field/_equipment_list_field.html
@@ -2,7 +2,7 @@
 <ul class="details-table__list">
   {% for item in items %}
     <li class="details-table__list-item">
-      <a href="{% pageurl page.get_parent %}?{{ field }}={{ item.equipment.pk }}" class="text-link">
+      <a href="{% pageurl page.get_parent %}?{{ field }}={{ item.equipment.name }}" class="text-link">
 				{{ item.equipment.name|capfirst }}, {{ item.quantity }}
 			</a>
     </li>

--- a/incident/templates/incident/category_field/_list_field.html
+++ b/incident/templates/incident/category_field/_list_field.html
@@ -2,7 +2,7 @@
 <ul class="details-table__list">
   {% for item in items %}
     <li class="details-table__list-item">
-      <a href="{% pageurl page.get_parent %}?{{ field }}={{ item.pk }}" class="text-link">{{ item.title|capfirst }}</a>
+      <a href="{% pageurl page.get_parent %}?{{ field }}={{ item.title }}" class="text-link">{{ item.title|capfirst }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -52,7 +52,7 @@ class TestCategoryFieldValuesByField(TestCase):
         output = render_function(self.incident, field_name)
         for item in getattr(self.incident, field_name).all():
             self.assertIn(item.title, output)
-            self.assertIn(f'{field_name}={item.pk}', output)
+            self.assertIn(f'{field_name}={item.title}', output)
         getattr(self.incident, field_name).clear()
         output = render_function(self.incident, field_name)
         self.assertEqual(output, '')
@@ -61,7 +61,7 @@ class TestCategoryFieldValuesByField(TestCase):
         output = render_function(self.incident, field_name)
         for item in getattr(self.incident, field_name).all():
             self.assertIn(item.equipment.name, output)
-            self.assertIn(f'{field_name}={item.equipment.pk}', output)
+            self.assertIn(f'{field_name}={item.equipment.name}', output)
         getattr(self.incident, field_name).clear()
         output = render_function(self.incident, field_name)
         self.assertEqual(output, '')
@@ -106,7 +106,7 @@ class TestCategoryFieldValuesByField(TestCase):
 
         output = CAT_FIELD_VALUES['arresting_authority'](self.incident, 'arresting_authority')
         self.assertIn(leo.title.capitalize(), output)
-        self.assertIn(f'arresting_authority={leo.pk}', output)
+        self.assertIn(f'arresting_authority={leo.title}', output)
 
     def test_current_charges(self):
         self.incident.current_charges = ChargeFactory.create_batch(2)

--- a/incident/utils/category_field_values.py
+++ b/incident/utils/category_field_values.py
@@ -95,7 +95,7 @@ def arresting_authority_html_val(page, field):
     link = '{}?{}={}'.format(
         page.get_parent().get_url(),
         field,
-        getattr(page, field).pk
+        getattr(page, field).title
     )
     value = getattr(page, field).title.capitalize()
 


### PR DESCRIPTION
This PR fixes a problem where the links on DB cards were generating links to the filtered DB page using primary keys rather than text values. This would cause the integer to appear in the filter sidebar form for that field, which is not wanted.