### PR TITLE
Homepage API performance proof of concept

### DIFF
--- a/client/common/js/home.jsx
+++ b/client/common/js/home.jsx
@@ -35,7 +35,7 @@ chartContainers.forEach((node) => {
 
 	ReactDOM.render((
 		<DataLoader
-			dataUrl={`/api/edge/incidents/?${params.toString()}`}
+			dataUrl={`/api/edge/incidents/homepage_csv/?${params.toString()}`}
 			loadingComponent={(
 				<HomepageMainCharts selectedTags={selectedTags} databasePath={databasePath} data={[]} loading={true} />
 			)}

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -34,7 +34,7 @@
 				data-tags="{{ data_viz_tags_json|escape }}"
 				{% if search_page %}data-database-path="{% pageurl search_page %}"{% endif %}
 				{% if page.viz_data_start %}data-start-date="{{ page.viz_data_start|date:'c' }}"{% endif %}
-				{% if page.viz_data_end %}data-start-date="{{ page.viz_data_end|date:'c' }}"{% endif %}
+				{% if page.viz_data_end %}data-end-date="{{ page.viz_data_end|date:'c' }}"{% endif %}
 			></div>
 		</div>
 	{% endwith %}

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -348,6 +348,14 @@ class IncidentAPITest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_homepage_csv_requests_are_successful(self):
+        response = self.client.get(
+            reverse('incidentpage-homepage_csv'),
+            HTTP_ACCEPT='text/csv',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
     def test_result_attributes(self):
         response = self.client.get(
             reverse('incidentpage-list'),

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -348,14 +348,6 @@ class IncidentAPITest(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_homepage_csv_requests_are_successful(self):
-        response = self.client.get(
-            reverse('incidentpage-homepage_csv'),
-            HTTP_ACCEPT='text/csv',
-        )
-
-        self.assertEqual(response.status_code, 200)
-
     def test_result_attributes(self):
         response = self.client.get(
             reverse('incidentpage-list'),

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -129,7 +129,6 @@ class HomePageCSVTestCase(TestCase):
                 [tag.title for tag in self.tags]
             )
         )
-        print(f'{self.result=}')
 
 
 class IncidentCSVTestCase(TestCase):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -68,6 +68,70 @@ class MinimalIncidentCSVTestCase(TestCase):
         self.assertEqual(result['state'], '')
 
 
+class HomePageCSVTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.get(is_default_site=True)
+        root_page = site.root_page
+        cls.incident_index = IncidentIndexPageFactory.build()
+        root_page.add_child(instance=cls.incident_index)
+
+        cls.state = StateFactory(abbreviation='NM')
+        cls.cats = CategoryPageFactory.create_batch(3, parent=root_page)
+        cls.tags = CommonTagFactory.create_batch(3)
+        cls.incident = IncidentPageFactory(
+            parent=cls.incident_index,
+            categories=cls.cats,
+            tags=cls.tags,
+            state=cls.state,
+        )
+
+    def setUp(self):
+        self.response = self.client.get(
+            reverse('incidentpage-homepage_csv'),
+            HTTP_ACCEPT='text/csv',
+        )
+        content_lines = self.response.content.splitlines()
+        reader = csv.reader(line.decode('utf-8') for line in content_lines)
+
+        self.headers = next(reader)
+        self.result = dict(zip(self.headers, next(reader)))
+
+    def test_requests_are_successful(self):
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_supplies_correct_headers(self):
+        self.assertEqual(self.headers, [
+            'date',
+            'city',
+            'state',
+            'latitude',
+            'longitude',
+            'categories',
+            'tags',
+        ])
+
+    def test_returns_state_abbreviation(self):
+        self.assertEqual(self.result['state'], self.state.abbreviation)
+
+    def test_returns_correct_categories_list(self):
+        self.assertEqual(
+            self.result['categories'],
+            ', '.join(
+                [cat.title for cat in self.cats]
+            )
+        )
+
+    def test_returns_correct_tags_list(self):
+        self.assertEqual(
+            self.result['tags'],
+            ', '.join(
+                [tag.title for tag in self.tags]
+            )
+        )
+        print(f'{self.result=}')
+
+
 class IncidentCSVTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -100,8 +100,10 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         context = super().get_renderer_context()
 
         # Get set of fields from serializer that has been pruned
-        # according to request's query-string parameters.
-        if 'homepage_csv' not in self.request.path:
+        # according to request's query-string parameters.  In the
+        # homepage_csv action, this set is pre-determined and not
+        # affected by the request, in that case we skip this step.
+        if self.action != 'homepage_csv':
             context['header'] = list(self.get_serializer().fields.keys())
         return context
 

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -133,10 +133,10 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         lower_date = request.GET.get('lower_date')
         upper_date = request.GET.get('upper_date')
 
-        tag_summary = models.IncidentPage.objects.annotate(
+        tag_summary = models.IncidentPage.objects.only('tags').annotate(
             tag_summary=StringAgg('tags__title', delimiter=', ')
         ).filter(pk=OuterRef('pk'))
-        category_summary = models.IncidentPage.objects.annotate(
+        category_summary = models.IncidentPage.objects.only('categories').annotate(
             category_summary=StringAgg('categories__category__title', delimiter=', ')
         ).filter(pk=OuterRef('pk'))
 
@@ -156,7 +156,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
             fuzzy_date__overlap=target_range,
         )
 
-        incidents = models.IncidentPage.objects.live().annotate(
+        incidents = models.IncidentPage.objects.live().only('date', 'city', 'state', 'latitude', 'longitude').annotate(
             fuzzy_date=MakeDateRange(
                 Cast(Trunc('date', 'month'), DateField()),
                 Cast(TruncMonth('date') + Cast(Value('1 month'), DurationField()), DateField()),

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
 
 class HomePageCSVRenderer(CSVRenderer):
     header = ['date', 'city', 'state__abbreviation', 'latitude', 'longitude', 'category_summary', 'tag_summary']
+    labels = {
+        'state__abbreviation': 'state',
+        'category_summary': 'categories',
+        'tag_summary': 'tags',
+    }
 
 
 class HeaderCursorPagination(CursorPagination):

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -97,7 +97,8 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
 
         # Get set of fields from serializer that has been pruned
         # according to request's query-string parameters.
-        context['header'] = list(self.get_serializer().fields.keys())
+        if 'homepage_csv' not in self.request.path:
+            context['header'] = list(self.get_serializer().fields.keys())
         return context
 
     def get_serializer_class(self):

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -111,7 +111,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
 
         return incidents.with_most_recent_update().with_public_associations()
 
-    @action(detail=False, renderer_classes=[HomePageCSVRenderer])
+    @action(detail=False, renderer_classes=[HomePageCSVRenderer], url_name='homepage_csv')
     def homepage_csv(self, request):
         tag_summary = models.IncidentPage.objects.annotate(
             tag_summary=StringAgg('tags__title', delimiter=', ')

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -1,12 +1,15 @@
 import collections
 from typing import TYPE_CHECKING
 
+from django.contrib.postgres.aggregates import StringAgg
+from django.db.models import CharField, OuterRef, Subquery
+from rest_framework.decorators import action
 from rest_framework import viewsets
 from rest_framework.settings import api_settings
 from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
 from rest_framework.utils.urls import remove_query_param
-from rest_framework_csv.renderers import PaginatedCSVRenderer
+from rest_framework_csv.renderers import PaginatedCSVRenderer, CSVRenderer
 
 from common.models import CategoryPage
 from incident.api.serializers import (
@@ -21,6 +24,10 @@ from incident.utils.incident_filter import IncidentFilter
 
 if TYPE_CHECKING:
     from django.http import HttpResponse
+
+
+class HomePageCSVRenderer(CSVRenderer):
+    header = ['date', 'city', 'state__abbreviation', 'latitude', 'longitude', 'category_summary', 'tag_summary']
 
 
 class HeaderCursorPagination(CursorPagination):
@@ -103,6 +110,23 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         incidents = incident_filter.get_queryset()
 
         return incidents.with_most_recent_update().with_public_associations()
+
+    @action(detail=False, renderer_classes=[HomePageCSVRenderer])
+    def homepage_csv(self, request):
+        tag_summary = models.IncidentPage.objects.annotate(
+            tag_summary=StringAgg('tags__title', delimiter=', ')
+        ).filter(pk=OuterRef('pk'))
+        category_summary = models.IncidentPage.objects.annotate(
+            category_summary=StringAgg('categories__category__title', delimiter=', ')
+        ).filter(pk=OuterRef('pk'))
+
+        incidents = models.IncidentPage.objects.live().annotate(
+            tag_summary=Subquery(tag_summary.values('tag_summary'), output_field=CharField()),
+            category_summary=Subquery(category_summary.values('category_summary'), output_field=CharField()),
+        ).values('date', 'city', 'state__abbreviation', 'latitude', 'longitude', 'category_summary', 'tag_summary')
+
+        incidents = list(incidents)  # CSV Renderer requires a list
+        return Response(incidents)
 
 
 class JournalistViewSet(viewsets.ReadOnlyModelViewSet):

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -4,15 +4,9 @@ from typing import TYPE_CHECKING
 from django.contrib.postgres.aggregates import StringAgg
 from django.db.models import (
     CharField,
-    DateField,
-    DurationField,
     OuterRef,
-    Q,
     Subquery,
-    Value,
 )
-from django.db.models.functions import Trunc, TruncMonth, Cast
-from psycopg2.extras import DateRange
 from rest_framework.decorators import action
 from rest_framework import viewsets
 from rest_framework.settings import api_settings
@@ -30,7 +24,6 @@ from incident.api.serializers import (
     FlatIncidentSerializer,
 )
 from incident import models
-from incident.utils.db import MakeDateRange
 from incident.utils.incident_filter import IncidentFilter
 
 if TYPE_CHECKING:
@@ -140,30 +133,10 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
             category_summary=StringAgg('categories__category__title', delimiter=', ')
         ).filter(pk=OuterRef('pk'))
 
-        # TODO: extract fuzzy date logic to IncidentQuerySet
-        target_range = DateRange(
-            lower=lower_date,
-            upper=upper_date,
-            bounds='[]'
-        )
-        exact_date_match = Q(
-            date__contained_by=target_range,
-            exact_date_unknown=False,
-        )
-
-        inexact_date_match_lower = Q(
-            exact_date_unknown=True,
-            fuzzy_date__overlap=target_range,
-        )
-
         incidents = models.IncidentPage.objects.live().only('date', 'city', 'state', 'latitude', 'longitude').annotate(
-            fuzzy_date=MakeDateRange(
-                Cast(Trunc('date', 'month'), DateField()),
-                Cast(TruncMonth('date') + Cast(Value('1 month'), DurationField()), DateField()),
-            ),
             tag_summary=Subquery(tag_summary.values('tag_summary'), output_field=CharField()),
             category_summary=Subquery(category_summary.values('category_summary'), output_field=CharField()),
-        ).filter(exact_date_match | inexact_date_match_lower).values(
+        ).fuzzy_date_filter(lower=lower_date, upper=upper_date).values(
             'date', 'city', 'state__abbreviation', 'latitude', 'longitude', 'category_summary', 'tag_summary'
         )
 

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -146,6 +146,31 @@ class IncidentQuerySet(PageQuerySet):
         )
 
     def fuzzy_date_filter(self, lower=None, upper=None):
+        """Filter incidents by date range, accounting for unknown exact dates.
+
+        This method accepts a date range and returns a queryset
+        filtered according to the following algorithm:
+
+        1. If an incident has `exact_date_unknown` equal to `False`,
+        then the incident is included if the date range contains the
+        incident's `date` value.
+
+        2. If an incident has `exact_date_unknown` equal to `True`,
+        then the incident is included if the date range overlaps with
+        the month containing the incident's `date` value.  For
+        example, if an exact date unknown incident has a date of
+        2022-01-13 (or any other date in the month 2022-01), then it
+        will be included in the queryset results if the date range
+        overlaps at all with the range starting on 2022-01-01 and
+        ending on 2022-01-31.
+
+        3. Otherwise, the incident is excluded.
+
+        Keyword arguments:
+        lower -- the lower bound of the date (which is included in the range). If `None`, then the range is unbounded below.
+        upper -- the lower bound of the date (which is included in the range). If `None`, then the range is unbounded below.
+
+        """
         target_range = DateRange(
             lower=lower,
             upper=upper,


### PR DESCRIPTION
This pull request creates a separate API "action" (in Django Rest Framework's terminology) to return the data required by the home page with as little overhead as I can manage. Namely, I'm running as few DB queries as possible and not using any serializers.

The action lives at http://localhost:8000/api/edge/incidents/homepage_csv/ and you can test it with something like:

```bash
curl -H 'Accept: text/csv' "http://localhost:8000/api/edge/incidents/homepage_csv/"
```

When I do this it returns data quite quickly.

The purpose of doing this is (1) to help debug what's slowing down the "regular" API endpoint but showing what's possible under a "best-case" scenario, and (2) potentially create a stopgap (or even long-term) solution for improving the performance of the API for the home page, which we know is being requested quite a bit.

This PR also updates the front end to use the new URL.