### PR TITLE
Fix subscribe form non-AJAX submission handling

### DIFF
--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -49,6 +49,7 @@
 @import components/info-table
 @import components/statistics-table
 @import components/simplepage
+@import components/errorpage
 @import components/categorypage
 @import components/methodology
 @import components/article-content

--- a/client/common/sass/components/_errorpage.sass
+++ b/client/common/sass/components/_errorpage.sass
@@ -1,0 +1,3 @@
+.errorpage-body
+	margin-bottom: 3rem
+	+constrain-to-desktop

--- a/common/templates/common/_subscribe_error.html
+++ b/common/templates/common/_subscribe_error.html
@@ -3,7 +3,7 @@
 {% block title %}Subscription Error{% endblock %}
 
 {% block main %}
-	<div class="m-t-3 m-b-3">
+	<div class="errorpage-body m-t-3 m-b-3">
 		<h1 class="m-b-1">Subscription Error</h1>
 		<div class="text-size--large m-b-1">
 			<p>

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from django.core.files.base import ContentFile
 from django.urls import reverse
+from django.utils.http import urlencode
 from django.test import TestCase, override_settings
 from wagtail.documents.models import Document
 from common.models import CommonTag
@@ -207,9 +208,10 @@ class MailchimpInterestViewTest(TestCase):
         self.mailchimp_lists = fake_mc_data
 
     def test_view_forbidden_if_not_logged_in(self):
-        response = self.client.get(reverse('mailchimp_interests'))
-        self.assertEqual(response.status_code, 302)
-        self.assertIn(reverse('wagtailadmin_login'), response.url)
+        target_url = reverse('mailchimp_interests')
+        response = self.client.get(target_url)
+        expected_url = reverse('wagtailadmin_login') + '?' + urlencode({'next': target_url})
+        self.assertRedirects(response, expected_url)
 
     def test_view_reports_error_if_no_api_key(self):
         self.client.force_login(self.user)


### PR DESCRIPTION
Fixes a problem where non-AJAX submissions of the mailchimp subscribe form were being processed as though they were AJAX, but the form data submitted was not JSON, so this would cause an error.