### PR TITLE
Increase category visibility and clickability

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -829,9 +829,15 @@ class IncidentPage(MetadataPageMixin, Page):
     def get_category_details(self, index=None):
         if not index:
             index = self.get_parent()
+
         category_details = {}
+        categories_without_metadata = {}
         for category in self.categories.all():
             category_fields = CATEGORY_FIELD_MAP.get(category.category.slug, [])
+
+            if not category_fields:
+                categories_without_metadata[category.category] = []
+                continue
             category_details[category.category] = []
             for field in category_fields:
                 display_html = CAT_FIELD_VALUES[field[0]](self, field[0], index)
@@ -841,6 +847,7 @@ class IncidentPage(MetadataPageMixin, Page):
                         'html': display_html,
                     }
                 )
+        category_details.update(categories_without_metadata)
         return category_details
 
     def get_related_incidents(self, threshold=4):

--- a/incident/templates/incident/_category_table.html
+++ b/incident/templates/incident/_category_table.html
@@ -1,7 +1,9 @@
 {% load wagtailcore_tags %}
 <dl class="details-table__category-fields" aria-labelledby="incident-details-title">
 	<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">
-		{{ category.title }}
+		<a class="text-link text-link--card" href="{% pageurl category %}">
+			{{ category.title }}
+		</a>
 	</h3>
 
 	{% for detail in category_detail %}

--- a/incident/templates/incident/_database_card_details.html
+++ b/incident/templates/incident/_database_card_details.html
@@ -1,3 +1,4 @@
+{% load pageurl from wagtailcore_tags %}
 {% load get_category_details %}
 <button
 	class="disclose-summary incident-database-card__details-toggle"
@@ -17,25 +18,23 @@
 <div id="category-details-{{ incident.pk }}" class="incident-database-card__category-details database-card-table__container" data-visible="false">
 	{% get_category_details incident index as all_details %}
 	{% for category, category_detail in all_details.items %}
-		{% if category_detail %}
-			<dl class="database-card-table__category-details" aria-labelledby="{{ category.slug }}-details-title">
-				<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">
-					{{ category.title }}
-				</h3>
+		<dl class="database-card-table__category-details" aria-labelledby="{{ category.slug }}-details-title">
+			<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">
+				<a class="text-link text-link--card" href="{% pageurl category %}">{{ category.title }}</a>
+			</h3>
 
-				{% for detail in category_detail %}
-					{% if detail.html %}
-						<div class="database-card-table__row database-card-table__row--inline">
-							<dt class="database-card-table__label">
-								{{ detail.name }} &rarr;
-							</dt>
-							<dd class="database-card-table__value">
-								{{ detail.html | safe }}
-							</dd>
-						</div>
-					{% endif %}
-				{% endfor %}
-			</dl>
-		{% endif %}
+			{% for detail in category_detail %}
+				{% if detail.html %}
+					<div class="database-card-table__row database-card-table__row--inline">
+						<dt class="database-card-table__label">
+							{{ detail.name }} &rarr;
+						</dt>
+						<dd class="database-card-table__value">
+							{{ detail.html | safe }}
+						</dd>
+					</div>
+				{% endif %}
+			{% endfor %}
+		</dl>
 	{% endfor %}
 </div>

--- a/incident/templates/incident/_details_table.html
+++ b/incident/templates/incident/_details_table.html
@@ -7,9 +7,7 @@
 		{% include "incident/_incident_details_table.html" with incident=incident only %}
 
 		{% for category, category_detail in incident.get_category_details.items %}
-			{% if category_detail %}
-				{% include "incident/_category_table.html" with category=category category_detail=category_detail only %}
-			{% endif %}
+			{% include "incident/_category_table.html" with category=category category_detail=category_detail only %}
 		{% endfor %}
 	</div>
 </section>

--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -324,10 +324,14 @@ class CategoryFieldValues(TestCase):
         self.category2 = CategoryPageFactory(
             **{'equipment_damage': True}
         )
+        # Category 3 has no metadata fields
+        self.category3 = CategoryPageFactory(
+            **{'other_incident': True}
+        )
 
         self.incident = IncidentPageFactory(
             parent=self.index,
-            categories=[self.category1, self.category2],
+            categories=[self.category3, self.category1, self.category2],
             **{'arrest': True, 'equipment_damage': True}
         )
         charge = ChargeFactory()
@@ -337,7 +341,13 @@ class CategoryFieldValues(TestCase):
         self.category_details = self.incident.get_category_details()
 
     def test_should_get_category_details(self):
-        self.assertEqual(len(self.category_details.items()), 2)
+        self.assertEqual(len(self.category_details.items()), 3)
+
+    def test_should_sort_categories_without_metadata_last(self):
+        self.assertEqual(
+            list(self.category_details.items())[-1],
+            (self.category3, []),
+        )
 
     def test_should_get_basic_category_fields(self):
         arrest_details = self.category_details[self.category1]


### PR DESCRIPTION
Fixes #1433 

This PR fixes the first two items from the ticket. I did not work on the third item because (1) I think it needs a little more fleshing out, and (2) it would not solve the problem for the "Other Incident" category. Let me know, though, if you think something like that is desired.

- Category table "headers" on the database page and incident detail page are now clickable links to the appropriate category page.
- The category headers are shown even if there is no related data, and they're shown after the data-having categories.

Examples:

## Incident detail page

![image](https://user-images.githubusercontent.com/561931/172260147-0a465668-fb90-4a4a-9b73-fe185b95d7e9.png)

## Database page

![image](https://user-images.githubusercontent.com/561931/172260330-de63729f-ec21-46c6-8069-42b098f21919.png)
