### PR TITLE
Fixes date formatting in filter sidebar

### DIFF
--- a/client/charts/js/components/FilterSet.jsx
+++ b/client/charts/js/components/FilterSet.jsx
@@ -42,7 +42,10 @@ function DateFilter({
 							type: SET_PARAMETER,
 							payload: {
 								filterName: name,
-								value: { min: newMinDate, max: upperValue }
+								value: {
+									min: newMinDate,
+									max: isDateValid(upperValue) ? new Date(upperValue) : null
+								}
 							},
 						})
 					}}
@@ -64,7 +67,10 @@ function DateFilter({
 							type: SET_PARAMETER,
 							payload: {
 								filterName: name,
-								value: { min: lowerValue, max: newMaxDate }
+								value: {
+									min: isDateValid(lowerValue) ? new Date(lowerValue) : null,
+									max: newMaxDate
+								}
 							},
 						})
 					}}


### PR DESCRIPTION
When applying both the max and min date filters, the one which is set before gets converted to the ISOString, causing errors when trying to convert to string again. This commit ensures that the min and max values in the DateFilter is always finally set to a Date format.

Fixes #1546 