### PR TITLE
Apply reversed coloring to children of aside

### DIFF
--- a/client/common/sass/components/_aside.sass
+++ b/client/common/sass/components/_aside.sass
@@ -1,8 +1,32 @@
 .aside
 	&--reversed
-		*
+		* > span
 			color: $white
 			background-color: $black
+			padding: 5px 1px // To fill gap left by line-height
+
+		/* Seems like the line-height & gaps created between spans
+			are little different for ol li and ul li from the rest,
+			so adding some very specific rules for padding to fill
+			the gaps. The numbers Saptak determined from experimenting.
+			This is needed to align the background of list-style icons
+			correctly with the rest of the text. */
+		ol li > span
+			padding: 4px 1px
+
+		ul li > span
+			padding: 6.5px 1px 4px
+
+		/* This rule  is needed to add background color to the list-style
+			icons. Sadly, ::marker doesn't support background-color, so
+			we need this kind of a hack. This hack also makes the above
+			code necessary */ 
+		ol, ul
+			background-color: $black
+			color: $white
+
+			li
+				background-color: $white
 		a
 			color: $white
 

--- a/client/common/sass/components/_aside.sass
+++ b/client/common/sass/components/_aside.sass
@@ -1,11 +1,8 @@
 .aside
 	&--reversed
-		background-color: $black
-		color: $white
-
 		*
-			color: inherit
-
+			color: $white
+			background-color: $black
 		a
 			color: $white
 

--- a/client/common/sass/components/_aside.sass
+++ b/client/common/sass/components/_aside.sass
@@ -5,22 +5,22 @@
 			background-color: $black
 			padding: 5px 1px // To fill gap left by line-height
 
-		/* Seems like the line-height & gaps created between spans
-			are little different for ol li and ul li from the rest,
-			so adding some very specific rules for padding to fill
-			the gaps. The numbers Saptak determined from experimenting.
-			This is needed to align the background of list-style icons
-			correctly with the rest of the text. */
+		/* Seems like the line-height & gaps created between spans */
+		/* are little different for ol li and ul li from the rest, */
+		/* so adding some very specific rules for padding to fill */
+		/* the gaps. The numbers Saptak determined from experimenting. */
+		/* This is needed to align the background of list-style icons */
+		/* correctly with the rest of the text. */
 		ol li > span
 			padding: 4px 1px
 
 		ul li > span
 			padding: 6.5px 1px 4px
 
-		/* This rule  is needed to add background color to the list-style
-			icons. Sadly, ::marker doesn't support background-color, so
-			we need this kind of a hack. This hack also makes the above
-			code necessary */ 
+		/* This rule  is needed to add background color to the list-style */
+		/* icons. Sadly, ::marker doesn't support background-color, so */
+		/* we need this kind of a hack. This hack also makes the above */
+		/* code necessary */
 		ol, ul
 			background-color: $black
 			color: $white

--- a/common/templates/common/blocks/aside_block.html
+++ b/common/templates/common/blocks/aside_block.html
@@ -1,5 +1,6 @@
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags  %}
+{% load richtext_aside from common_tags %}
 
 <aside class="aside aside--reversed">
-    {{ value.text|richtext }}
+    {{ value.text|richtext_aside }}
 </aside>

--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -35,7 +35,11 @@ def richtext_aside(value):
     html_str = richtext(value).__html__()
 
     # Implicit cache invalidation happens based on the string
-    cache_key = f"aside_html_cache_{hashlib.md5(html_str.encode('UTF-8')).hexdigest()}"  # nosec
+    html_str_hash = hashlib.md5(
+        html_str.encode('UTF-8'),
+        usedforsecurity=False,
+    ).hexdigest()
+    cache_key = f"aside_html_cache_{html_str_hash}"
     if cache_key in cache:
         return cache.get(cache_key)
 

--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -35,7 +35,7 @@ def richtext_aside(value):
     html_str = richtext(value).__html__()
 
     # Implicit cache invalidation happens based on the string
-    cache_key = hashlib.md5(html_str.encode('UTF-8')).hexdigest()  # nosec
+    cache_key = f"aside_html_cache_{hashlib.md5(html_str.encode('UTF-8')).hexdigest()}"  # nosec
     if cache_key in cache:
         return cache.get(cache_key)
 

--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -35,7 +35,7 @@ def richtext_aside(value):
     html_str = richtext(value).__html__()
 
     # Implicit cache invalidation happens based on the string
-    cache_key = hashlib.md5(html_str.encode('UTF-8')).hexdigest()
+    cache_key = hashlib.md5(html_str.encode('UTF-8')).hexdigest()  # nosec
     if cache_key in cache:
         return cache.get(cache_key)
 
@@ -51,6 +51,8 @@ def richtext_aside(value):
             elem.append(new_span)
 
     aside_html = mark_safe(str(soup))
+
+    # Setting cache for 1 hour
     cache.set(cache_key, aside_html, 3600)
     return aside_html
 

--- a/common/tests/test_template_tags.py
+++ b/common/tests/test_template_tags.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 
-from common.templatetags.common_tags import lookup, add_as_string
+from common.templatetags.common_tags import lookup, add_as_string, richtext_aside
 
 
 class TestTemplateTags(TestCase):
@@ -41,3 +41,13 @@ class TestTemplateTags(TestCase):
         bad_object.__radd__.return_value = 'I was added to something'
 
         self.assertEqual(add_as_string(part_string, bad_object), 'I was added to something')
+
+    def test_richtext_aside(self):
+        paragraph_aside = '<p data-block-key="89kgh">This is paragraph with <b>bold text</b></p>'
+        paragraph_aside_with_span = '<p data-block-key="89kgh"><span>This is paragraph with <b>bold text</b></span></p>'
+
+        heading_aside = '<h3 data-block-key="89agh">This is a heading</h3>'
+        heading_aside_with_span = '<h3 data-block-key="89agh"><span>This is a heading</span></h3>'
+
+        self.assertEqual(richtext_aside(paragraph_aside), paragraph_aside_with_span)
+        self.assertEqual(richtext_aside(heading_aside), heading_aside_with_span)

--- a/common/tests/test_template_tags.py
+++ b/common/tests/test_template_tags.py
@@ -57,7 +57,7 @@ class TestTemplateTags(TestCase):
     def test_cache_usage_in_richtext_aside(self, mock_django_cache_get):
         paragraph_aside = '<p data-block-key="89kgh">This is paragraph with <b>bold text</b></p>'
         heading_aside = '<h3 data-block-key="89agh">This is a heading</h3>'
-        paragraph_aside_cache_key = f"aside_html_cache_{hashlib.md5(paragraph_aside.encode('UTF-8')).hexdigest()}"
+        paragraph_aside_cache_key = f"aside_html_cache_{hashlib.md5(paragraph_aside.encode('UTF-8')).hexdigest()}"  # nosec
 
         richtext_aside(paragraph_aside)
         self.assertFalse(mock_django_cache_get.called)

--- a/common/tests/test_template_tags.py
+++ b/common/tests/test_template_tags.py
@@ -57,7 +57,11 @@ class TestTemplateTags(TestCase):
     def test_cache_usage_in_richtext_aside(self, mock_django_cache_get):
         paragraph_aside = '<p data-block-key="89kgh">This is paragraph with <b>bold text</b></p>'
         heading_aside = '<h3 data-block-key="89agh">This is a heading</h3>'
-        paragraph_aside_cache_key = f"aside_html_cache_{hashlib.md5(paragraph_aside.encode('UTF-8')).hexdigest()}"  # nosec
+        paragraph_aside_hash = hashlib.md5(
+            paragraph_aside.encode('UTF-8'),
+            usedforsecurity=False,
+        ).hexdigest()
+        paragraph_aside_cache_key = f"aside_html_cache_{paragraph_aside_hash}"
 
         richtext_aside(paragraph_aside)
         self.assertFalse(mock_django_cache_get.called)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 bleach>=4.1.0
+beautifulsoup4
 Django>=3.2.19,<3.3
 django-anymail
 django-csp>=3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,9 @@ beautifulsoup4==4.9.3 \
     --hash=sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35 \
     --hash=sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25 \
     --hash=sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666
-    # via wagtail
+    # via
+    #   -r requirements.in
+    #   wagtail
 bleach==6.0.0 \
     --hash=sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414 \
     --hash=sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4


### PR DESCRIPTION
This is a pretty simple fix, so perhaps I'm missing some edge cases. I did use `*` to target all children, as opposed to `> *` because that missed some text in development that had no tag. I think `> *` would be preferable, but they both do pretty much the same thing and probably better to protect against stray, random text. 

![Screenshot from 2022-11-16 17-05-03](https://user-images.githubusercontent.com/1114645/202306242-f39362b5-6e23-459e-a1df-3f18e973618f.png)

If you all know of places other than the blog to look for this pattern, please let me know! For now, hopefully this works well enough.
_____________________________________________

## Dev: 
(looks weird, but should be correct)  

![Screenshot from 2022-11-16 17-11-58](https://user-images.githubusercontent.com/1114645/202305611-cf82ff8b-7d32-426b-b855-e5968de74550.png)

http://localhost:8000/pft-blog/wrong-project-mother-respond-a-simple-successful-18/

_____________________________________________
## Prod: 
(same rule applied in Devtools) 

![Screenshot from 2022-11-16 17-05-40](https://user-images.githubusercontent.com/1114645/202305689-c150f870-c0aa-4b34-a1d6-6a96ff8a3bee.png)
https://pressfreedomtracker.us/blog/celebrating-5-years-since-launch-of-the-us-press-freedom-tracker/

![Screenshot from 2022-11-16 17-19-33](https://user-images.githubusercontent.com/1114645/202306818-ef098849-38f6-42eb-b597-b596bf253af6.png)



