### PR TITLE
Handle case number and case type filters

### DIFF
--- a/client/charts/js/components/FilterSet.jsx
+++ b/client/charts/js/components/FilterSet.jsx
@@ -241,6 +241,9 @@ export default function FilterSet({ filters, handleFilterChange, filterParameter
 	const components = filters.map((filter, index) => {
 		if (filter.name === 'search' || filter.name === 'tags') {
 			return
+		} else if (!filterParameters.hasOwnProperty(filter.name)) {
+			console.warn(`no filter parameters defined for filter "${filter.name}"`)
+			return
 		} else if (filter.name == 'tags') {
 			return (
 				<details

--- a/client/charts/js/components/FiltersIntegration.jsx
+++ b/client/charts/js/components/FiltersIntegration.jsx
@@ -40,6 +40,9 @@ function filterReducer(state, {type, payload}) {
 			return {...state}
 
 		case SET_PARAMETER:
+			if (!state.hasOwnProperty(payload.filterName)) {
+				throw new Error(`Cannot set parameter for unknown filter name "${payload.filterName}"`)
+			}
 			state[payload.filterName].parameters = payload.value
 			return {...state}
 		default:

--- a/client/charts/js/components/FiltersIntegration.jsx
+++ b/client/charts/js/components/FiltersIntegration.jsx
@@ -134,7 +134,7 @@ export default function FiltersIntegration({ width, dataset: dirtyDataset, initi
 					if (filter && filter.parameters) {
 						if (name == 'tags' && filter.parameters?.size > 0) {
 							searchParams.append('tags', Array.from(filter.parameters).join(','))
-						} else if (filter.type === 'autocomplete' || filter.type === 'choice' || filter.type === 'bool' || filter.type === 'radio' || filter.type === 'text') {
+						} else if (filter.type === 'autocomplete' || filter.type === 'choice' || filter.type === 'bool' || filter.type === 'radio' || filter.type === 'text' || filter.type === 'string') {
 							searchParams.append(name, filter.parameters)
 						} else if (filter.type === 'date') {
 							if (filter.parameters.min) {

--- a/client/charts/js/components/GeneralFilter.jsx
+++ b/client/charts/js/components/GeneralFilter.jsx
@@ -1,6 +1,10 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import TagFilter from './TagFilter'
 import FilterSet from './FilterSet'
+import { FiltersDispatch } from '../lib/context'
+import {
+	SET_PARAMETER,
+} from '../lib/actionTypes'
 
 export default function GeneralFilter({
 	filterDef,
@@ -11,9 +15,16 @@ export default function GeneralFilter({
 	filterWithout,
 	initialFilterParams,
 }) {
+	const updateFilters = useContext(FiltersDispatch);
 
 	function handleFilterChange(event) {
-		setFilterParameters(event.target.name, event.target.value)
+		updateFilters({
+			type: SET_PARAMETER,
+			payload: {
+				filterName: event.target.name,
+				value: event.target.value,
+			},
+		})
 	}
 
 	return (

--- a/client/charts/js/lib/queryString.js
+++ b/client/charts/js/lib/queryString.js
@@ -48,6 +48,8 @@ const queryFields = {
 	lawsuit_name: parseString,
 	venue: parseString,
 	case_statuses: parseString,
+	case_type: parseString,
+	case_number: parseString,
 	arrest_status: parseString,
 	arresting_authority: parseString,
 	status_of_charges: parseString,

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -337,8 +337,8 @@ class Command(BaseCommand):
             'targeted_journalists',
             'targeted_institutions',
             'tags',
-            'lawsuit_name',
-            'venue',
+            'case_number',
+            'case_type',
             'case_statuses',
         ]
         for f in filters_to_make:

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -21,6 +21,7 @@ from common.models import (
     SimplePage, SimplePageWithSidebar,
     FooterSettings, SearchSettings,
     GeneralIncidentFilter, IncidentFilterSettings, CategoryPage,
+    CommonTag,
 )
 from common.devdata import (
     PersonPageFactory, CustomImageFactory, OrganizationIndexPageFactory,
@@ -373,7 +374,7 @@ class Command(BaseCommand):
                 MultimediaIncidentPageFactory(
                     parent=incident_index_page,
                     categories=category_pages,
-                    tags=2,
+                    tags=0,
                     **kwargs,
                 )
 
@@ -388,6 +389,36 @@ class Command(BaseCommand):
             MultimediaIncidentUpdateFactory(page=incident)
             IncidentLinkFactory.create_batch(3, page=incident)
         home_page.save()
+
+        tag_groups = [
+            ['summer', 'autumn', 'winter', 'spring'],
+            ['antelopes', 'giraffes', 'deer', 'impalas', 'wildebeest', 'hippopotamuses', 'camels', 'pigs'],
+            ['frogs', 'newts', 'salamanders', 'caecilians', 'toads'],
+            ['box jellyfish', 'true jellyfish', 'stalked jellyfish'],
+            ['diamond', 'sapphire', 'ruby', 'emerald', 'tanzanite', 'opal'],
+            ['moss', 'seaweed', 'ferns', 'trees', 'flowers'],
+            ['spiders', 'centipedes', 'copepods', 'crabs', 'dragonflies', 'crickets', 'mantises', 'termites', 'stick insects', 'aphids', 'bees', 'ants'],
+            ['snails', 'slugs', 'squids', 'octopuses', 'cuttlefish', 'nautiluses', 'ammonites', 'clams', 'oysters'],
+            ['lizards', 'snakes', 'crocodiles', 'geckoes', 'turtles', 'tortoises'],
+            ['ostriches', 'kiwis', 'flamingoes', 'doves', 'hummingbirds', 'storks'],
+            ['kangaroo', 'opossom', 'wombat'],
+            ['shrews', 'rodents', 'rabbits'],
+            ['echidna', 'platypus'],
+            ['plum', 'orchid', 'chrysanthemum', 'bamboo'],
+            ['hyena', 'mongoose', 'civet'],
+            ['tarsier', 'lemur', 'loris', 'baboon'],
+        ]
+        cat_map = {}
+        for incident in IncidentPage.objects.all():
+            incident.tags.clear()
+            cat_ids = [x.category_id for x in incident.categories.all()]
+            for cat_id in cat_ids:
+                if cat_id not in cat_map:
+                    cat_map[cat_id] = tag_groups.pop()
+                tag, _ = CommonTag.objects.get_or_create(title=random.choice(cat_map[cat_id]))
+                incident.tags.add(tag)
+
+            incident.save()
 
         topic_page = TopicPageFactory(
             parent=home_page,


### PR DESCRIPTION
This pull request is a follow up to #1518. It fixes a two bugs in the filter sidebar introduced with that PR, and also adds some information to aid in future debugging.

1. `case_type` and `case_number` filters will now render correctly.
2. "string" type filters now are now correctly encoded into the query string when activating the "Apply Filters" button
3. Enhancements to dev data to more closely match what's in staging and production
4. Add warnings and errors where filter names are not found where they're expected to be found.