### PR TITLE
safety: Use centralized project.json information

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ jobs:
       - checkout
 
       - run:
+          name: Obtain misc resources
+          command: git clone --depth 1 https://github.com/freedomofpress/fpf-misc-resources.git
+
+      - run:
           name: Install pip dependencies
           command: pip install --no-deps --require-hashes -r dev-requirements.txt
 

--- a/project.json
+++ b/project.json
@@ -1,5 +1,0 @@
-{
-	"variables": {
-		"SAFETY_IGNORE_IDS": ["41002", "51159"]
-	}
-}

--- a/scripts/safety_check.py
+++ b/scripts/safety_check.py
@@ -7,6 +7,9 @@ import sys
 import pathlib
 
 
+CENTRALIZATION_REPO_NAME = "fpf-misc-resources"
+
+
 def check_full_report(ids_to_ignore=[]):
     """Runs `safety` on all requirements files, outputs the full report
     for each.  Exits with a success code (0) if all the checks also
@@ -29,9 +32,14 @@ def check_full_report(ids_to_ignore=[]):
 
 
 if __name__ == '__main__':
-    project_path = pathlib.Path(__file__).parent.parent / "project.json"
+    resources_path = (
+        pathlib.Path(__file__).parent.parent /
+        CENTRALIZATION_REPO_NAME /
+        "projectfiles" /
+        "pressfreedomtracker.us.json"
+    )
 
-    project = json.loads(project_path.read_text())
+    project = json.loads(resources_path.read_text())
 
     try:
         sys.exit(


### PR DESCRIPTION
This pull request removes the `project.json` file used in the PR-based safety check and replaces it with the one in the fpf-misc-resources repo.