### PR TITLE
Activate carousel buttons on window resize

### DIFF
--- a/client/common/js/ArticleLoader.js
+++ b/client/common/js/ArticleLoader.js
@@ -154,6 +154,7 @@ ArticleLoader.NUM_AUTO_FETCHES = 0
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (window._articleLoader) {
+		// eslint-disable-next-line no-console
 		console.warn('An ArticleLoader instance already exists.')
 		return
 	}

--- a/client/common/js/articleScroller.js
+++ b/client/common/js/articleScroller.js
@@ -1,3 +1,5 @@
+import { throttle } from './utils'
+
 class ArticleScroller {
 	constructor(scrollerElement) {
 		// Since JS is loaded we can show the interactive horizontal scroller
@@ -28,19 +30,11 @@ class ArticleScroller {
 		this.scrollPrevBtn.addEventListener('click', this.scrollToRight)
 
 		const self = this
-		this.delay = 250
-    	this.throttled = false
 
-		window.addEventListener('resize', () => {
-			if (!self.throttled) {
-				self.scrollPrevBtn.disabled = !self.prevExists()
-				self.scrollNextBtn.disabled = !self.nextExists()
-				self.throttled = true
-				setTimeout(function() {
-				  	self.throttled = false
-				}, self.delay)
-			}
-		});
+		window.addEventListener('resize', throttle(() => {
+			self.scrollPrevBtn.disabled = !self.prevExists()
+			self.scrollNextBtn.disabled = !self.nextExists()
+		}, 250))
 	}
 
 	static isVisible(article) {
@@ -99,6 +93,7 @@ class ArticleScroller {
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (window._articleScrollers) {
+		// eslint-disable-next-line no-console
 		console.warn('ArticleScroller instances already exist.')
 		return
 	}

--- a/client/common/js/articleScroller.js
+++ b/client/common/js/articleScroller.js
@@ -26,6 +26,21 @@ class ArticleScroller {
 
 		this.scrollNextBtn.addEventListener('click', this.scrollToLeft)
 		this.scrollPrevBtn.addEventListener('click', this.scrollToRight)
+
+		const self = this
+		this.delay = 250
+    	this.throttled = false
+
+		window.addEventListener('resize', () => {
+			if (!self.throttled) {
+				self.scrollPrevBtn.disabled = !self.prevExists()
+				self.scrollNextBtn.disabled = !self.nextExists()
+				self.throttled = true
+				setTimeout(function() {
+				  	self.throttled = false
+				}, self.delay)
+			}
+		});
 	}
 
 	static isVisible(article) {

--- a/client/common/js/utils.js
+++ b/client/common/js/utils.js
@@ -3,7 +3,7 @@ export function throttle(fn, _threshhold, scope, ...args) {
 	let last
 	let deferTimer
 	const threshhold = _threshhold || 250
-	return function () {
+	return () => {
 		const context = scope || this
 		const now = +new Date()
 		if (last && now < last + threshhold) {


### PR DESCRIPTION
This adds a throttled window resize event handler to set the carousel button disabled attribute based on article visibility.

Fixes note "Carousel buttons inactive if page is resized to small": https://github.com/freedomofpress/pressfreedomtracker.us/projects/4#card-80136199