### PR TITLE
Fix broken links to tag filter

### DIFF
--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -72,7 +72,7 @@ function getFilteredUrl(databasePath, filtersApplied, currentDate) {
 	}
 
 	if (filtersApplied.tag !== null) {
-		parameters.push(`tags=${filtersApplied.tag.replace(' ', '-')}`)
+		parameters.push(`tags=${filtersApplied.tag.replace(' ', '+')}`)
 	}
 
 	return `${baseUrl}${parameters.join('&')}`


### PR DESCRIPTION
Previously the react charts were replacing spaces with '-'s for
generating urls with tags in them, but since the tags are in
querystrings and need to be converted back to spaces for searching
'+' is the correct character to use. The previous approach was
generating filtered pages with no results