### PR TITLE
Remove related incident cache purging

### DIFF
--- a/incident/signals.py
+++ b/incident/signals.py
@@ -26,29 +26,6 @@ def purge_incident_from_frontend_cache_for_category(
         )
 
 
-def purge_incident_from_frontend_cache_for_incident(
-    instance=None, sender=None, **kwargs
-):
-    """
-    Busts the cache for any incident that shares a category or is
-    a related incident to the incident just changed.
-    """
-
-    # Purge cache for related incidents
-    for incident in instance.related_incidents.all():
-        purge_page_from_cache(incident)
-        logger.info(
-            f"Purged page IncidentPage with title: {incident.title} and slug: {incident.slug}"
-        )
-
-    # Purge cache for incidents that share a category and may
-    # therefore show up as a related incident
-    for categorization in instance.categories.all():
-        purge_incident_from_frontend_cache_for_category(
-            instance=categorization.category
-        )
-
-
 def purge_incident_index_from_frontend_cache(**kwargs):
     tags = []
     for incident_index_page in IncidentIndexPage.objects.live():
@@ -68,10 +45,6 @@ page_published.connect(
 post_delete.connect(
     purge_incident_from_frontend_cache_for_category,
     sender=CategoryPage
-)
-page_published.connect(
-    purge_incident_from_frontend_cache_for_incident,
-    sender=IncidentPage
 )
 
 # IncidentIndexPage cache

--- a/incident/tests/test_frontend_cache_purge.py
+++ b/incident/tests/test_frontend_cache_purge.py
@@ -107,17 +107,6 @@ class TestIncidentPageCachePurge(TestCase):
 
         assert_never_called_with(purge_page_from_cache, incident)
 
-    def test_cache_purged_on_related_incident(self, purge_page_from_cache):
-        "Should purge cache for an incident when a related incident changes"
-        incident1 = IncidentPageFactory()
-        incident2 = IncidentPageFactory(related_incidents=[incident1])
-
-        # Should trigger purge on incident2
-        incident1.title = 'New Incident Name'
-        incident1.save_revision().publish()
-
-        purge_page_from_cache.assert_any_call(incident2)
-
     def test_cache_not_purged_on_unrelated_incident(
         self,
         purge_page_from_cache
@@ -133,24 +122,3 @@ class TestIncidentPageCachePurge(TestCase):
         incident1.save_revision().publish()  # Should not trigger purge on incident2
 
         assert_never_called_with(purge_page_from_cache, incident2)
-
-    def test_cache_purged_on_same_cat_incident(
-        self,
-        purge_page_from_cache
-    ):
-        """
-        Should purge cache for an incident that is in the same category
-        as a changed incident
-        """
-        category = CategoryPageFactory()
-        incident1 = IncidentPageFactory()
-        incident2 = IncidentPageFactory()
-        incident1.categories = [IncidentCategorization(category=category)]
-        incident2.categories = [IncidentCategorization(category=category)]
-        incident1.save()
-        incident2.save()
-
-        incident1.title = 'New Incident Title'
-        incident1.save_revision().publish()
-
-        purge_page_from_cache.assert_any_call(incident2)

--- a/incident/tests/test_frontend_cache_purge.py
+++ b/incident/tests/test_frontend_cache_purge.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase, Client
 from unittest.mock import patch
 from wagtail.core.models import Site
@@ -30,13 +28,11 @@ class TestIncidentIndexPageCachePurge(TestCase):
     def tearDown(self):
         self.index.delete()
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_tag_index(self):
         "Response from IncidentIndexPage should include Cache-Tag header"
         response = self.client.get('/incidents/')
         self.assertEqual(response['Cache-Tag'], 'incident-index-{}'.format(self.index.pk))
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_tag_subpath(self):
         """
         Response from IncidentIndexPage with subpath should include


### PR DESCRIPTION
Fixes #1155 

This pull request alters the "page published" signal for Incident Pages to remove the purging of "related" incidents (as we've defined it) and incidents of the same categories from the cache. When an incident page is published, these other incidents will not be purged from the cache anymore.