### PR TITLE
Sign up form tests

### DIFF
--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -548,19 +548,6 @@ class SimplePage(MetadataPageMixin, Page):
         StreamFieldPanel('sidebar_content')
     ]
 
-    def get_context(self, request, *args, **kwargs):
-        # Avoid circular import
-        from home.models import HomePage
-
-        context = super(SimplePage, self).get_context(request, *args, **kwargs)
-
-        home = Page.objects.all().live().type(
-            HomePage)[0]
-
-        context['home_page'] = home
-
-        return context
-
     def get_meta_description(self):
         if self.search_description:
             return self.search_description

--- a/common/tests/selenium.py
+++ b/common/tests/selenium.py
@@ -1,30 +1,40 @@
 import os
 import socket
-import unittest
 
 from django.db import connections
 from django.db.utils import OperationalError
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core.management import call_command
 from selenium import webdriver
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from wagtail.core.models import Page, Site, Locale
+
+from home.models import HomePage
 
 
 SELENIUM_HOST = os.environ['SELENIUM_HOST']
 HOST_IP = socket.gethostbyname(socket.gethostname())
 
 
-@unittest.skip("Skipping till templates have been added")
 class SeleniumTest(StaticLiveServerTestCase):
     host = HOST_IP
+    javascript_enabled = True
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        options = webdriver.FirefoxOptions()
+
+        firefox_profile = FirefoxProfile()
+        firefox_profile.set_preference(
+            "javascript.enabled",
+            cls.javascript_enabled,
+        )
+        options.profile = firefox_profile
         cls.browser = webdriver.Remote(
             command_executor=f'http://{SELENIUM_HOST}:4444/wd/hub',
-            desired_capabilities=DesiredCapabilities.FIREFOX,
+            options=options,
         )
 
     @classmethod
@@ -62,7 +72,7 @@ class SeleniumTest(StaticLiveServerTestCase):
             depth=1,
         )
 
-        root_page = root.add_child(instance=Page(
+        root_page = root.add_child(instance=HomePage(
             title='Home',
             path='00010001',
             depth=2,

--- a/common/tests/test_subscribe_form_selenium.py
+++ b/common/tests/test_subscribe_form_selenium.py
@@ -1,0 +1,168 @@
+from unittest import mock
+
+from wagtail.core.models import Page, Site
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.common.by import By
+
+from emails.models import Subscription
+from common.tests.selenium import SeleniumTest
+from common.tests.factories import SimplePageFactory
+from emails.devdata import EmailSettingsFactory
+from common.utils import MailchimpError
+
+
+class SubscribeFormNoJSTestCase(SeleniumTest):
+    javascript_enabled = False
+
+    def setUp(self):
+        super().setUp()
+        root_page = Page.objects.get(slug='home')
+        self.site = Site.objects.get()
+        EmailSettingsFactory(site=self.site)
+        self.page = SimplePageFactory(parent=root_page)
+
+    @mock.patch('common.views.subscribe_for_site')
+    def test_form_submission(self, mock_subscribe):
+        full_name = 'Treebeard'
+        email = 'treebeard@example.com'
+        self.browser.get(self.live_server_url + self.page.url)
+        name_input = self.browser.find_element(By.ID, 'mce-MMERGE6')
+        email_input = self.browser.find_element(By.ID, 'mce-EMAIL')
+
+        handles = self.browser.window_handles
+        name_input.send_keys(full_name)
+        email_input.send_keys(email)
+        email_input.submit()
+        WebDriverWait(self.browser, 10).until(
+            expected_conditions.new_window_is_opened(handles)
+        )
+        self.browser.switch_to.window(self.browser.window_handles[-1])
+        header = WebDriverWait(self.browser, 10).until(
+            expected_conditions.presence_of_element_located((By.TAG_NAME, 'h1'))
+        )
+        self.assertEqual(header.text, 'Thank you for subscribing!')
+        mock_subscribe.assert_called_once_with(
+            self.site,
+            Subscription(email=email, full_name=full_name)
+        )
+
+    @mock.patch('common.views.subscribe_for_site')
+    def test_form_submission_error(self, mock_subscribe):
+        mock_subscribe.side_effect = MailchimpError
+
+        full_name = 'Treebeard'
+        email = 'treebeard@example.com'
+        self.browser.get(self.live_server_url + self.page.url)
+        name_input = self.browser.find_element(By.ID, 'mce-MMERGE6')
+        email_input = self.browser.find_element(By.ID, 'mce-EMAIL')
+
+        handles = self.browser.window_handles
+        name_input.send_keys(full_name)
+        email_input.send_keys(email)
+        email_input.submit()
+        WebDriverWait(self.browser, 10).until(
+            expected_conditions.new_window_is_opened(handles)
+        )
+        self.browser.switch_to.window(self.browser.window_handles[-1])
+        header = WebDriverWait(self.browser, 10).until(
+            expected_conditions.presence_of_element_located((By.TAG_NAME, 'h1'))
+        )
+        self.assertEqual(header.text, 'Subscription Error')
+        WebDriverWait(self.browser, 10).until(
+            expected_conditions.presence_of_element_located(
+                (By.XPATH, "//p[normalize-space()='An internal error occurred']")
+            )
+        )
+
+
+class SubscribeFormJSTestCase(SeleniumTest):
+    javascript_enabled = True
+
+    def setUp(self):
+        super().setUp()
+        root_page = Page.objects.get(slug='home')
+        self.site = Site.objects.get()
+        EmailSettingsFactory(site=self.site)
+        self.page = SimplePageFactory(parent=root_page)
+
+    @mock.patch('common.views.subscribe_for_site')
+    def test_form_submission(self, mock_subscribe):
+        full_name = 'Treebeard'
+        email = 'treebeard@example.com'
+        self.browser.get(self.live_server_url + self.page.url)
+        name_input = self.browser.find_element(By.ID, 'mce-MMERGE6')
+        email_input = self.browser.find_element(By.ID, 'mce-EMAIL')
+        name_input.send_keys(full_name)
+        email_input.send_keys(email)
+        email_input.submit()
+
+        element = WebDriverWait(self.browser, 10).until(
+            expected_conditions.visibility_of_element_located((By.ID, "mc-subscribe-thanks"))
+        )
+        self.assertIn(
+            "Thanks for subscribing to Freedom of the Press Foundation",
+            element.text,
+        )
+        mock_subscribe.assert_called_once_with(
+            self.site,
+            Subscription(email=email, full_name=full_name)
+        )
+
+    @mock.patch('common.views.subscribe_for_site')
+    def test_form_submission_error(self, mock_subscribe):
+        mock_subscribe.side_effect = MailchimpError
+
+        full_name = 'Treebeard'
+        email = 'treebeard@example.com'
+        self.browser.get(self.live_server_url + self.page.url)
+        name_input = self.browser.find_element(By.ID, 'mce-MMERGE6')
+        email_input = self.browser.find_element(By.ID, 'mce-EMAIL')
+        name_input.send_keys(full_name)
+        email_input.send_keys(email)
+        email_input.submit()
+
+        element = WebDriverWait(self.browser, 10).until(
+            expected_conditions.visibility_of_element_located((By.ID, "mce-error-response"))
+        )
+        self.assertEqual(
+            element.text,
+            'An internal error occurred.',
+        )
+
+
+class SubscribeFormJSNoNameTestCase(SeleniumTest):
+    javascript_enabled = True
+
+    def setUp(self):
+        super().setUp()
+        root_page = Page.objects.get(slug='home')
+        self.site = Site.objects.get()
+        EmailSettingsFactory(
+            site=self.site,
+            mailchimp_collect_name=False,
+        )
+        self.page = SimplePageFactory(parent=root_page)
+
+    @mock.patch('common.views.subscribe_for_site')
+    def test_form_submission(self, mock_subscribe):
+        email = 'treebeard@example.com'
+        self.browser.get(self.live_server_url + self.page.url)
+        with self.assertRaises(NoSuchElementException):
+            self.browser.find_element(By.ID, 'mce-MMERGE6')
+        email_input = self.browser.find_element(By.ID, 'mce-EMAIL')
+        email_input.send_keys(email)
+        email_input.submit()
+
+        element = WebDriverWait(self.browser, 10).until(
+            expected_conditions.visibility_of_element_located((By.ID, "mc-subscribe-thanks"))
+        )
+        self.assertIn(
+            "Thanks for subscribing to Freedom of the Press Foundation",
+            element.text,
+        )
+        mock_subscribe.assert_called_once_with(
+            self.site,
+            Subscription(email=email, full_name=None)
+        )

--- a/incident/tests/test_filters_selenium.py
+++ b/incident/tests/test_filters_selenium.py
@@ -1,3 +1,4 @@
+import unittest
 import urllib.parse
 import itertools
 from datetime import timedelta
@@ -36,6 +37,7 @@ def powerset(iterable):
     )
 
 
+@unittest.skip('Test applies to legacy templates')
 class FilterTest(SeleniumTest):
     def setUp(self):
         super().setUp()
@@ -72,6 +74,7 @@ class FilterTest(SeleniumTest):
         )
 
 
+@unittest.skip('Test applies to legacy templates')
 class BooleanFilterTestCase(FilterTest):
     def setUp(self):
         super().setUp()

--- a/incident/tests/test_pagination_selenium.py
+++ b/incident/tests/test_pagination_selenium.py
@@ -1,3 +1,5 @@
+import unittest
+
 from wagtail.core.models import Page
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
@@ -6,6 +8,7 @@ from common.tests.selenium import SeleniumTest
 from incident.tests.factories import IncidentIndexPageFactory, IncidentPageFactory
 
 
+@unittest.skip('Test applies to legacy templates')
 class PaginationTestCase(SeleniumTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Add selenium-based tests, with JS enabled and disabled, to the Mailchimp signup form in the page footer.