### PR TITLE
Fix handling of charge updates with equal dates the base charge

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -152,7 +152,7 @@ class IncidentQuerySet(PageQuerySet):
         charge's most recent status."""
         newest_update = ChargeUpdate.objects.filter(
             incident_charge=OuterRef('pk'),
-            date__gt=OuterRef('date')
+            date__gte=OuterRef('date')
         ).order_by('-date').values('status')[:1]
 
         latest_status = IncidentCharge.objects.filter(


### PR DESCRIPTION
Previously, charge updates with dates equal to the date on their base `IncidentCharge` object would not be considered "newer" than the base, but now they will be.

Fixes #1516