### PR TITLE
Limit "recent incidents" on category page to only that category

### DIFF
--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -451,6 +451,7 @@ class CategoryPage(MetadataPageMixin, Page):
             orphans=5
         )
 
+        context['recent_incidents'] = incident_qs
         context['entries_page'] = entries
         context['paginator'] = paginator
         context['summary_table'] = incident_filter.get_summary()

--- a/common/templates/common/category_page.html
+++ b/common/templates/common/category_page.html
@@ -43,7 +43,7 @@
 		{% if search_page %}
 			<section class="categorypage-section categorypage-section--gray">
 				<div class="categorypage-section-inner">
-					{% include "home/_recent_incidents_section.html" with count=8 %}
+					{% include "home/_recent_incidents_section.html" with count=8 incidents_base=recent_incidents %}
 				</div>
 			</section>
 		{% endif %}

--- a/common/tests/test_category_page.py
+++ b/common/tests/test_category_page.py
@@ -30,6 +30,20 @@ class ContextTest(TestCase):
 
         self.assertEqual(set(context['entries_page']), {incident1})
 
+    def test_unpaginated_recent_incidents(self):
+        category1 = CategoryPageFactory()
+        category2 = CategoryPageFactory()
+        incident3 = IncidentPageFactory(categories=[category1], date='2022-01-01')
+        incident1 = IncidentPageFactory(categories=[category1], date='2022-03-01')
+        incident2 = IncidentPageFactory(categories=[category1], date='2022-02-01')
+        IncidentPageFactory(title='Not relevant', categories=[category2])
+
+        request = RequestFactory().get('/')
+
+        context = category1.get_context(request)
+
+        self.assertEqual(list(context['recent_incidents']), [incident1, incident2, incident3])
+
     def test_incidents_filtered_by_category__and_choice(self):
         category1 = CategoryPageFactory(incident_filters=['arrest_status'])
         category2 = CategoryPageFactory()

--- a/home/templates/home/_recent_incidents_section.html
+++ b/home/templates/home/_recent_incidents_section.html
@@ -2,7 +2,7 @@
 
 <h2 class="homepage-section-header">{{ label|default:"Recent Incidents" }}</h2>
 
-{% with incidents=search_page.get_incidents|slice:count %}
+{% with incidents=incidents_base|slice:count %}
 	<ul class="article-carousel__items">
 		{% for incident in incidents %}
 			<li class="article-carousel__item article-carousel__item--latest">

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -65,7 +65,7 @@
 		{% if search_page %}
 			<section class="homepage-section">
 				<div class="homepage-section-inner">
-					{% include "home/_recent_incidents_section.html" with label=page.recent_incidents_label more_label=page.recent_incidents_more_label count=page.recent_incidents_count %}
+					{% include "home/_recent_incidents_section.html" with incidents_base=search_page.get_incidents label=page.recent_incidents_label more_label=page.recent_incidents_more_label count=page.recent_incidents_count %}
 				</div>
 			</section>
 		{% endif %}


### PR DESCRIPTION
This, I think, is the most minimal change needed here to make this
section display the correct data.  I think a lot of what's in the
`context` dict of the category page is obsolete, but that's best
solved another time.

Fixes #1378 