### PR TITLE
Ignore `d3-color` vulnerability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,12 @@ bandit: ## Runs bandit static code analysis in Python3 container.
 
 .PHONY: npm-audit
 npm-audit: ## Checks NodeJS NPM dependencies for vulnerabilities
-	@docker-compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus'
+	@docker compose run --rm --entrypoint "/bin/ash -c" node 'npm install && $$(npm bin)/npm-audit-plus --ignore=1084597'
 
 .PHONY: ci-npm-audit
 ci-npm-audit:
 	@mkdir -p test-results # Creates necessary test-results folder
-	@docker-compose run --entrypoint "/bin/ash -c" node 'npm ci && $$(npm bin)/npm-audit-plus --xml > test-results/audit.xml'
+	@docker compose run --entrypoint "/bin/ash -c" node 'npm ci && $$(npm bin)/npm-audit-plus --ignore=1084597 --xml > test-results/audit.xml'
 
 .PHONY: safety
 safety: ## Runs `safety check` to check python dependencies for vulnerabilities


### PR DESCRIPTION
This cannot be fixed right now, it's a dependency of `react-animated-dataset` which has not issued an update.