### PR TITLE
Modifies the behavior of blog index page when filtered by author or organization

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -93,9 +93,9 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
         entry_qs = post_filters.filter(self.get_posts())
 
         if request.GET.get('author'):
-            context['author_filter'] = get_object_or_404(PersonPage, pk=post_filters.author)
+            author_filter = get_object_or_404(PersonPage, pk=post_filters.author)
         if request.GET.get('organization'):
-            context['organization_filter'] = get_object_or_404(OrganizationPage, pk=post_filters.organization)
+            organization_filter = get_object_or_404(OrganizationPage, pk=post_filters.organization)
 
         paginator, entries = paginate(
             request,
@@ -108,9 +108,17 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
         context['entries_page'] = entries
         context['paginator'] = paginator
 
-        context['featured_blogs'] = [
-            f.page for f in self.featured_blogs.select_related('page').all()
-        ]
+        if not request.GET.get('author') and not request.GET.get('organization'):
+            context['featured_blogs'] = [
+                f.page for f in self.featured_blogs.select_related('page').all()
+            ]
+
+        context['incident_listing_heading'] = 'Latest'
+        if request.GET.get('author'):
+            context['incident_listing_heading'] = f'Showing posts by <b>{author_filter.title}</b>'
+        if request.GET.get('organization'):
+            context['incident_listing_heading'] = f'Showing posts by <b>{organization_filter.title}</b>'
+
 
         return context
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -119,7 +119,6 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
         if request.GET.get('organization'):
             context['incident_listing_heading'] = f'Showing posts by <b>{organization_filter.title}</b>'
 
-
         return context
 
     def get_cache_tag(self):

--- a/blog/templates/blog/_blog_list.html
+++ b/blog/templates/blog/_blog_list.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags common_tags %}
 
 <section class="blog-list {% if type %}blog-list--{{ type }}{% endif %}">
-	<h2 class="heading-regular">{{ heading }}</h2>
+	<h2 class="heading-regular">{{ heading | safe }}</h2>
 
 	<ol class="blog-list__posts {% if type %}blog-list__posts--{{ type }}{% endif %} {% if ajax_load and blogs.has_other_pages %}js-article-loading-parent{% endif %}">
 		{% for blog in blogs %}

--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -23,6 +23,6 @@
 		</section>
 	{% endif %}
 
-	{% include 'blog/_blog_list.html' with blogs=entries_page heading='Latest' ajax_load=True request=request only %}
+	{% include 'blog/_blog_list.html' with blogs=entries_page heading=incident_listing_heading ajax_load=True request=request only %}
 
 {% endblock %}


### PR DESCRIPTION
Resolves #1348 

- Don't load featured section if filtered by author or organization
- Update the blog listing heading based on the author and org name