### PR TITLE
Use fixed category colours on TreeMap

### DIFF
--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -148,6 +148,7 @@ function HomepageMainChartsWidth({
 						openSearchPage={(category) => {
 							goToFilterPage(databasePath, { ...filtersApplied, category }, currentDate)
 						}}
+						categoriesColors={categoriesColors}
 						allCategories={Object.keys(categoriesColors)}
 					/>
 				</div>

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -157,7 +157,11 @@ export default function TreeMap({
 		return Math.max(yScale(start) - yScale(end), 1)
 	}
 
-	const colorScale = categoriesColors !== undefined ? categoriesColors : d3.scaleOrdinal(colors)
+	const getCategoryColour = (category) => {
+		return categoriesColors[category]
+	}
+
+	const colorScale = categoriesColors !== undefined ? getCategoryColour : d3.scaleOrdinal(colors)
 
 	const colorsByCategory = datasetStackedByCategory
 		.filter((d) => d.numberOfIncidents !== 0)


### PR DESCRIPTION
Passes categoriesColors to TreeMap, adds function to get color value by category key.

Resolves https://github.com/freedomofpress/pressfreedomtracker.us/issues/1392.