### PR TITLE
Fix date instantiation

### DIFF
--- a/client/charts/js/components/HomepageSelection.jsx
+++ b/client/charts/js/components/HomepageSelection.jsx
@@ -33,7 +33,7 @@ export default function HomepageSelection({
 	data: originalDataset,
 	numberOfTags = 5,
 	selectedTags = chooseMostFrequentTags(originalDataset, numberOfTags),
-	currentDate = new Date(Date.UTC()),
+	currentDate = new Date(),
 	filtersApplied,
 	setFiltersApplied,
 }) {


### PR DESCRIPTION
`Date.UTC()` (with zero arguments) always returns `NaN`, so let's avoid calling that when what we want is the current date:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC#compatibility_notes

In my testing locally, this fixed the issue described in #1368 