### PR TITLE
Removes sandbox directive from CSP rules

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -255,7 +255,6 @@ CSP_BASE_URI = ("'self'",)
 CSP_FORM_ACTION = ("'self'",)
 CSP_FRAME_ANCESTORS = ("'self'",)
 CSP_PLUGIN_TYPES = ("'self'",)
-CSP_SANDBOX = ("'self'",)
 CSP_SCRIPT_SRC = (
     "'self'",
     "https://analytics.freedom.press",

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -254,7 +254,6 @@ CSP_DEFAULT_SRC = ("'self'",)
 CSP_BASE_URI = ("'self'",)
 CSP_FORM_ACTION = ("'self'",)
 CSP_FRAME_ANCESTORS = ("'self'",)
-CSP_PLUGIN_TYPES = ("'self'",)
 CSP_SCRIPT_SRC = (
     "'self'",
     "https://analytics.freedom.press",


### PR DESCRIPTION
The sandbox directive doesn't support the "self" value. It allows a tuple of values of `allow-*` related to things that are allowed. Keeping with the logic of being safe, making a tuple might be less flexible for us and might need much more thorough testing. Hence removing the directive for now. As far as my understanding, this isn't really that risky of a directive to skip. @mig5 do you agree?