### PR TITLE
Fixes search button for safari

### DIFF
--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -7,5 +7,6 @@
 	right: 2px
 	top: 2px
 	border: 0
+	margin: 0
 	font-weight: 500
 	background-color: $white

--- a/client/common/sass/components/_text-field.sass
+++ b/client/common/sass/components/_text-field.sass
@@ -27,6 +27,7 @@
 
 	&--search-bar
 		width: 100%
+		margin: 0
 		border: 2px solid
 		padding: 13px 24px
 		font-style: italic


### PR DESCRIPTION
Fixes #1361 

Seems like safari was adding a marging of 2px around the entire input field and the search bar as a browser default appearance. So I added margin: 0 in both to ensure that no margin is added.