### PR TITLE
Amends mobile-nav-toggle top and right positions to match figma design

### DIFF
--- a/client/common/sass/components/_menu.sass
+++ b/client/common/sass/components/_menu.sass
@@ -37,13 +37,14 @@
 		width: 3rem
 		// fix for button not displaying iPad Pro
 		height: 3rem
-		top: 1rem
-		right: 2rem
+		top: 0.5rem
+		right: 1rem
 		aspect-ratio: 1
 
 	&[aria-expanded="true"]
 		+tablet-down
 			background-image: url(../icons/icon-menu-close.svg)
+			top: 0.45rem
 
 .top-nav-bar
 	box-sizing: border-box


### PR DESCRIPTION
Fixes this browser testing issue: https://github.com/freedomofpress/pressfreedomtracker.us/issues/1307#issuecomment-1081629959