### PR TITLE
Allow connections to postgresql on port 5432

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     image: postgres:13
     init: true
     ports:
-      - "127.0.0.1::5432"
+      - "5432:5432"
     volumes:
       - ./:/django:ro
     environment:


### PR DESCRIPTION
This exposes a fixed port for the postgresql container, making it easier to connect to the database using clients running on your local machine.

Syntax documentation:
https://docs.docker.com/compose/compose-file/#ports