### PR TITLE
Remove moment from JS dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "hamburgers": "^0.8.1",
         "invariant": "^2.2.2",
         "js-cookie": "^2.1.3",
-        "moment": "^2.29.1",
         "money-math": "^2.4.3",
         "normalize-css": "^2.3.1",
         "normalize.css": "^6.0.0",
@@ -10586,14 +10585,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/money-math": {
@@ -21849,11 +21840,6 @@
       "integrity": "sha1-5SpvmhJXi5RKu9bL1lyGPqSoP0k=",
       "dev": true,
       "requires": {}
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "money-math": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "hamburgers": "^0.8.1",
     "invariant": "^2.2.2",
     "js-cookie": "^2.1.3",
-    "moment": "^2.29.1",
     "money-math": "^2.4.3",
     "normalize-css": "^2.3.1",
     "normalize.css": "^6.0.0",


### PR DESCRIPTION
We're not using this package anymore, and there's a security
vulnerability in this version (see below), so we might as well take
this opportunity to remove it.

Vulnerability info at: https://cwe.mitre.org/data/definitions/27.html