### PR TITLE
Filter sidebar improvements

### DIFF
--- a/incident/tests/test_incident_filter_forms.py
+++ b/incident/tests/test_incident_filter_forms.py
@@ -1,3 +1,5 @@
+import operator
+
 from django.test import RequestFactory, TestCase
 from django.utils.text import capfirst
 from django import forms
@@ -251,5 +253,5 @@ class FilterFormTest(TestCase):
         self.assertIsInstance(form[-1].fields.get(name).widget, forms.CheckboxSelectMultiple)
         self.assertEqual(
             form[-1].fields.get(name).choices,
-            capitalize_choice_labels(choices),
+            capitalize_choice_labels(sorted(choices, key=operator.itemgetter(1))),
         )

--- a/incident/tests/test_incident_filter_forms.py
+++ b/incident/tests/test_incident_filter_forms.py
@@ -249,9 +249,9 @@ class FilterFormTest(TestCase):
         ]
         form = get_filter_forms(request, serialized_filters)
 
-        self.assertIsInstance(form[-1].fields.get(name), forms.MultipleChoiceField)
-        self.assertIsInstance(form[-1].fields.get(name).widget, forms.CheckboxSelectMultiple)
+        self.assertIsInstance(form[0].fields.get(name), forms.MultipleChoiceField)
+        self.assertIsInstance(form[0].fields.get(name).widget, forms.CheckboxSelectMultiple)
         self.assertEqual(
-            form[-1].fields.get(name).choices,
+            form[0].fields.get(name).choices,
             capitalize_choice_labels(sorted(choices, key=operator.itemgetter(1))),
         )

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -156,7 +156,8 @@ def get_filter_forms(request, serialized_filters):
             }]
 
         }
-        filter_forms.append(
+        filter_forms.insert(
+            0,
             FilterForm(
                 request.GET,
                 data=item

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -1,3 +1,5 @@
+import operator
+
 from django import forms
 from django.utils.text import capfirst
 from django.apps import apps
@@ -125,6 +127,7 @@ class FilterForm(forms.Form):
 def get_filter_forms(request, serialized_filters):
     filter_forms = []
 
+    serialized_filters.sort(key=operator.itemgetter('title'))
     # Any filter item with an id other than -1 is a category
     categories = [
         item for item in serialized_filters if item.get('id', -1) != -1

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -144,9 +144,9 @@ def get_filter_forms(request, serialized_filters):
     # if we have category items, create form filter for them
     if categories:
         item = {
-            'title': 'Limit to',
+            'title': 'Category',
             'filters': [{
-                'title': 'Category',
+                'title': 'Limit to',
                 'type': 'checkbox',
                 'name': 'categories',
                 'choices': [[x.get('id', ''), x.get('title', '')] for x in categories]

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -137,12 +137,11 @@ def get_filter_forms(request, serialized_filters):
 
         # if the item has a filters object then create a form from the item
         if item.get('filters', []):
-            filter_forms.append(
-                FilterForm(
-                    request.GET,
-                    data=item
-                )
-            )
+            filter_form = FilterForm(request.GET, data=item)
+            if item['id'] == -1:
+                filter_forms.insert(0, filter_form)
+            else:
+                filter_forms.append(filter_form)
 
     # if we have category items, create form filter for them
     if categories:

--- a/incident/utils/forms.py
+++ b/incident/utils/forms.py
@@ -87,10 +87,13 @@ class FilterForm(forms.Form):
                     kwargs['widget'] = forms.DateInput(
                         attrs={'type': 'date'}
                     )
-                    kwargs['label'] = label.replace('between', 'before')
-                    self.fields[f'{name}_upper'] = field(**kwargs)
+
                     kwargs['label'] = label.replace('between', 'after')
                     self.fields[f'{name}_lower'] = field(**kwargs)
+
+                    kwargs['label'] = label.replace('between', 'before')
+                    self.fields[f'{name}_upper'] = field(**kwargs)
+
                     field.field_type = _type
                     continue
 


### PR DESCRIPTION
Fixes #1417

Note: does not address point five, the "Maybe" point, because right now we don't have a straightforward way of managing (or style-guide for) help text on the sidebar filter form elements. I think better to act on this if we think a lot of incident searchers are wanting to make multi-tag queries but don't know how to.