### PR TITLE
make blog site summary children max-width 50% - desktop up only

### DIFF
--- a/client/common/sass/components/_site-summary.sass
+++ b/client/common/sass/components/_site-summary.sass
@@ -24,5 +24,9 @@
 	&--blog
 		font-size: 1.125rem
 
+		> *
+			+desktop-up
+				max-width: 50%
+
 	&--error
 		margin-bottom: 104px


### PR DESCRIPTION
Fixes #1388 

![Screenshot from 2022-11-14 16-52-55](https://user-images.githubusercontent.com/1114645/201775847-f5d94252-ccb6-4832-a322-4d012c69bc16.png)
