### PR TITLE
Removes filtering from treemap clicks in homepage

### DIFF
--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -81,7 +81,7 @@ function HomepageMainChartsWidth({
 						categoryColumn={'categories'}
 						titleLabel={'incidents'}
 						openSearchPage={(category) => {
-							goToFilterPage(databasePath, { ...filtersApplied, category }, currentDate)
+							goToFilterPage(databasePath, { category }, currentDate)
 						}}
 						categoriesColors={categoriesColors}
 						allCategories={Object.keys(categoriesColors)}

--- a/client/charts/js/lib/utilities.js
+++ b/client/charts/js/lib/utilities.js
@@ -75,7 +75,7 @@ export function getFilteredUrl(databasePath, filtersApplied, currentDate) {
 		parameters.push(`state=${filtersApplied.state.replace(' ', '+')}`)
 	}
 
-	if (filtersApplied.year !== null && filtersApplied.monthName === undefined) {
+	if (filtersApplied.year !== null && filtersApplied.year !== undefined && filtersApplied.monthName === undefined) {
 		parameters.push(`date_lower=${filtersApplied.year}-01-01&date_upper=${filtersApplied.year}-12-31`)
 	}
 


### PR DESCRIPTION
Fixes #1547 

As mentioned in the issue, the treemaps always added 6 month filtering to the category page links. However the category page has no way of displaying active filters and it always will show only the 8 latest incident with the filter applied. So removing the filters from the treemap in the homepage.