### PR TITLE
Do not install pip dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run:
           name: Install pip dependencies
-          command: pip install --require-hashes -r dev-requirements.txt
+          command: pip install --no-deps --require-hashes -r dev-requirements.txt
 
       - run:
           name: Check Python dependencies for CVEs
@@ -173,7 +173,7 @@ jobs:
           name: Install dependencies
           command: |
             python -m pip install --upgrade pip
-            pip install --require-hashes -r ci-requirements.txt
+            pip install --no-deps --require-hashes -r ci-requirements.txt
 
       - attach_workspace:
           at: /tmp/workspace

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -14,7 +14,7 @@ COPY devops/docker/django-start.sh /usr/local/bin
 RUN  chmod +x /usr/local/bin/django-start.sh
 
 COPY dev-requirements.txt /requirements.txt
-RUN pip install --require-hashes -r /requirements.txt
+RUN pip install --no-deps --require-hashes -r /requirements.txt
 
 ARG USERID
 RUN getent passwd "${USERID?USERID must be supplied}" || adduser --uid "${USERID}" --disabled-password --gecos "" gcorn

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -44,7 +44,7 @@ COPY --from=node-assets /src-files/ /django/
 RUN find /django -path /django/node_modules -prune -o -print -exec chown gcorn: '{}' \;
 
 WORKDIR /django
-RUN pip install --require-hashes -r /django/requirements.txt
+RUN pip install --no-deps --require-hashes -r /django/requirements.txt
 
 
 # Really not used in production. Needed for mapped named volume


### PR DESCRIPTION
This pull request makes it so that when we install pip packages on our docker containers, we use the `--no-deps` flag. This should address a problem where sometimes the pip install command would fail when new versions of urllib3 were released.

In theory, pip-tools figures out the dependencies for us and puts what is needed into the `*requirements.txt` files.  Adding this flag fixes a bug where sometimes the `--require-hashes` check would fail when dependencies were followed by pip that were not specified in the requirements file, and thus were not hashed. 