### PR TITLE
Replace X-Real-IP with X-CF-Connecting-IP in log meta

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -18,8 +18,8 @@ class RequestLogMiddleware(object):
             'HTTP_REFERER',
             'HTTP_HOST',
             'HTTP_X_FORWARDED_FOR',
-            'HTTP_X_REAL_IP',
-            'HTTP_X_SCEHEME',
+            'HTTP_X_CF_CONNECTING_IP',
+            'HTTP_X_SCHEME',
         )
         self.response_keys = ('charset', 'reason_phrase', 'status_code')
 

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -74,7 +74,7 @@ class RequestLogTestCase(TestCase):
             HTTP_X_FORWARDED_FOR=forwarded_for,
             HTTP_HOST=host,
             HTTP_REFERER=referer,
-            HTTP_X_REAL_IP=real_ip,
+            HTTP_X_CF_CONNECTING_IP=real_ip,
         )
         request.user = self.user
 
@@ -103,8 +103,8 @@ class RequestLogTestCase(TestCase):
                     'HTTP_REFERER': referer,
                     'HTTP_USER_AGENT': user_agent,
                     'HTTP_X_FORWARDED_FOR': forwarded_for,
-                    'HTTP_X_REAL_IP': real_ip,
-                    'HTTP_X_SCEHEME': '',
+                    'HTTP_X_CF_CONNECTING_IP': real_ip,
+                    'HTTP_X_SCHEME': '',
                 },
                 'method': 'GET',
                 'path_info': '/',


### PR DESCRIPTION
Addresses https://github.com/freedomofpress/pressfreedomtracker.us/issues/1419 (not closing, let's use the data once we have it to decide if rate limiting will help)

We don't need X-Real-IP as it is (in our deployment) the same as X-Forwarded-For. Also, correct the spelling of X-Scheme.