### PR TITLE
Fix header name: no X- in CF-Connecting-IP

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -17,8 +17,8 @@ class RequestLogMiddleware(object):
             'HTTP_USER_AGENT',
             'HTTP_REFERER',
             'HTTP_HOST',
+            'HTTP_CF_CONNECTING_IP',
             'HTTP_X_FORWARDED_FOR',
-            'HTTP_X_CF_CONNECTING_IP',
             'HTTP_X_SCHEME',
         )
         self.response_keys = ('charset', 'reason_phrase', 'status_code')

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -74,7 +74,7 @@ class RequestLogTestCase(TestCase):
             HTTP_X_FORWARDED_FOR=forwarded_for,
             HTTP_HOST=host,
             HTTP_REFERER=referer,
-            HTTP_X_CF_CONNECTING_IP=real_ip,
+            HTTP_CF_CONNECTING_IP=real_ip,
         )
         request.user = self.user
 
@@ -102,8 +102,8 @@ class RequestLogTestCase(TestCase):
                     'HTTP_HOST': host,
                     'HTTP_REFERER': referer,
                     'HTTP_USER_AGENT': user_agent,
+                    'HTTP_CF_CONNECTING_IP': real_ip,
                     'HTTP_X_FORWARDED_FOR': forwarded_for,
-                    'HTTP_X_CF_CONNECTING_IP': real_ip,
                     'HTTP_X_SCHEME': '',
                 },
                 'method': 'GET',


### PR DESCRIPTION
This corrects #1420, which spelled the header name `X-CF-Connecting-IP`. It's actually just `CF-Connecting-IP`, see: https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/