### PR TITLE
Replace reset button with "clear all" link

### DIFF
--- a/incident/templates/incident/_filters.html
+++ b/incident/templates/incident/_filters.html
@@ -2,7 +2,7 @@
 	<header class="filters__header">
 		Filters
 
-		<button class="btn btn-ghost" type="reset">Clear All</button>
+		<a class="btn btn-ghost" href="{{ page.url }}">Clear All</a>
 	</header>
 	{% for item in filters %}
 		<details class="filters__group" role="group" aria-labelledby="{{ item.title|slugify }}"{% if item.has_changed %}open{% endif %}>


### PR DESCRIPTION
The `<button type="reset">` restores the form to the state it was in
_when the page loaded_, meaning the pre-populated values (from the GET
parameters) are still there.  What we want is "clear all"
functionality, which would put the blank value into all fields, even
if they were pre-populated.  This change accomplishes that.