### PR TITLE
Remove unnecessary computation from Incidents Database page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,17 +106,21 @@ To ``tracker/settings/local.py`` (you may need to create this file if it does no
 Profiling
 ---------
 
-There are a couple of options preconfigured in this repo for profiling the application.  They are `django-cprofile-middleware <https://pypi.org/project/django-cprofile-middleware/>`_ and `silk <https://github.com/jazzband/django-silk>`_ middleware.
+There are a couple of options preconfigured in this repo for profiling the application.  They are `django-cprofile-middleware <https://pypi.org/project/django-cprofile-middleware/>`_, `silk <https://github.com/jazzband/django-silk>`_ middleware, and `pyinstrument <https://pypi.org/project/pyinstrument/>`_.
 
-Profiling is not enabled by default, as it does add potential performance overhead if you don't actively need it.  To enable profiling, set ``DJANGO_PROFILE=yes`` when starting docker compose:
+Profiling is not enabled by default, as it does add potential performance overhead if you don't actively need it.  To enable silk (and cprofile), set ``DJANGO_PROFILE=yes`` when starting docker compose.  To enable pyinstrument, set ``PYINSTRUMENT=yes``:
 
 .. code:: bash
 
-    DJANGO_PROFILE=yes docker-compose up
+    PYINSTRUMENT=yes DJANGO_PROFILE=yes docker compose up
 
 This will enable both middlewares.  To view the cProfile information for any url, append ``?prof`` to the url (or add it to an existing query string with ``&prof``).  This can give you fairly detailed information about which lines of code are causing your view to be slow.  Additional information about the information provided is available in `the Python documentation <https://docs.python.org/3.7/library/profile.html>`_.
 
+Pyinstrument functions similarly to cProfile, but it has a much nicer interface.  Append ``?profile`` (or ``&profile``) to any URL to load it.
+
 If the specific lines of python code are not enough to determine what's causing the slowdown, it might be the database.  To view more detailed profiling data about database queries, I recommend silk.  The silk middleware logs all queries generated on a per-request basis.  To see this, make a request to the view you want to profile, wait for it to complete, then load the silk admin at ``http://localhost:8000/silk``.
+
+
 
 Dependency Management
 ---------------------

--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -503,7 +503,6 @@ class CategoryPage(MetadataPageMixin, Page):
         context['recent_incidents'] = incident_qs
         context['entries_page'] = entries
         context['paginator'] = paginator
-        context['summary_table'] = incident_filter.get_summary()
 
         #  check if filters other than category are applied
         filters = dict(request.GET)

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,8 +1,9 @@
 -r requirements.txt
 coverage>=5.5
-django-cprofile-middleware
+django-cprofile-middleware>=1.0.5
+pyinstrument>=4.4.0
 django-debug-toolbar>=3.2.4
-django-silk
+django-silk>=5.0.3
 flake8
 ipdb>=0.13.9
 selenium

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -260,9 +260,9 @@ django-recaptcha==3.0.0 \
 django-settings-export==1.2.1 \
     --hash=sha256:fceeae49fc597f654c1217415d8e049fc81c930b7154f5d8f28c432db738ff79
     # via -r requirements.txt
-django-silk==4.3.0 \
-    --hash=sha256:15ce316ac56d202bc7f0edab52d90d9b5282a41cbef9e38faab27e642d8a4e2b \
-    --hash=sha256:b010e51d9a2408ca0471bc943941676950f1d2906af3d09f9ffcd56f232688fc
+django-silk==5.0.3 \
+    --hash=sha256:2f1fcaaf21192011147537fe1ca72dc9f552f32d7043ebd82aeeda370f194469 \
+    --hash=sha256:50552f06d9306d06517fbeab9a2c74856355e06304f03ed16b6dd353f7c77e7a
     # via -r dev-requirements.in
 django-storages[google]==1.13.2 \
     --hash=sha256:31dc5a992520be571908c4c40d55d292660ece3a55b8141462b4e719aa38eab3 \
@@ -476,9 +476,7 @@ jedi==0.18.1 \
 jinja2==3.1.2 \
     --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
     --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
-    # via
-    #   -r requirements.txt
-    #   django-silk
+    # via -r requirements.txt
 jsonschema==4.4.0 \
     --hash=sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83 \
     --hash=sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823
@@ -796,6 +794,58 @@ pygments==2.14.0 \
     # via
     #   -r requirements.txt
     #   ipython
+pyinstrument==4.4.0 \
+    --hash=sha256:09167ece8802bc03a63e97536dcefd9c1a340dae686f40914cf995099bc0d0af \
+    --hash=sha256:0bbd169b92147ec5d67ed160c300dda504059cfd81e953ed5b059e8ef92bb482 \
+    --hash=sha256:1d2a1e53615c8ef210286e4d2d93be0d3e8296995b090df29a0b7ddeae5d874b \
+    --hash=sha256:2d131b98f116fb895d759dfb8c1078e0e9fa8987a9f44f566d29221545f75bd4 \
+    --hash=sha256:2f57b61d39d3b1a4d773da16baa8456aa66102d6016ce1f39817051550cbe47e \
+    --hash=sha256:30f5ce299c3219559870117c5b0825f33243808be375be9c3525572ba050c2db \
+    --hash=sha256:3643084ee8ad22d9ea2adb13d65d4b6e18810113e4176b19d026a011957f8c7c \
+    --hash=sha256:375a340c3fbebd922a35b0834de1c82d1b4fea681df49f99729439a6cb5e6ad4 \
+    --hash=sha256:39584c0fec147e3bbfa7b28454332f9801af5f93331f4143f24a4b0f9e3cb470 \
+    --hash=sha256:3c012422c851f0457c3cb82d8b1259d96fa0dcddc0f1e8bf4d97f0b2efe54485 \
+    --hash=sha256:4f07941bb5dd5cd730fc84eef6497ef9f0807c686e68d0c6b1f464589646a3b7 \
+    --hash=sha256:50727b686a0961a11eba2fe6205d0899f3479c983bcf34abb114d6da70bc1b93 \
+    --hash=sha256:5491a5cb3ae5e88436d48b4b3de8328286e843e7307116dc2cca397c9c2ffe21 \
+    --hash=sha256:59f5f479db277b3dbeb0c6843a7e9a38ee8b7c23d75b9ef764d96cb522d96212 \
+    --hash=sha256:5a9aead0ca5579473f66fed4c449c693feee464802b5ba9b98772e64e02c575c \
+    --hash=sha256:5e750fc3afb9acc288ad84b183a5ccd863e9185c435b445fcc62e0c133af9b7f \
+    --hash=sha256:73edbce7fda1b3d8cab0b6c39c43b012167d783c072f40928600c3357d1a5dc5 \
+    --hash=sha256:7526f0b1dab721ddc19920fa1f4eeaa5bcb658a4d18ac9c50868e84f911f794b \
+    --hash=sha256:7c614e2c241fb558a25973019ff43ce027ba4958bcb87383f0b0789af9c4d03b \
+    --hash=sha256:7db8cb55182883be48520eb915bd1769f176a4813ce0cc38243aa2d1182e7ce7 \
+    --hash=sha256:8874f8f58cfcb1ff134dc8e4a2b31ab9175adb271a4423596ed7ac8183592cf8 \
+    --hash=sha256:97cbeb5f5a048dc6eb047495f73db90c9e2ec97606e65298c7ea2c61fa52de38 \
+    --hash=sha256:9a13c75b24bf8eed5a4356ffa8a419cc534284a529f2b314f3e10275a820420f \
+    --hash=sha256:9a4a053cd67102c6fcc313366ea6be97cfce7eae2b9e57e62c9be8adbbdebc17 \
+    --hash=sha256:9b2bcd803d273c8addf01eaf75a42ae0a2a9196a58fb0ebb8d29be75abb88701 \
+    --hash=sha256:9e7d1cc3affef4a7e4695bb87c6cfcd577e2dac508624a91481f24217ef78c57 \
+    --hash=sha256:9fda1bd596e81ecd2b6a976eb9b930a757a5dd04071583d0141d059e34eed83f \
+    --hash=sha256:a19784a898133b7e0ffe4489155bacd2d07ec48ea059f9bf50033dc2b814c273 \
+    --hash=sha256:a7c774c4b8df21664b082d3e72fa8cbc0631fe9bb222bb9d285ccfe9cd9b4909 \
+    --hash=sha256:a8afee175335005d2964848b77579bfc18f011ea74b59b79ab6d5b35433bf3e3 \
+    --hash=sha256:b2a6609ef74ad8ba292a11fbd975660bc86466c7eaab1ff11360d24e0300800b \
+    --hash=sha256:b50cf50513a5318738c3c7147f02596cda4891089acf2f627bb65954fc5bcbfd \
+    --hash=sha256:b72bde0b1a03d1b2dc9b9d79546f551df6f67673cca816614e98ea0aebd3bc50 \
+    --hash=sha256:b9cbaf3bcda5ad9af4c9a7bf4f1b8f15bb32c4cadf554d0a2c723892c898021b \
+    --hash=sha256:bb89033e41e74dc2ac4fd882269e91ddf677588efa665d2be8b718e96ea4cec6 \
+    --hash=sha256:be34a2e8118c14a616a64538e02430d9099d5d67d8a370f2888e4ac71e52bbb7 \
+    --hash=sha256:be9ac54a4dd07d969d5941e4dcba67d5aef5f6826f43b9ddda65553816f6abca \
+    --hash=sha256:bfc4e2fd670a570ea847f6897283d10d4b9606170e491f01b75488ed1aa37a81 \
+    --hash=sha256:d66fcc94f0ebaab6bcbbdfa2482f833dd634352a20295616ea45286e990f7446 \
+    --hash=sha256:d70fed48ddd0078e287fb580daaeede4d8703a9edc8bf4f703308a77920bac37 \
+    --hash=sha256:dd9625cf136eb6684d9ca555a5088f21a7ac6c6cb2ece3ae45d09772906ceba8 \
+    --hash=sha256:de83152bafc9eed4e5469e340b6002be825151f0654c32bbb9a3a7e31708d227 \
+    --hash=sha256:e4f5ad100710dda68f9f345961780bf4f0cbb9fd3e46295d099bb9ad65b179ea \
+    --hash=sha256:e5233022ba511ef7ecfef2e07d162c0817048c995f0940f9aa2f6a1936afcb9c \
+    --hash=sha256:e5583b0d23f87631af06bb9f3c184190c889c194b02553eed132de966324bdf9 \
+    --hash=sha256:e5f4d6e1c395f259f67a923a9c54dc3eaccd5f02540598da4f865c4bb3545762 \
+    --hash=sha256:ebc63b70845e3a44b673f7dcdc78ac2c475684db41b0402eea370f194da2a287 \
+    --hash=sha256:fcd717910a8ab6deca353aded890403bbaea14a6dd99a87c3367f24721d2d6aa \
+    --hash=sha256:ffd9a9fa73fd83a40252430c6ebf8dfff7c668cc68eab4a92562b8b27c302598 \
+    --hash=sha256:ffeeaa0d036a8bef31da6fc13c4ea097160f913d86319897314113bb9271af4c
+    # via -r dev-requirements.in
 pyopenssl==22.0.0 \
     --hash=sha256:660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf \
     --hash=sha256:ea252b38c87425b64116f808355e8da644ef9b07e429398bfece610f893ee2e0
@@ -841,7 +891,6 @@ python-dateutil==2.8.2 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
     # via
     #   -r requirements.txt
-    #   django-silk
     #   faker
     #   mailchimp-marketing
 python-json-logger==2.0.7 \
@@ -855,7 +904,6 @@ pytz==2022.1 \
     #   -r requirements.txt
     #   django
     #   django-modelcluster
-    #   django-silk
     #   djangorestframework
     #   l18n
 pyyaml==6.0 \
@@ -901,7 +949,6 @@ requests==2.27.1 \
     # via
     #   -r requirements.txt
     #   django-anymail
-    #   django-silk
     #   google-api-core
     #   google-cloud-storage
     #   mailchimp-marketing

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,7 @@ services:
       DJANGO_XMLTEST_OUTPUT: "yes"
       DEPLOY_ENV: dev
       DJANGO_PROFILE: "${DJANGO_PROFILE:-no}"
+      PYINSTRUMENT: "${PYINSTRUMENT:-no}"
       SELENIUM_HOST: selenium
     working_dir: /django
     volumes:

--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -228,7 +228,6 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
 
         context['entries_page'] = entries
         context['paginator'] = paginator
-        context['summary_table'] = incident_filter.get_summary()
 
         get_data = request.GET.copy()
         context['sort_choices'] = []

--- a/tracker/settings/dev.py
+++ b/tracker/settings/dev.py
@@ -123,6 +123,9 @@ def get_default_gateway_linux():
 
 
 if DEBUG:
+    if os.environ.get('PYINSTRUMENT', 'no').lower() == 'yes':
+        MIDDLEWARE = ['pyinstrument.middleware.ProfilerMiddleware'] + MIDDLEWARE  # noqa: F405
+
     if os.environ.get('DJANGO_PROFILE', 'no').lower() == 'yes':
         # Silk
         INSTALLED_APPS.append('silk')  # noqa: F405


### PR DESCRIPTION
This PR 

1. Removes a call computing the incidents summary from the `IncidentIndexPage.get_context()` method. We aren't using this data anywhere (as far as I can tell) on that page, and this is just wasting time.
2. Updates `django-silk` to the latest version
3. Adds `pyinstrument` (https://pypi.org/project/pyinstrument/) for additional profiling help. It's enabled separately from silk because I didn't want them interfering with each other (not sure if this is a problem, but I'm trying to be careful here).