### PR TITLE
Add attribution to aligned captioned image block template

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -116,11 +116,11 @@ pytest-testinfra==6.4.0 \
     --hash=sha256:5c3d1f61852a4e2c08bf40dbdf9ff004b10ee8308985883986e53d1610c0b2c3 \
     --hash=sha256:b3f147cf18608298381b976ba5e161bc625e9f58ca6d8d61eb769fbd99716de6
     # via -r ci-requirements.in
+setuptools==65.6.3 \
+    --hash=sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54 \
+    --hash=sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75
+    # via diff-cover
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via pytest
-
-# WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools

--- a/client/common/sass/components/_media.sass
+++ b/client/common/sass/components/_media.sass
@@ -10,13 +10,19 @@
 		margin-left: 1em
 
 	&__caption
+		line-height: 1
 		p
 			font-size: $font-size-small-p
 			letter-spacing: -0.01em
 			line-height: 1.43
+			display: inline
 
 			&:first-of-type
 				margin-top: 0.25em
+
+		.media-attribution
+			font-size: $font-size-small-p
+			text-transform: uppercase
 
 		a
 			color: $black

--- a/common/templates/common/_video_or_image.html
+++ b/common/templates/common/_video_or_image.html
@@ -13,7 +13,7 @@
 				{% if image.attribution %}
 					<span
 						class="media-attribution"
-						aria-label="Attributed to: {{ image.attribution }}"> — {{ image.attribution }}</span>
+					> — {{ image.attribution }}</span>
 				{% endif %}
 			</figcaption>
         {% endif %}

--- a/common/templates/common/blocks/aligned_captioned_image.html
+++ b/common/templates/common/blocks/aligned_captioned_image.html
@@ -1,6 +1,14 @@
 <figure class="inline-media {{ value.alignment }}">
     {% include 'common/blocks/image_block.html' with value=value.image %}
-    {% if value.caption %}
-        <figcaption class="inline-media__caption">{{ value.caption }}</figcaption>
+    {% if value.caption or value.image.attribution %}
+        <figcaption class="inline-media__caption">
+			{% if value.caption %}{{ value.caption }}{% endif %}
+			{% if value.image.attribution %}
+				<span
+					class="media-attribution"
+					aria-label="Attributed to: {{ value.image.attribution }}"> — {{ value.image.attribution }}
+				</span>
+			{% endif %}
+		</figcaption>
     {% endif %}
 </figure>

--- a/common/templates/common/blocks/aligned_captioned_image.html
+++ b/common/templates/common/blocks/aligned_captioned_image.html
@@ -6,7 +6,7 @@
 			{% if value.image.attribution %}
 				<span
 					class="media-attribution"
-					aria-label="Attributed to: {{ value.image.attribution }}"> — {{ value.image.attribution }}
+				> — {{ value.image.attribution }}
 				</span>
 			{% endif %}
 		</figcaption>

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -989,6 +989,12 @@ toml==0.10.2 \
     # via
     #   autopep8
     #   ipdb
+tqdm==4.64.1 \
+    --hash=sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4 \
+    --hash=sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1
+    # via
+    #   -r requirements.txt
+    #   wagtail-inventory
 traitlets==5.1.1 \
     --hash=sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7 \
     --hash=sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033
@@ -1042,6 +1048,7 @@ wagtail==4.1.1 \
     #   -r requirements.txt
     #   wagtail-autocomplete
     #   wagtail-factories
+    #   wagtail-inventory
     #   wagtail-metadata
 wagtail-autocomplete==0.9.0 \
     --hash=sha256:b64828d35f370453c84bc4094174872822798e54414f5fb9fc8a43c2a6c3e727 \
@@ -1053,6 +1060,10 @@ wagtail-django-recaptcha==1.0 \
 wagtail-factories==3.1.0 \
     --hash=sha256:26b42998420005ab556f714e72e4a53427aac59ae595c66d1379a2c141f92be5 \
     --hash=sha256:ea366dc1d399e9c24218366fc80a104f51c3f18469ed19c576e15023a226c942
+    # via -r requirements.txt
+wagtail-inventory==1.6 \
+    --hash=sha256:42d7845fd561a1b8c71b100b41f658351d5547a7653cfb689f2263df5ed5bcf3 \
+    --hash=sha256:4bb75ddc87d6abcaed4404b22977ee5b6f3a746c81a657f64b434e0cf2552de3
     # via -r requirements.txt
 wagtail-metadata==4.0.2 \
     --hash=sha256:28436201e308921ec6a4e15ac45b3bd09cdd61f699a0973d968653a8e2fff5a7 \

--- a/requirements.in
+++ b/requirements.in
@@ -29,5 +29,6 @@ wagtail-autocomplete>=0.9.0
 wagtail-factories>=3.1.0
 wagtail-django-recaptcha
 wagtail-metadata>=4
+wagtail-inventory
 unittest-xml-reporting
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -621,6 +621,10 @@ telepath==0.2 \
     --hash=sha256:801615094d3d964e178183099bf04020f4ff9c84ec43945d40b096df0a5767ee \
     --hash=sha256:ef4cf2a45ed1908c58639c346756955f8a73ae79002a8116d596b3fd702bf84c
     # via wagtail
+tqdm==4.64.1 \
+    --hash=sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4 \
+    --hash=sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1
+    # via wagtail-inventory
 typing==3.7.4.3 \
     --hash=sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9 \
     --hash=sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5
@@ -652,6 +656,7 @@ wagtail==4.1.1 \
     #   -r requirements.in
     #   wagtail-autocomplete
     #   wagtail-factories
+    #   wagtail-inventory
     #   wagtail-metadata
 wagtail-autocomplete==0.9.0 \
     --hash=sha256:b64828d35f370453c84bc4094174872822798e54414f5fb9fc8a43c2a6c3e727 \
@@ -663,6 +668,10 @@ wagtail-django-recaptcha==1.0 \
 wagtail-factories==3.1.0 \
     --hash=sha256:26b42998420005ab556f714e72e4a53427aac59ae595c66d1379a2c141f92be5 \
     --hash=sha256:ea366dc1d399e9c24218366fc80a104f51c3f18469ed19c576e15023a226c942
+    # via -r requirements.in
+wagtail-inventory==1.6 \
+    --hash=sha256:42d7845fd561a1b8c71b100b41f658351d5547a7653cfb689f2263df5ed5bcf3 \
+    --hash=sha256:4bb75ddc87d6abcaed4404b22977ee5b6f3a746c81a657f64b434e0cf2552de3
     # via -r requirements.in
 wagtail-metadata==4.0.2 \
     --hash=sha256:28436201e308921ec6a4e15ac45b3bd09cdd61f699a0973d968653a8e2fff5a7 \

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     'webpack_loader',
     'wagtailautocomplete',
     'widget_tweaks',
+    'wagtailinventory',
 
     'django.contrib.admin',
     'django.contrib.auth',


### PR DESCRIPTION
This PR adds some logic for showing the attribution of an image belonging to the Aligned Captioned Image Block. Minor changes made to CSS here to display that caption inline with the attribution with the correct line height.

Also adds the wagtail inventory package. **Note**: we will need to run `manage.py block_inventory` after this is deployed.

Fixes #1558 

### Screenshots

Top to bottom: Long caption with attribution, short caption with attribution, no caption.

![image](https://user-images.githubusercontent.com/561931/208759501-b22f536d-23f0-4203-b0ae-02233253d5f6.png)

![image](https://user-images.githubusercontent.com/561931/208759596-43a1acc1-3c46-43ae-b889-620fc8624af5.png)
