### PR TITLE
Reduce database page query count

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -773,13 +773,15 @@ class IncidentPage(MetadataPageMixin, Page):
             return first_category.category
         return None
 
-    def get_category_details(self):
+    def get_category_details(self, index=None):
+        if not index:
+            index = self.get_parent()
         category_details = {}
         for category in self.categories.all():
             category_fields = CATEGORY_FIELD_MAP.get(category.category.slug, [])
             category_details[category.category] = []
             for field in category_fields:
-                display_html = CAT_FIELD_VALUES[field[0]](self, field[0])
+                display_html = CAT_FIELD_VALUES[field[0]](self, field[0], index)
                 category_details[category.category].append(
                     {
                         'name': field[1],

--- a/incident/templates/incident/_database_card_details.html
+++ b/incident/templates/incident/_database_card_details.html
@@ -1,3 +1,4 @@
+{% load get_category_details %}
 <button
 	class="disclose-summary incident-database-card__details-toggle"
 	aria-expanded="false"
@@ -9,12 +10,13 @@
 	<div class="incident-database-card__main-details">
 		<h3 class="heading-table incident-database-card__details-title" id="incident-details-title">Incident Details</h3>
 
-		{% include "incident/_database_card_table.html" with incident=incident only %}
+		{% include "incident/_database_card_table.html" with incident=incident index=index only %}
 	</div>
 </div>
 
 <div id="category-details-{{ incident.pk }}" class="incident-database-card__category-details database-card-table__container" data-visible="false">
-	{% for category, category_detail in incident.get_category_details.items %}
+	{% get_category_details incident index as all_details %}
+	{% for category, category_detail in all_details.items %}
 		{% if category_detail %}
 			<dl class="database-card-table__category-details" aria-labelledby="{{ category.slug }}-details-title">
 				<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">

--- a/incident/templates/incident/_database_card_table.html
+++ b/incident/templates/incident/_database_card_table.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags case_tags %}
 
 <dl class="database-card-table__incident-details" aria-labelledby="incident-details-title">
-	{% with incident.last_updated as last_updated %}
+	{% with incident.latest_update as last_updated %}
 		{% if last_updated and incident.updates.all.exists %}
 			<div class="database-card-table__row">
 				<dt class="database-card-table__label database-card-table__label--bold">

--- a/incident/templates/incident/_database_card_table.html
+++ b/incident/templates/incident/_database_card_table.html
@@ -19,7 +19,7 @@
 			Date of Incident
 		</dt>
 		<dd class="database-card-table__value">
-			<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?date_lower={{ incident.date|date:'Y-m-d' }}&date_upper={{ incident.date|date:'Y-m-d' }}{% endif %}" class="text-link">
+			<a href="{% if index %}{% pageurl index %}?date_lower={{ incident.date|date:'Y-m-d' }}&date_upper={{ incident.date|date:'Y-m-d' }}{% endif %}" class="text-link">
 				{% if incident.exact_date_unknown %}
 					{{ incident.date|date:"F Y" }}
 				{% else %}
@@ -36,11 +36,11 @@
 			</dt>
 			<dd class="database-card-table__value">
 				{% if incident.city %}
-					<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?city={{ incident.city }}{% endif %}" class="text-link">
+					<a href="{% if index %}{% pageurl index %}?city={{ incident.city }}{% endif %}" class="text-link">
 						{{ incident.city }}</a>{% if incident.state %},{% endif %}
 				{% endif %}
 				{% if incident.state %}
-					<a href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?state={{ incident.state.pk }}{% endif %}" class="text-link">{{ incident.state.name }}</a>
+					<a href="{% if index %}{% pageurl index %}?state={{ incident.state.pk }}{% endif %}" class="text-link">{{ incident.state.name }}</a>
 				{% endif %}
 			</dd>
 		</div>
@@ -52,7 +52,7 @@
 				Case number
 			</dt>
 			<dd class="database-card-table__value">
-				<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_number={{ incident.case_number }}{% endif %}">
+				<a class="text-link" href="{% if index %}{% pageurl index %}?case_number={{ incident.case_number }}{% endif %}">
 					{{ incident.case_number }}
 				</a>
 			</dd>
@@ -64,7 +64,7 @@
 			<dt class="database-card-table__label database-card-table__label--bold">Targets</dt>
 			<dd class="database-card-table__value">
 				{% for target in incident.get_all_targets_for_linking %}
-					<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?{{ target.url_arguments }}{% endif %}">{{ target.text }}</a>{% if not forloop.last %}, {% endif %}
+					<a class="text-link" href="{% if index %}{% pageurl index %}?{{ target.url_arguments }}{% endif %}">{{ target.text }}</a>{% if not forloop.last %}, {% endif %}
 				{% endfor %}
 			</dd>
 		</div>
@@ -77,7 +77,7 @@
 			</dt>
 			<dd class="database-card-table__value">
 				{% for case_status in incident.case_statuses %}
-					<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_statuses={{ case_status }}{% endif %}">
+					<a class="text-link" href="{% if index %}{% pageurl index %}?case_statuses={{ case_status }}{% endif %}">
 						{% get_case_status_display case_status as case_status_display_name %}
 						{{ case_status_display_name|capfirst }}</a>{% if not forloop.last %}, {% endif %}
 				{% endfor %}
@@ -91,7 +91,7 @@
 				Type of case
 			</dt>
 			<dd class="database-card-table__value">
-				<a class="text-link" href="{% if incident.get_parent %}{% pageurl incident.get_parent %}?case_type={{ incident.case_type }}{% endif %}">
+				<a class="text-link" href="{% if index %}{% pageurl index %}?case_type={{ incident.case_type }}{% endif %}">
 					{{ incident.get_case_type_display }}
 				</a>
 			</dd>

--- a/incident/templates/incident/_incident_database_card.html
+++ b/incident/templates/incident/_incident_database_card.html
@@ -18,5 +18,5 @@
 		{% endif %}
 	</div>
 
-	{% include "incident/_database_card_details.html" with incident=incident only %}
+	{% include "incident/_database_card_details.html" with incident=incident index=index only %}
 </article>

--- a/incident/templates/incident/_incident_details_table.html
+++ b/incident/templates/incident/_incident_details_table.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags case_tags %}
 
 <dl class="details-table__incident-details" aria-labelledby="incident-details-title">
-	{% with incident.last_updated as last_updated %}
+	{% with incident.latest_update as last_updated %}
 		{% if last_updated and incident.updates.all.exists %}
 		<div class="details-table__row">
 			<dt class="details-table__label details-table__label--bold">

--- a/incident/templates/incident/category_field/_basic_field.html
+++ b/incident/templates/incident/category_field/_basic_field.html
@@ -1,4 +1,4 @@
 {% load wagtailcore_tags %}
-<a href="{% pageurl page.get_parent %}?{{ field }}={{ value }}" class="text-link">
+<a href="{% pageurl index %}?{{ field }}={{ value }}" class="text-link">
 	{{ display_value|capfirst }}
 </a>

--- a/incident/templates/incident/category_field/_date_field.html
+++ b/incident/templates/incident/category_field/_date_field.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 <a
-	href="{% pageurl page.get_parent %}?{{ field }}_lower={{ value|date:'Y-m-d' }}&{{ field }}_upper={{ value|date:'Y-m-d' }}"
+	href="{% pageurl index %}?{{ field }}_lower={{ value|date:'Y-m-d' }}&{{ field }}_upper={{ value|date:'Y-m-d' }}"
 	class="text-link"
 >
 	<time datetime="{{ value|date:'c' }}">

--- a/incident/templates/incident/category_field/_equipment_list_field.html
+++ b/incident/templates/incident/category_field/_equipment_list_field.html
@@ -2,7 +2,7 @@
 <ul class="details-table__list">
   {% for item in items %}
     <li class="details-table__list-item">
-      <a href="{% pageurl page.get_parent %}?{{ field }}={{ item.equipment.name }}" class="text-link">
+      <a href="{% pageurl index %}?{{ field }}={{ item.equipment.name }}" class="text-link">
 				{{ item.equipment.name|capfirst }}, {{ item.quantity }}
 			</a>
     </li>

--- a/incident/templates/incident/category_field/_list_field.html
+++ b/incident/templates/incident/category_field/_list_field.html
@@ -2,7 +2,7 @@
 <ul class="details-table__list">
   {% for item in items %}
     <li class="details-table__list-item">
-      <a href="{% pageurl page.get_parent %}?{{ field }}={{ item.title }}" class="text-link">{{ item.title|capfirst }}</a>
+      <a href="{% pageurl index %}?{{ field }}={{ item.title }}" class="text-link">{{ item.title|capfirst }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/incident/templatetags/get_category_details.py
+++ b/incident/templatetags/get_category_details.py
@@ -1,0 +1,9 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_category_details(incident, index):
+    return incident.get_category_details(index)

--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -30,7 +30,7 @@ class TestCategoryFieldValuesByField(TestCase):
 
     def assert_text(self, field_name, render_function):
         setattr(self.incident, field_name, 'Text')
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertIn('Text', output)
         self.assertIn(f'{field_name}=Text', output)
 
@@ -38,50 +38,50 @@ class TestCategoryFieldValuesByField(TestCase):
         field = IncidentPage._meta.get_field(field_name)
         for choice_value, choice_name in field.choices:
             setattr(self.incident, field_name, choice_value)
-            output = render_function(self.incident, field_name)
+            output = render_function(self.incident, field_name, self.index)
             pretty_name = capfirst(
                 getattr(self.incident, f'get_{field_name}_display')()
             )
             self.assertIn(pretty_name, output)
             self.assertIn(f'{field_name}={choice_value}', output)
         setattr(self.incident, field_name, '')
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertEqual(output, '')
 
     def assert_many_relationship(self, field_name, render_function):
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         for item in getattr(self.incident, field_name).all():
             self.assertIn(item.title, output)
             self.assertIn(f'{field_name}={item.title}', output)
         getattr(self.incident, field_name).clear()
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertEqual(output, '')
 
     def assert_equipment(self, field_name, render_function):
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         for item in getattr(self.incident, field_name).all():
             self.assertIn(item.equipment.name, output)
             self.assertIn(f'{field_name}={item.equipment.name}', output)
         getattr(self.incident, field_name).clear()
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertEqual(output, '')
 
     def assert_date(self, field_name, render_function):
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         value = getattr(self.incident, field_name)
         self.assertIn(f'{field_name}_upper={value:%Y-%m-%d}', output)
         self.assertIn(f'{field_name}_lower={value:%Y-%m-%d}', output)
         self.assertIn(f'{value:%B %-d, %Y}', output)
         setattr(self.incident, field_name, None)
-        self.assertEqual(render_function(self.incident, field_name), '')
+        self.assertEqual(render_function(self.incident, field_name, self.index), '')
 
     def assert_boolean(self, field_name, render_function):
         setattr(self.incident, field_name, True)
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertIn('Yes', output)
         self.assertIn(f'{field_name}=1', output)
         setattr(self.incident, field_name, False)
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertIn('No', output)
         self.assertIn(f'{field_name}=0', output)
 
@@ -98,13 +98,13 @@ class TestCategoryFieldValuesByField(TestCase):
         )
 
     def test_arresting_authority(self):
-        output = CAT_FIELD_VALUES['arresting_authority'](self.incident, 'arresting_authority')
+        output = CAT_FIELD_VALUES['arresting_authority'](self.incident, 'arresting_authority', self.index)
         self.assertEqual(output, '')
 
         leo = LawEnforcementOrganizationFactory()
         self.incident.arresting_authority = leo
 
-        output = CAT_FIELD_VALUES['arresting_authority'](self.incident, 'arresting_authority')
+        output = CAT_FIELD_VALUES['arresting_authority'](self.incident, 'arresting_authority', self.index)
         self.assertIn(leo.title.capitalize(), output)
         self.assertIn(f'arresting_authority={leo.title}', output)
 
@@ -224,11 +224,11 @@ class TestCategoryFieldValuesByField(TestCase):
         self.incident.subpoena_statuses = []
         field_name = 'subpoena_statuses'
         render_function = CAT_FIELD_VALUES[field_name]
-        output = render_function(self.incident, field_name)
+        output = render_function(self.incident, field_name, self.index)
         self.assertEqual(output, '')
         for choice_value, choice_name in choices.SUBPOENA_STATUS:
             self.incident.subpoena_statuses.append(choice_value)
-            output = render_function(self.incident, field_name)
+            output = render_function(self.incident, field_name, self.index)
             self.assertIn(choice_name.capitalize(), output)
             self.assertIn(f'{field_name}={choice_value}', output)
 

--- a/incident/utils/category_field_values.py
+++ b/incident/utils/category_field_values.py
@@ -3,7 +3,7 @@ from django.template.loader import render_to_string
 from incident.models import choices
 
 
-def basic_html_val(page, field):
+def basic_html_val(page, field, index):
     # If no value for the attribute, return blank
     value = getattr(page, field)
     if not value:
@@ -19,23 +19,25 @@ def basic_html_val(page, field):
         'page': page,
         'field': field,
         'value': value,
-        'display_value': display_value
+        'display_value': display_value,
+        'index': index,
     })
 
 
-def boolean_html_val(page, field):
-    value = getattr(page, field)
+def boolean_html_val(page, field, index):
+    value = getattr(page, field, index)
     display_value = 'Yes' if value else 'No'
 
     return render_to_string('incident/category_field/_basic_field.html', {
         'page': page,
         'field': field,
+        'index': index,
         'value': '1' if value else '0',
         'display_value': display_value
     })
 
 
-def list_html_val(page, field):
+def list_html_val(page, field, index):
     # If no value for the attribute, return blank
     items = getattr(page, field).all()
     if not items:
@@ -43,12 +45,13 @@ def list_html_val(page, field):
 
     return render_to_string('incident/category_field/_list_field.html', {
         'page': page,
+        'index': index,
         'field': field,
         'items': items,
     })
 
 
-def equipments_list_html_val(page, field):
+def equipments_list_html_val(page, field, index):
     # If no value for the attribute, return blank
     items = getattr(page, field).all()
     if not items:
@@ -56,12 +59,13 @@ def equipments_list_html_val(page, field):
 
     return render_to_string('incident/category_field/_equipment_list_field.html', {
         'page': page,
+        'index': index,
         'field': field,
         'items': items,
     })
 
 
-def date_html_val(page, field):
+def date_html_val(page, field, index):
     # If no value for the attribute, return blank
     value = getattr(page, field)
     if not value:
@@ -69,6 +73,7 @@ def date_html_val(page, field):
 
     return render_to_string('incident/category_field/_date_field.html', {
         'page': page,
+        'index': index,
         'field': field,
         'value': value,
     })
@@ -79,21 +84,21 @@ def date_html_val(page, field):
 # covered using the generic functions above
 
 
-def arrest_status_html_val(page, field):
-    return basic_html_val(page, field)
+def arrest_status_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def status_of_charges_html_val(page, field):
-    return basic_html_val(page, field)
+def status_of_charges_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def arresting_authority_html_val(page, field):
+def arresting_authority_html_val(page, field, index):
     # If no value for the attribute, return blank
     if not getattr(page, field):
         return ''
 
     link = '{}?{}={}'.format(
-        page.get_parent().get_url(),
+        index.get_url(),
         field,
         getattr(page, field).title
     )
@@ -102,118 +107,118 @@ def arresting_authority_html_val(page, field):
     return f'<a href="{link}" class="text-link">{value}</a>'
 
 
-def current_charges_html_val(page, field):
-    return list_html_val(page, field)
+def current_charges_html_val(page, field, index):
+    return list_html_val(page, field, index)
 
 
-def dropped_charges_html_val(page, field):
-    return list_html_val(page, field)
+def dropped_charges_html_val(page, field, index):
+    return list_html_val(page, field, index)
 
 
-def detention_date_html_val(page, field):
-    return date_html_val(page, field)
+def detention_date_html_val(page, field, index):
+    return date_html_val(page, field, index)
 
 
-def release_date_html_val(page, field):
-    return date_html_val(page, field)
+def release_date_html_val(page, field, index):
+    return date_html_val(page, field, index)
 
 
-def unnecessary_use_of_force_html_val(page, field):
-    return boolean_html_val(page, field)
+def unnecessary_use_of_force_html_val(page, field, index):
+    return boolean_html_val(page, field, index)
 
 
-def equipment_broken_html_val(page, field):
-    return equipments_list_html_val(page, field)
+def equipment_broken_html_val(page, field, index):
+    return equipments_list_html_val(page, field, index)
 
 
-def equipment_seized_html_val(page, field):
-    return equipments_list_html_val(page, field)
+def equipment_seized_html_val(page, field, index):
+    return equipments_list_html_val(page, field, index)
 
 
-def status_of_seized_equipment_html_val(page, field):
-    return basic_html_val(page, field)
+def status_of_seized_equipment_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def is_search_warrant_obtained_html_val(page, field):
-    return boolean_html_val(page, field)
+def is_search_warrant_obtained_html_val(page, field, index):
+    return boolean_html_val(page, field, index)
 
 
-def actor_html_val(page, field):
-    return basic_html_val(page, field)
+def actor_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def border_point_html_val(page, field):
-    return basic_html_val(page, field)
+def border_point_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def target_nationality_html_val(page, field):
-    return list_html_val(page, field)
+def target_nationality_html_val(page, field, index):
+    return list_html_val(page, field, index)
 
 
-def target_us_citizenship_status_html_val(page, field):
-    return basic_html_val(page, field)
+def target_us_citizenship_status_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def denial_of_entry_html_val(page, field):
-    return boolean_html_val(page, field)
+def denial_of_entry_html_val(page, field, index):
+    return boolean_html_val(page, field, index)
 
 
-def stopped_at_border_html_val(page, field):
-    return boolean_html_val(page, field)
+def stopped_at_border_html_val(page, field, index):
+    return boolean_html_val(page, field, index)
 
 
-def stopped_previously_html_val(page, field):
-    return boolean_html_val(page, field)
+def stopped_previously_html_val(page, field, index):
+    return boolean_html_val(page, field, index)
 
 
-def did_authorities_ask_for_device_access_html_val(page, field):
-    return basic_html_val(page, field)
+def did_authorities_ask_for_device_access_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def did_authorities_ask_for_social_media_user_html_val(page, field):
-    return basic_html_val(page, field)
+def did_authorities_ask_for_social_media_user_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def did_authorities_ask_for_social_media_pass_html_val(page, field):
-    return basic_html_val(page, field)
+def did_authorities_ask_for_social_media_pass_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def were_devices_searched_or_seized_html_val(page, field):
-    return basic_html_val(page, field)
+def were_devices_searched_or_seized_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def did_authorities_ask_about_work_html_val(page, field):
-    return basic_html_val(page, field)
+def did_authorities_ask_about_work_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def assailant_html_val(page, field):
-    return basic_html_val(page, field)
+def assailant_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def was_journalist_targeted_html_val(page, field):
-    return basic_html_val(page, field)
+def was_journalist_targeted_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def workers_whose_communications_were_obtained_html_val(page, field):
-    return list_html_val(page, field)
+def workers_whose_communications_were_obtained_html_val(page, field, index):
+    return list_html_val(page, field, index)
 
 
-def charged_under_espionage_act_html_val(page, field):
-    return boolean_html_val(page, field)
+def charged_under_espionage_act_html_val(page, field, index):
+    return boolean_html_val(page, field, index)
 
 
-def subpoena_type_html_val(page, field):
-    return basic_html_val(page, field)
+def subpoena_type_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def subpoena_statuses_html_val(page, field):
-    if not getattr(page, field):
+def subpoena_statuses_html_val(page, field, index):
+    if not getattr(page, field, index):
         return ''
 
     html = []
     for subpoena_status in getattr(page, field):
         link = '{}?{}={}'.format(
-            page.get_parent().get_url(),
+            index.get_url(),
             field,
             subpoena_status
         )
@@ -223,29 +228,29 @@ def subpoena_statuses_html_val(page, field):
     return html
 
 
-def held_in_contempt_html_val(page, field):
-    return basic_html_val(page, field)
+def held_in_contempt_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def detention_status_html_val(page, field):
-    return basic_html_val(page, field)
+def detention_status_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def third_party_in_possession_of_communications_html_val(page, field):
-    return basic_html_val(page, field)
+def third_party_in_possession_of_communications_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def third_party_business_html_val(page, field):
-    return basic_html_val(page, field)
+def third_party_business_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def legal_order_type_html_val(page, field):
-    return basic_html_val(page, field)
+def legal_order_type_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def status_of_prior_restraint_html_val(page, field):
-    return basic_html_val(page, field)
+def status_of_prior_restraint_html_val(page, field, index):
+    return basic_html_val(page, field, index)
 
 
-def politicians_or_public_figures_involved_html_val(page, field):
-    return list_html_val(page, field)
+def politicians_or_public_figures_involved_html_val(page, field, index):
+    return list_html_val(page, field, index)


### PR DESCRIPTION
This pull request attempts to improve the DB page performance by reducing the number of queries performed in the `incident_index_page.html` (and child components) template code. This happens in two places:

1. Replace the use of the model method `last_updated` with the pre-computed annotation `latest_update`. It's possible that the old method should be removed or something to prevent confusion, as almost anywhere it is being used there is probably a more performant way to get that information.
2. Eliminate the calls to `incident.get_parent`. In every case where we are using this, we already know the parent, but it happens deep enough in the code that it's simpler to make that call. But this call produces at least one DB query, so I eliminate that by threading a reference to the parent through the template code (and the category details code), which was kind of a chore but I don't really mind the result. 

Using silk to test, I'm seeing the incident index page make ~88 queries on this branch, vs ~104 on develop. I guess it's not astounding, but does seem like an improvement.