### PR TITLE
Fixes the statistics grid to fluidly occupy space based on device dimension

### DIFF
--- a/client/common/sass/components/_categorypage.sass
+++ b/client/common/sass/components/_categorypage.sass
@@ -8,6 +8,7 @@
 	+desktop-up
 		display: flex
 		flex-wrap: wrap
+		gap: 14px
 
 		> *
 			flex: 1

--- a/client/common/sass/components/_statistics-table.sass
+++ b/client/common/sass/components/_statistics-table.sass
@@ -20,7 +20,7 @@
 			align-items: center
 
 			+tablet-up
-				grid-template-columns:  436px 100px 30px 1fr
+				grid-template-columns:  clamp(20.00rem, calc(10.66rem + 12.96vw), 27.25rem) clamp(0.00rem, calc(-8.05rem + 11.17vw), 6.25rem) 30px 1fr
 
 	&__link
 		color: $gray-text


### PR DESCRIPTION
Right now in the category pages, after the charts PR, the statistics table breaks in some dimensions. This is because the grid column widths are fixed for the statistics table, and since only 50% of the whole screen is available, sometimes, the grid row is overflowing the 50% because of fixed widths. Hence there is both overflowing and wrapping of the "See incidents" text. I have fluidified(not sure if that's a word) the first and second column (which is used for spacing) widths using `clamp`. So now, ideally it should still take the fixed widths when available, but it will take lesser width when there is no space. According to me this is an elegant solution, anything else would need us either to increase the space available for the table, or do some other hacky media query. Let me know if anyone disagrees.

![image](https://user-images.githubusercontent.com/9530293/200864292-52c6f853-8f38-4e88-8ee0-f3ebf7e7ebb7.png)

This is how it look at 1153px now.