### PR TITLE
Fix warning from react-18 about improper import

### DIFF
--- a/client/charts/js/filter-sidebar.js
+++ b/client/charts/js/filter-sidebar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { createRoot } from "react-dom";
+import { createRoot } from "react-dom/client";
 import FilterSidebar from "./components/FilterSidebar";
 
 function renderSidebar() {

--- a/client/charts/js/index.js
+++ b/client/charts/js/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { createRoot } from "react-dom";
+import { createRoot } from "react-dom/client";
 import App from "./components/App";
 
 function renderApp() {

--- a/client/common/js/categoryPage.jsx
+++ b/client/common/js/categoryPage.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { createRoot } from "react-dom"
+import { createRoot } from "react-dom/client"
 import CategoryPageChart from "../../charts/js/components/CategoryPageChart"
 import DataLoader from "../../charts/js/components/DataLoader"
 

--- a/client/common/js/home.jsx
+++ b/client/common/js/home.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { createRoot } from "react-dom"
+import { createRoot } from "react-dom/client"
 
 import HomepageMainCharts from '../../charts/js/components/HomepageMainCharts'
 import DataLoader from "../../charts/js/components/DataLoader"


### PR DESCRIPTION
Fixes the warning on some pages that says:

> Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".
