### PR TITLE
Log query string information

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -36,6 +36,9 @@ class RequestLogMiddleware(object):
         request_id = str(uuid.uuid4())
 
         request_dict = {key: getattr(request, key, '') for key in self.request_keys}
+        if request.GET:
+            request_dict["query_string_raw"] = request.GET.urlencode()
+            request_dict["query_string_parsed"] = request.GET.dict()
         request_dict["user"] = str(request_dict["user"])
         request_dict["meta"] = {
             key: request.META.get(key, "") for key in self.request_meta_keys

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -68,6 +68,7 @@ class RequestLogTestCase(TestCase):
 
         request = self.factory.get(
             '/',
+            data={'key': 'value'},
             HTTP_USER_AGENT=user_agent,
             HTTP_X_FORWARDED_FOR=forwarded_for,
             HTTP_HOST=host,
@@ -108,6 +109,8 @@ class RequestLogTestCase(TestCase):
                 'path_info': '/',
                 'scheme': 'http',
                 'user': 'username1',
+                'query_string_raw': 'key=value',
+                'query_string_parsed': {'key': 'value'},
             }
         )
 


### PR DESCRIPTION
This PR adds the query string to information we are logging about incoming requests.

I'm deciding to log the "raw" string and the "parsed" string separately since Django's parsing does omit information (if a key appears more than once), but I also find the parsed version more legible most of the time.