### PR TITLE
Validate fuzzy date filter inputs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1010,9 +1010,9 @@ uritemplate==4.1.1 \
     # via
     #   -r requirements.txt
     #   drf-spectacular
-urllib3[secure,socks]==1.26.10 \
-    --hash=sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec \
-    --hash=sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6
+urllib3[secure,socks]==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
     # via
     #   -r requirements.txt
     #   mailchimp-marketing

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -192,6 +192,52 @@ class FilteredHomePageCSVTestCase(TestCase):
         self.assertEqual(self.results[0]['date'], '2022-02-02')
 
 
+class InvalidFilterHomePageCSVTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.get(is_default_site=True)
+        root_page = site.root_page
+        cls.incident_index = IncidentIndexPageFactory.build()
+        root_page.add_child(instance=cls.incident_index)
+
+    def setUp(self):
+        self.url = reverse(
+            'incidentpage-homepage_csv',
+            kwargs={'version': 'edge'},
+        )
+
+    def test_returns_400_if_lower_date_argument_is_not_valid(self):
+        self.response = self.client.get(
+            self.url,
+            {
+                'date_lower': 'INVALID_DATE',
+            },
+            HTTP_ACCEPT='text/csv',
+        )
+        self.assertEqual(self.response.status_code, 400)
+
+    def test_returns_400_if_upper_date_argument_is_not_valid(self):
+        self.response = self.client.get(
+            self.url,
+            {
+                'date_upper': 'INVALID_DATE',
+            },
+            HTTP_ACCEPT='text/csv',
+        )
+        self.assertEqual(self.response.status_code, 400)
+
+    def test_returns_400_if_both__date_arguments_are_not_valid(self):
+        self.response = self.client.get(
+            self.url,
+            {
+                'date_lower': 'INVALID_DATE',
+                'date_upper': 'INVALID_DATE',
+            },
+            HTTP_ACCEPT='text/csv',
+        )
+        self.assertEqual(self.response.status_code, 400)
+
+
 class IncidentCSVTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -172,8 +172,8 @@ class IncidentQuerySet(PageQuerySet):
 
         """
         target_range = DateRange(
-            lower=lower,
-            upper=upper,
+            lower=datetime.date.fromisoformat(str(lower)) if lower is not None else None,
+            upper=datetime.date.fromisoformat(str(upper)) if upper is not None else None,
             bounds='[]',
         )
         exact_date_match = Q(

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -696,6 +696,13 @@ class IncidentPageDateRangeFilter(TestCase):
         )
         self.assertEqual(set(incidents), {self.incident2})
 
+    def test_filters_by_date_range_using_date_types(self):
+        incidents = IncidentPage.objects.fuzzy_date_filter(
+            lower=date(2022, 2, 1),
+            upper=date(2022, 3, 1),
+        )
+        self.assertEqual(set(incidents), {self.incident2})
+
     def test_filters_by_date_range_unbounded_above(self):
         incidents = IncidentPage.objects.fuzzy_date_filter(
             lower='2022-02-01',
@@ -714,6 +721,12 @@ class IncidentPageDateRangeFilter(TestCase):
             upper='2022-02-14',
         )
         self.assertEqual(set(incidents), {self.incident2, self.incident1})
+
+    def test_validates_dates_passed_to_it(self):
+        with self.assertRaises(ValueError):
+            IncidentPage.objects.fuzzy_date_filter(
+                lower='QWERTY',
+            )
 
 
 class IncidentPageFuzzyDateRangeFilter(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -624,10 +624,12 @@ uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
     # via drf-spectacular
-urllib3==1.26.10 \
-    --hash=sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec \
-    --hash=sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6
-    # via requests
+urllib3==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
+    # via
+    #   mailchimp-marketing
+    #   requests
 wagtail==2.15.2 \
     --hash=sha256:0086c8bf7fb93e456f15f230f0bfcb3d3945420aa663a8a962c404051da96d46 \
     --hash=sha256:9a2c7ceee79f2d1974f021f76b814ba36744e91c732e7e5113a43cfb046e56f1


### PR DESCRIPTION
This pull request adds validation to the homepage CSV view to check that the dates we receive as input are valid before actually running any DB queries using them. Further explanation for individual changes made in commit messages.

This fixes a problem where a request like this:

```
GET /api/edge/incidents/homepage_csv/?date_lower=INVALID&fields=categories%2Cauthors%2Cdate%2Ccity%2Cstate%2Clatitude%2Clongitude%2Ctags&format=csv
```

Would result in a 500 error. It now results in a 400 error, and that error happens much earlier in the response chain.