### PR TITLE
Simplify querystring logging

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -21,6 +21,7 @@ class RequestLogMiddleware(object):
             'HTTP_CF_CONNECTING_IP',
             'HTTP_X_FORWARDED_FOR',
             'HTTP_X_SCHEME',
+            'QUERY_STRING',
         )
         self.response_keys = ('charset', 'reason_phrase', 'status_code')
 
@@ -36,9 +37,6 @@ class RequestLogMiddleware(object):
         request_id = str(uuid.uuid4())
 
         request_dict = {key: getattr(request, key, '') for key in self.request_keys}
-        if request.GET:
-            request_dict["query_string_raw"] = request.GET.urlencode()
-            request_dict["query_string_parsed"] = request.GET.dict()
         request_dict["user"] = str(request_dict["user"])
         request_dict["meta"] = {
             key: request.META.get(key, "") for key in self.request_meta_keys

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -104,13 +104,12 @@ class RequestLogTestCase(TestCase):
                     'HTTP_CF_CONNECTING_IP': real_ip,
                     'HTTP_X_FORWARDED_FOR': forwarded_for,
                     'HTTP_X_SCHEME': '',
+                    'QUERY_STRING': 'key=value',
                 },
                 'method': 'GET',
                 'path_info': '/',
                 'scheme': 'http',
                 'user': 'username1',
-                'query_string_raw': 'key=value',
-                'query_string_parsed': {'key': 'value'},
             }
         )
 


### PR DESCRIPTION
Refs #1494 

`request.GET` is a `QueryDict` which isn't the friendliest object to use for obtaining log-worthy data (it's more meant for processing the query string in code), so let's do the simpler thing here, which also happens to be more readable.