### PR TITLE
Implement mobile width strokes for TreeMap component

### DIFF
--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -37,6 +37,7 @@ const textPaddings = {
 const borderWidth = {
 	hover: 7,
 	normal: 5,
+	mobile: 3,
 }
 
 const textStyle = {
@@ -249,7 +250,7 @@ export default function TreeMap({
 										: findColor(d.category)
 									: 'white',
 							stroke: (d) => (hoveredElement === d.category ? findColor(d.category) : 'black'),
-							strokeWidth: borderWidth.normal,
+							strokeWidth: isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile,
 							cursor: 'pointer',
 							pointerEvents: (d) => (d.numberOfIncidents === 0 ? 'none' : null),
 							shapeRendering: 'crispEdges',
@@ -291,8 +292,8 @@ export default function TreeMap({
 									? 1
 									: 0,
 							display: (d) => (d.startingPoint !== d.endPoint ? null : 'none'),
-							x1: paddings.left - borderWidth.normal / 2,
-							x2: width - paddings.right + borderWidth.normal / 2,
+							x1: paddings.left - (isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile) / 2,
+							x2: width - paddings.right + (isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile) / 2,
 							y1: (d) =>
 								height - yScale(d.startingPoint) + computeBarHeight(d.startingPoint, d.endPoint),
 							y2: (d) =>
@@ -304,7 +305,7 @@ export default function TreeMap({
 										hoveredElement === nextCategory(datasetStackedByCategory, i)
 									? findColor(nextCategory(datasetStackedByCategory, i))
 									: 'black',
-							strokeWidth: borderWidth.normal + 1,
+							strokeWidth: isHomePageDesktopView ? borderWidth.normal + 1 : borderWidth.mobile,
 							pointerEvents: 'none',
 							shapeRendering: 'crispEdges',
 						}}

--- a/client/common/js/ArticleLoader.js
+++ b/client/common/js/ArticleLoader.js
@@ -154,6 +154,7 @@ ArticleLoader.NUM_AUTO_FETCHES = 0
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (window._articleLoader) {
+		// eslint-disable-next-line no-console
 		console.warn('An ArticleLoader instance already exists.')
 		return
 	}

--- a/client/common/js/articleScroller.js
+++ b/client/common/js/articleScroller.js
@@ -84,6 +84,7 @@ class ArticleScroller {
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (window._articleScrollers) {
+		// eslint-disable-next-line no-console
 		console.warn('ArticleScroller instances already exist.')
 		return
 	}

--- a/client/common/js/utils.js
+++ b/client/common/js/utils.js
@@ -3,7 +3,7 @@ export function throttle(fn, _threshhold, scope, ...args) {
 	let last
 	let deferTimer
 	const threshhold = _threshhold || 250
-	return function () {
+	return () => {
 		const context = scope || this
 		const now = +new Date()
 		if (last && now < last + threshhold) {


### PR DESCRIPTION
Adds mobile width of 3px to TreeMap strokes, adds ternary operator where necessary to select correct width for render.

Resolves note titled "Reduced margins/paddings on category buttons on homepage to match Figma": https://github.com/freedomofpress/pressfreedomtracker.us/projects/4#card-80136414