### PR TITLE
Centralize npm audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     docker:
-      - image: cimg/node:16.16.0
+      - image: cimg/node:18.16
     working_directory: ~/tracker
     steps:
       - checkout
@@ -56,7 +56,7 @@ jobs:
 
       - run:
           name: Upgrade NPM to consistent version with dev environment
-          command: npm install --location=global npm@9.6.0
+          command: npm install --location=global npm@9.6.4
 
       - run:
           name: Check node dependencies for vulnerabilities

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,12 @@ jobs:
           command: npm install --location=global npm@9.6.4
 
       - run:
-          name: Check node dependencies for vulnerabilities
-          command: |
-            mkdir -p test-results
-            npm ci
-            npx npm-audit-plus  --ignore=1084597,1088594 --xml > test-results/audit.xml
+          name: Obtain misc resources
+          command: git clone --depth 1 https://github.com/freedomofpress/fpf-misc-resources.git
 
-      - store_test_results:
-          path: ~/tracker/test-results/
+      - run:
+          name: Check node dependencies for vulnerabilities
+          command: npx audit-ci@^6 --config fpf-misc-resources/audit-ci/pressfreedomtracker.us.json5
 
   dev:
     environment:


### PR DESCRIPTION
This PR switches us from using `npm-audit-plus` to `audit-ci` with settings centralized in our misc. resources repo.

Refs https://github.com/freedomofpress/fpf-www-projects/issues/326