### PR TITLE
Add Troubleshooting Doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,8 @@ environment, run the following your first run:
 
 You should be able to hit the web server interface by running ``make open-browser``
 
+If you run into any issues starting the application locally, check the `troubleshooting doc <TROUBLESHOOTING.md>`_ for solutions to common problems.
+
 Note: the ``createdevdata`` command fetches images from the internet
 by default.  To disable this behavior, run the command with the
 ``--no-download`` argument, e.g.:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,4 @@
+# Troubleshooting
+
+## Running `docker-compose up` throws errors and doesn't start
+If this is a fresh install, the steps for generating all the required files may not occur in the proper order. To solve this, simply re-run `docker-compose up` a few times in succession, and it should start successfully.


### PR DESCRIPTION
Current working PR as I note the things I run into while getting started.

I noticed that many docs in this repo are `.rst` files instead of `.md`, let me know if I should also making this troubleshooting doc a `.rst`.