### PR TITLE
Uses page title instead of hardcoded text in index pages

### DIFF
--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -5,7 +5,7 @@
 {% block main %}
 
 	<h1 class="page-title" id="title">
-		Blog
+		{{ page.title }}
 	</h1>
 
 	{% if page.body %}

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -4,7 +4,7 @@
 
 {% block main %}
 	{% pageurl page as current_page_url %}
-	<h1 class="page-title" id="title">Incidents Database</h1>
+	<h1 class="page-title" id="title">{{ page.title }}</h1>
 	<button class="mobile-filter-toggle" aria-controls="database-filters" aria-expanded="false">
 		Filters
 	</button>


### PR DESCRIPTION
I just discussed with @harrislapiroff and I think we want the website to reflect the page title set in the admin instead of hard coded text. This also means if we want the text shown in design, we need to update that in prod.