### PR TITLE
Makes mobile menu fixes

### DIFF
--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -85,6 +85,7 @@
 			text-decoration: none
 			justify-content: space-between
 			border-bottom: solid 1px #c1c1c1
+			padding-bottom: 4px
 			font-weight: 700
 
 			&:hover
@@ -100,9 +101,11 @@
 
 .secondary-navigation
 	display: flex
+	flex-wrap: wrap
 	gap: 1rem
 	list-style: none
 	margin: 0
+	margin-bottom: 2rem
 	padding: 0
 
 .overflow-hidden


### PR DESCRIPTION
fixes #1342 

![image](https://user-images.githubusercontent.com/9530293/161756810-96d34e70-2bed-470c-86cd-92f8f06c4e30.png)

I made the flex wrap so that instead of the text in button wrapping, it goes to next line, I feel that looks better than having the buttons side-by-side and then the text inside breaking the button layout. Let me know if you feel strongly otherwise.