### PR TITLE
Unskip tests related to templates in PFT

### DIFF
--- a/blog/tests/test_frontend_cache_purge.py
+++ b/blog/tests/test_frontend_cache_purge.py
@@ -1,5 +1,3 @@
-import unittest
-
 from unittest.mock import patch
 
 from django.test import TestCase, Client

--- a/blog/tests/test_frontend_cache_purge.py
+++ b/blog/tests/test_frontend_cache_purge.py
@@ -18,13 +18,11 @@ class TestBlogIndexPageCachePurge(TestCase):
             parent=site.root_page, slug='blog')
         self.author = PersonPageFactory()
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_tag_index(self):
         "Response from BlogIndexPage should include Cache-Tag header"
         response = self.client.get('/blog/')
         self.assertEqual(response['Cache-Tag'], 'blog-index-{}'.format(self.index.pk))
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_tag_subpath(self):
         """
         Response from BlogIndexPage with subpath should include

--- a/common/templates/common/blocks/stat_table_block.html
+++ b/common/templates/common/blocks/stat_table_block.html
@@ -1,0 +1,14 @@
+
+{% load render_as_template %}
+<table class="data-table">
+	{% for item in self %}
+		<tr class="data-table__row">
+			<th class="data-table__label">
+				{{ item.header }}
+			</th>
+			<td class="data-table__value">
+				{% render_as_template item.value %}
+			</td>
+		</tr>
+	{% endfor %}
+</table>

--- a/common/tests/selenium.py
+++ b/common/tests/selenium.py
@@ -1,6 +1,5 @@
 import os
 import socket
-import unittest
 
 from django.db import connections
 from django.db.utils import OperationalError

--- a/common/tests/selenium.py
+++ b/common/tests/selenium.py
@@ -1,5 +1,6 @@
 import os
 import socket
+import unittest
 
 from django.db import connections
 from django.db.utils import OperationalError
@@ -14,6 +15,7 @@ SELENIUM_HOST = os.environ['SELENIUM_HOST']
 HOST_IP = socket.gethostbyname(socket.gethostname())
 
 
+@unittest.skip("Skipping till templates have been added")
 class SeleniumTest(StaticLiveServerTestCase):
     host = HOST_IP
 

--- a/common/tests/selenium.py
+++ b/common/tests/selenium.py
@@ -15,7 +15,6 @@ SELENIUM_HOST = os.environ['SELENIUM_HOST']
 HOST_IP = socket.gethostbyname(socket.gethostname())
 
 
-@unittest.skip("Skipping till templates have been added")
 class SeleniumTest(StaticLiveServerTestCase):
     host = HOST_IP
 

--- a/common/tests/test_frontend_cache_purge.py
+++ b/common/tests/test_frontend_cache_purge.py
@@ -35,13 +35,11 @@ class TestCategoryPageCacheInvalidation(TestCase):
 
         self.categorypage = CategoryPageFactory(parent=self.home_page, slug='category')
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_tag_index(self):
         "Response from CategoryPage should include Cache-Tag header"
         response = self.client.get('/category/')
         self.assertEqual(response['Cache-Tag'], 'category-page-{}'.format(self.categorypage.pk))
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_tag_subpath(self):
         """
         Response from IncidentIndexPage with subpath should include

--- a/common/tests/test_frontend_cache_purge.py
+++ b/common/tests/test_frontend_cache_purge.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase, Client
 from unittest.mock import patch
 from wagtail.core.models import Site, Page

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -1,5 +1,4 @@
 import contextlib
-import unittest
 from unittest import mock
 
 import structlog

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -38,7 +38,6 @@ class RequestLogTestCase(TestCase):
         self.response_status_code = 200
         self.response_reason_phrase = 'OK'
 
-    @unittest.skip("Skipping till templates have been added")
     @mock.patch.object(Page, 'serve')
     def test_request_log_failed(self, serve):
         serve.side_effect = Exception('Application Error')

--- a/common/tests/test_simple_page.py
+++ b/common/tests/test_simple_page.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.urls import reverse
 from wagtail.core.models import Site, Page
 from wagtail.tests.utils import WagtailPageTests

--- a/common/tests/test_simple_page.py
+++ b/common/tests/test_simple_page.py
@@ -14,7 +14,6 @@ from common.tests.factories import CategoryPageFactory, SimplePageFactory
 from home.tests.factories import HomePageFactory
 
 
-@unittest.skip("Skipping till templates have been added")
 class SimplePageStatisticsTagsTestCase(WagtailPageTests):
     def setUp(self):
         super(SimplePageStatisticsTagsTestCase, self).setUp()

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -44,13 +44,6 @@ class DocumentDownloadTest(TestCase):
         self.assertEqual(response['content-disposition'], 'inline; filename="{}"'.format(document.filename))
 
 
-@unittest.skip("Skipping till templates have been added")
-class MergeTagFormTestCase(WagtailPageTests):
-    def test_getting_the_form_succeeds(self):
-        self.response = self.client.get(CommonTagAdmin().url_helper.merge_url)
-        self.assertEqual(self.response.status_code, 200)
-
-
 class MergeTagTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -1,4 +1,3 @@
-import unittest
 import json
 from unittest import mock
 
@@ -6,7 +5,6 @@ from django.core.files.base import ContentFile
 from django.urls import reverse
 from django.test import TestCase, override_settings
 from wagtail.documents.models import Document
-from wagtail.tests.utils import WagtailPageTests
 from common.models import CommonTag
 from common.wagtail_hooks import CommonTagAdmin
 from django.contrib.auth import get_user_model

--- a/devops/tests/test_basic.py
+++ b/devops/tests/test_basic.py
@@ -2,7 +2,6 @@ import subprocess
 import pytest
 
 
-@pytest.mark.skip(reason="Skipping till templates have been added")
 def test_mainpage(host):
     """
     Basic test to make sure home-page is coming up.

--- a/forms/tests/test_models.py
+++ b/forms/tests/test_models.py
@@ -23,27 +23,20 @@ from forms.tests.factories import (
 class FormPageTestCase(TestCase):
     @classmethod
     def setUpTestData(kls):
-        Page.objects.filter(slug='home').delete()
-        root_page = Page.objects.get(title='Root')
+        site = Site.objects.get(is_default_site=True)
+        root_page = site.root_page
         home_page = HomePageFactory.build()
         root_page.add_child(instance=home_page)
-        site, created = Site.objects.get_or_create(
-            is_default_site=True,
-            defaults={
-                'site_name': 'Test site',
-                'hostname': 'testserver',
-                'port': '1111',
-                'root_page': home_page,
-            }
-        )
-        if not created:
-            site.root_page = home_page
-            site.save()
+        # print("outside if")
+        # if not created:
+        #     print("here")
+        #     site.root_page = home_page
+        #     site.save()
+        #     print(site)
 
         kls.form_page = FormPageFactory.build()
         home_page.add_child(instance=kls.form_page)
 
-    @unittest.skip("Skipping till templates have been added")
     def test_cache_control_header_private(self):
         response = self.client.get(self.form_page.get_full_url())
         self.assertEqual(response['cache-control'], 'private')

--- a/forms/tests/test_models.py
+++ b/forms/tests/test_models.py
@@ -1,10 +1,8 @@
-import unittest
-
 from django.contrib.auth.models import AnonymousUser
 from django.core import mail
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
-from wagtail.core.models import Site, Page
+from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.tests.utils.form_data import (
     inline_formset,

--- a/forms/tests/test_models.py
+++ b/forms/tests/test_models.py
@@ -23,16 +23,19 @@ from forms.tests.factories import (
 class FormPageTestCase(TestCase):
     @classmethod
     def setUpTestData(kls):
-        site = Site.objects.get(is_default_site=True)
-        root_page = site.root_page
         home_page = HomePageFactory.build()
+        site, created = Site.objects.get_or_create(
+            is_default_site=True,
+            defaults={
+                'site_name': 'Test site',
+                'hostname': 'testserver',
+                'port': '1111',
+            }
+        )
+        if not created:
+            site.save()
+        root_page = site.root_page
         root_page.add_child(instance=home_page)
-        # print("outside if")
-        # if not created:
-        #     print("here")
-        #     site.root_page = home_page
-        #     site.save()
-        #     print(site)
 
         kls.form_page = FormPageFactory.build()
         home_page.add_child(instance=kls.form_page)

--- a/incident/api/tests/test_pagination.py
+++ b/incident/api/tests/test_pagination.py
@@ -19,7 +19,6 @@ def humanize_links(response):
     return result
 
 
-@unittest.skip("Skipping till templates have been added")
 class IncidentListPaginationTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_pagination.py
+++ b/incident/api/tests/test_pagination.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from requests.utils import parse_header_links

--- a/incident/tests/test_incident_summary.py
+++ b/incident/tests/test_incident_summary.py
@@ -28,7 +28,6 @@ class IncidentSummaryAPIPost(TestCase):
         self.assertEqual(self.response.status_code, 405)
 
 
-@unittest.skip("Skipping till templates have been added")
 class IncidentSummaryAPIGet(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/tests/test_incident_summary.py
+++ b/incident/tests/test_incident_summary.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from urllib import parse
 
 from django.test import TestCase

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -905,7 +905,6 @@ class TestTopicPage(WagtailPageTests):
             parent=self.home_page,
         )
 
-    @unittest.skip("Skipping till templates have been added")
     def test_can_create_topic_page(self):
         stats_tag = '{{% num_incidents categories="{}" %}}'.format(self.category.pk)
 
@@ -947,7 +946,6 @@ class TestTopicPage(WagtailPageTests):
         response = self.client.get(topic_page.url)
         self.assertEqual(response.status_code, 200)
 
-    @unittest.skip("Skipping till templates have been added")
     def test_can_preview_topic_page(self):
         topic_page = TopicPageFactory(
             parent=self.home_page,

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -1,7 +1,6 @@
 import calendar
 import csv
 import json
-import unittest
 from datetime import timedelta, date
 from urllib import parse
 

--- a/incident/tests/test_views.py
+++ b/incident/tests/test_views.py
@@ -60,16 +60,6 @@ class IncidentAdminSearch(TestCase):
         )
 
 
-@unittest.skip("Skipping till templates have been added")
-class MergeFormViewTestCase(WagtailPageTests):
-    def test_getting_the_form_succeeds(self):
-        for item in IncidentGroup.items:
-            admin = item()
-            with self.subTest(form=f'Merge {admin.menu_label} form'):
-                self.response = self.client.get(item().url_helper.merge_url)
-                self.assertEqual(self.response.status_code, 200)
-
-
 class InstitutionMergeViewTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/tests/test_views.py
+++ b/incident/tests/test_views.py
@@ -1,15 +1,13 @@
 import json
-import unittest
 
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from wagtail.core.models import Site
 from wagtail.core.rich_text import RichText
-from wagtail.tests.utils import WagtailPageTests
 
 from incident.models import Charge, Nationality, PoliticianOrPublic, Venue, Journalist, Institution, TargetedJournalist, GovernmentWorker
-from incident.wagtail_hooks import ChargeAdmin, NationalityAdmin, VenueAdmin, PoliticianOrPublicAdmin, JournalistAdmin, InstitutionAdmin, GovernmentWorkerAdmin, IncidentGroup
+from incident.wagtail_hooks import ChargeAdmin, NationalityAdmin, VenueAdmin, PoliticianOrPublicAdmin, JournalistAdmin, InstitutionAdmin, GovernmentWorkerAdmin
 from incident.tests.factories import (
     IncidentPageFactory,
     IncidentIndexPageFactory,


### PR DESCRIPTION
Fixes #1416 

- I have unskipped all the tests related to template loading (updated wherever necessary)
- I have removed the tests which depended on the autocomplete bundle in frontend since we are not using that anymore.
- I have kept the selenium tests skipped till the incident filters are implemented (since a lot of the tests involve that)