### PR TITLE
Use 1 or 0 as filter query parameters for boolean fields

### DIFF
--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -79,11 +79,11 @@ class TestCategoryFieldValuesByField(TestCase):
         setattr(self.incident, field_name, True)
         output = render_function(self.incident, field_name)
         self.assertIn('Yes', output)
-        self.assertIn(f'{field_name}=True', output)
+        self.assertIn(f'{field_name}=1', output)
         setattr(self.incident, field_name, False)
         output = render_function(self.incident, field_name)
         self.assertIn('No', output)
-        self.assertIn(f'{field_name}=False', output)
+        self.assertIn(f'{field_name}=0', output)
 
     def test_arrest_status(self):
         self.assert_choices(
@@ -363,4 +363,5 @@ class CategoryFieldValues(TestCase):
     def test_should_get_boolean_category_fields(self):
         arrest_details = self.category_details[self.category1]
         self.assertEqual(arrest_details[7]['name'], 'Unnecessary use of force?')
-        self.assertIn(str(self.incident.unnecessary_use_of_force), arrest_details[7]['html'])
+        expected_value = '1' if self.incident.unnecessary_use_of_force else '0'
+        self.assertIn(expected_value, arrest_details[7]['html'])

--- a/incident/utils/category_field_values.py
+++ b/incident/utils/category_field_values.py
@@ -30,7 +30,7 @@ def boolean_html_val(page, field):
     return render_to_string('incident/category_field/_basic_field.html', {
         'page': page,
         'field': field,
-        'value': value,
+        'value': '1' if value else '0',
         'display_value': display_value
     })
 


### PR DESCRIPTION
Replaces, for example, `held_in_contempt=True` with `held_in_contempt=1`. This allows the filter form to properly populate that value into the radio button list, as that field has 1/0 values, rather than True/False values.