### PR TITLE
Incident card fixes

### DIFF
--- a/client/common/sass/components/_incident-database-card.sass
+++ b/client/common/sass/components/_incident-database-card.sass
@@ -74,7 +74,6 @@
 
 		+tablet-up
 			display: flex
-			align-items: center
 
 		+desktop-up
 			padding: 0.25rem 0 0 0

--- a/incident/templates/incident/_incident_card.html
+++ b/incident/templates/incident/_incident_card.html
@@ -54,10 +54,16 @@
 						</time>
 					</dd>
 				</div>
-				<div class="database-card-table__row">
-					<dt class="database-card-table__label database-card-table__label--bold">Location</dt>
-					<dd class="database-card-table__value">{{ incident.city }}, {{ incident.state.name }}</dd>
-				</div>
+				{% if incident.city or incident.state %}
+					<div class="database-card-table__row">
+						<dt class="database-card-table__label database-card-table__label--bold">Location</dt>
+						<dd class="database-card-table__value">
+							{% if incident.city %}{{ incident.city }}{% endif %}
+							{% if incident.city and incident.state %}, {% endif %}
+							{% if incident.state %}{{ incident.state.name }}{% endif %}
+						</dd>
+					</div>
+				{% endif %}
 				{% if incident.get_all_targets_for_display %}
 					<div class="database-card-table__row">
 						<dt class="database-card-table__label database-card-table__label--bold">Targets</dt>


### PR DESCRIPTION
Fixes #1443 

- [x] Don't render a location line at all if location is None. Also added individual city and state checks to better modify the display
- [x] top-align labels and content