### PR TITLE
Adds all category icons in the incident title

### DIFF
--- a/incident/templates/incident/incident_page.html
+++ b/incident/templates/incident/incident_page.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 
 {% block main %}
-	<h1 class="category category-{{ main_category.page_symbol }} article-title" id="title">{{ page.title }}</h1>
+	<h1 class="article-title" id="title">
+		{% for category in category_details.keys %}
+			<span class="category category-{{ category.page_symbol }}" title="Category: {{ category.title }}"></span>
+		{% endfor %}
+		{{ page.title }}
+	</h1>
 
 	<section class="incident-tags">
 		{% include 'incident/_incident_tags.html' with incident=page %}


### PR DESCRIPTION
Fixes #1421 

Removes the category page symbol classes from the h1 element. Loops over all the categories in the incident and adds a span tag with the category page symbol and also a title attribute to show the category title (and also announce in screen readers)

PS: The category title shown by title attribute won't be visible to keyboard users and touch users so they will just see icons (which might be fine since the text isn't super important).