### PR TITLE
Updates the clamp parameters to adjust the gap in wider screens for category page

### DIFF
--- a/client/common/sass/components/_statistics-table.sass
+++ b/client/common/sass/components/_statistics-table.sass
@@ -20,7 +20,7 @@
 			align-items: center
 
 			+tablet-up
-				grid-template-columns:  clamp(20.00rem, calc(10.66rem + 12.96vw), 27.25rem) clamp(0.00rem, calc(-8.05rem + 11.17vw), 6.25rem) 30px 1fr
+				grid-template-columns:  clamp(20.00rem, calc(10.66rem + 12.96vw), 27.25rem) clamp(0.00rem, calc(-17.58rem + 24.39vw), 4.38rem) 30px 1fr
 
 	&__link
 		color: $gray-text


### PR DESCRIPTION
As mentioned by @chigby in https://github.com/freedomofpress/pressfreedomtracker.us/pull/1524#issuecomment-1310443282, in wider screens, the 100px space between the first and second column was causing some weird issues. Fixed the clamp parameters to adjust for it.