### PR TITLE
Incident search filter improvements

### DIFF
--- a/common/search.py
+++ b/common/search.py
@@ -1,0 +1,14 @@
+def get_searchable_content_for_fields(value, child_blocks, fields_to_index):
+    """Returns the searchable content for a subset of indexable fields
+
+    Intended to be used with StructBlocks or other collections of
+    blocks where not all fields should be included in the public
+    index.
+
+    `fields_to_index` should be a list of field names.
+
+    """
+    content = []
+    for field in fields_to_index:
+        content.extend(child_blocks[field].get_searchable_content(value[field]))
+    return content

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -1,13 +1,21 @@
 import factory
 import wagtail_factories
+from wagtail_factories.blocks import BlockFactory
 from wagtail import blocks
 from wagtail.rich_text import RichText
 
 from common.blocks import (
+    ALIGNMENT_CHOICES,
     Heading1,
     Heading2,
     Heading3,
     StyledTextBlock,
+    RichTextTemplateBlock,
+    AlignedCaptionedImageBlock,
+    TweetEmbedBlock,
+    PullQuoteBlock,
+    RichTextBlockQuoteBlock,
+    AlignedCaptionedEmbedBlock,
 )
 from common.choices import CATEGORY_SYMBOL_CHOICES
 from common.models import (
@@ -22,6 +30,55 @@ from common.models import (
     TaxonomyCategoryPage,
     TaxonomySettings,
 )
+
+
+class RichTextTemplateBlockFactory(BlockFactory):
+    class Meta:
+        model = RichTextTemplateBlock
+
+
+class AlignedCaptionedImageBlockFactory(wagtail_factories.StructBlockFactory):
+    image = factory.SubFactory(
+        wagtail_factories.blocks.ImageChooserBlockFactory,
+    )
+    caption = RichText('Caption')
+    alignment = ALIGNMENT_CHOICES[0][0]
+
+    class Meta:
+        model = AlignedCaptionedImageBlock
+
+
+class TweetEmbedBlockFactory(wagtail_factories.StructBlockFactory):
+    tweet = factory.SubFactory(wagtail_factories.blocks.CharBlockFactory)
+
+    class Meta:
+        model = TweetEmbedBlock
+
+
+class RichTextBlockQuoteBlockFactory(wagtail_factories.StructBlockFactory):
+    text = RichText('Quote content')
+    source_text = RichText('Name of source')
+    source_url = 'https://freedom.press'
+
+    class Meta:
+        model = RichTextBlockQuoteBlock
+
+
+class PullQuoteBlockFactory(wagtail_factories.StructBlockFactory):
+    text = 'Text of Quote'
+
+    class Meta:
+        model = PullQuoteBlock
+
+
+class AlignedCaptionedEmbedBlockFactory(wagtail_factories.StructBlockFactory):
+    caption = RichText('Embed caption')
+    attribution = 'Attribution of embed'
+    video = factory.SubFactory(wagtail_factories.blocks.CharBlockFactory)
+    alignment = ALIGNMENT_CHOICES[0][0]
+
+    class Meta:
+        model = AlignedCaptionedEmbedBlock
 
 
 class DevelopmentSiteFactory(wagtail_factories.SiteFactory):

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -31,7 +31,7 @@ from wagtail import blocks
 from wagtail.fields import StreamField, RichTextField
 from wagtail.models import Page, Orderable, PageManager, PageQuerySet
 from wagtail.images.blocks import ImageChooserBlock
-
+from wagtail.search import index
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 from common.blocks import (
     RichTextBlockQuoteBlock,
@@ -769,6 +769,14 @@ class IncidentPage(MetadataPageMixin, Page):
     ]
 
     parent_page_types = ['incident.IncidentIndexPage']
+
+    search_fields = Page.search_fields + [
+        index.SearchField('body'),
+        index.SearchField('city'),
+        index.RelatedFields('state', [
+            index.SearchField('name'),
+        ])
+    ]
 
     def get_context(self, request, *args, **kwargs):
         context = super(IncidentPage, self).get_context(request, *args, **kwargs)

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -775,7 +775,13 @@ class IncidentPage(MetadataPageMixin, Page):
         index.SearchField('city'),
         index.RelatedFields('state', [
             index.SearchField('name'),
-        ])
+        ]),
+        index.SearchField('introduction'),
+        index.SearchField('teaser'),
+        index.RelatedFields('teaser_image', [
+            index.SearchField('attribution'),
+        ]),
+        index.SearchField('image_caption'),
     ]
 
     def get_context(self, request, *args, **kwargs):

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -782,6 +782,10 @@ class IncidentPage(MetadataPageMixin, Page):
             index.SearchField('attribution'),
         ]),
         index.SearchField('image_caption'),
+        index.RelatedFields('updates', [
+            index.SearchField('title'),
+            index.SearchField('body'),
+        ]),
     ]
 
     def get_context(self, request, *args, **kwargs):

--- a/incident/tests/factories.py
+++ b/incident/tests/factories.py
@@ -114,6 +114,19 @@ class IncidentUpdateFactory(factory.django.DjangoModelFactory):
     body = None
 
 
+class IncidentUpdateWithBodyFactory(IncidentUpdateFactory):
+    body = wagtail_factories.StreamFieldFactory({
+        'rich_text': factory.SubFactory(RichTextTemplateBlockFactory),
+        'image': factory.SubFactory(
+            wagtail_factories.blocks.ImageChooserBlockFactory
+        ),
+        'raw_html': factory.SubFactory(RawHTMLBlockFactory),
+        'tweet': factory.SubFactory(TweetEmbedBlockFactory),
+        'blockquote': factory.SubFactory(RichTextBlockQuoteBlockFactory),
+        'video': factory.SubFactory(AlignedCaptionedEmbedBlockFactory),
+    })
+
+
 class IncidentLinkFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = IncidentPageLinks

--- a/incident/tests/factories.py
+++ b/incident/tests/factories.py
@@ -147,7 +147,7 @@ class IncidentPageFactory(wagtail_factories.PageFactory):
     title = factory.Sequence(lambda n: f'Incident {n}')
     date = factory.LazyFunction(datetime.date.today)
     city = None
-    state = None
+    state = factory.SubFactory(StateFactory)
     longitude = None
     latitude = None
     body = None

--- a/incident/tests/factories.py
+++ b/incident/tests/factories.py
@@ -33,6 +33,13 @@ from common.tests.factories import (
     CategoryPageFactory,
     CommonTagFactory,
     PersonPageFactory,
+    RichTextTemplateBlockFactory,
+    AlignedCaptionedImageBlockFactory,
+    RawHTMLBlockFactory,
+    TweetEmbedBlockFactory,
+    RichTextBlockQuoteBlockFactory,
+    PullQuoteBlockFactory,
+    AlignedCaptionedEmbedBlockFactory,
 )
 from common.tests.utils import StreamfieldProvider
 from menus.factories import MainMenuItemFactory
@@ -406,6 +413,21 @@ class IncidentPageFactory(wagtail_factories.PageFactory):
 
         if extracted:
             self.related_incidents.set(extracted)
+
+
+class IncidentPageWithBodyFactory(IncidentPageFactory):
+    body = wagtail_factories.StreamFieldFactory({
+        'rich_text': factory.SubFactory(RichTextTemplateBlockFactory),
+        'image': factory.SubFactory(
+            wagtail_factories.blocks.ImageChooserBlockFactory
+        ),
+        'aligned_image': factory.SubFactory(AlignedCaptionedImageBlockFactory),
+        'raw_html': factory.SubFactory(RawHTMLBlockFactory),
+        'tweet': factory.SubFactory(TweetEmbedBlockFactory),
+        'blockquote': factory.SubFactory(RichTextBlockQuoteBlockFactory),
+        'pull_quote': factory.SubFactory(PullQuoteBlockFactory),
+        'video': factory.SubFactory(AlignedCaptionedEmbedBlockFactory),
+    })
 
 
 class InexactDateIncidentPageFactory(IncidentPageFactory):

--- a/incident/tests/factories.py
+++ b/incident/tests/factories.py
@@ -30,6 +30,7 @@ from incident.models import (
     Venue,
 )
 from common.tests.factories import (
+    CustomImageFactory,
     CategoryPageFactory,
     CommonTagFactory,
     PersonPageFactory,
@@ -416,6 +417,7 @@ class IncidentPageFactory(wagtail_factories.PageFactory):
 
 
 class IncidentPageWithBodyFactory(IncidentPageFactory):
+    teaser_image = factory.SubFactory(CustomImageFactory)
     body = wagtail_factories.StreamFieldFactory({
         'rich_text': factory.SubFactory(RichTextTemplateBlockFactory),
         'image': factory.SubFactory(

--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -507,6 +507,9 @@ class TestSearchFiltering(TestCase):
                 'https://www.youtube.com/watch?v=DEa0xegtIEk',
             ),
             body__6__video__alignment=ALIGNMENT_CHOICES[1][0],
+            body__7__tweet__tweet=EmbedValue(
+                'https://completely-nonexistent-site.com/empty-url',
+            ),
         )
         IncidentUpdateWithBodyFactory(
             page=cls.incident1,
@@ -588,6 +591,10 @@ class TestSearchFiltering(TestCase):
     def test_body_tweet_embeds_are_searched(self):
         incidents = IncidentFilter({'search': 'restrict'}).get_queryset()
         self.assertQuerysetEqual(incidents, [self.incident1])
+
+    def test_unreachable_body_tweet_embeds_are_not_searched(self):
+        incidents = IncidentFilter({'search': 'nonexistent'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [])
 
     def test_body_blockquote_texts_are_searched(self):
         incidents = IncidentFilter({'search': 'pear'}).get_queryset()

--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -41,8 +41,9 @@ from incident.utils.incident_filter import IncidentFilter, ManyRelationValue, Se
 
 class TestFiltering(TestCase):
     """Incident filters"""
-    def setUp(self):
-        self.index = IncidentIndexPageFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.index = IncidentIndexPageFactory()
 
     def test_should_filter_by_search_text(self):
         """should filter by search text."""

--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -481,6 +481,7 @@ class TestSearchFiltering(TestCase):
             image_caption=RichText('Banana'),
             state__name='Lime',
             state__abbreviation='LI',
+            city='Pomelo',
             body__0__rich_text=RichText('Mango.'),
             body__1__aligned_image__caption=RichText('Apple'),
             body__1__aligned_image__alignment=ALIGNMENT_CHOICES[2][0],
@@ -554,6 +555,10 @@ class TestSearchFiltering(TestCase):
 
     def test_image_caption_is_searched(self):
         incidents = IncidentFilter({'search': 'banana'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
+
+    def test_city_is_searched(self):
+        incidents = IncidentFilter({'search': 'pomelo'}).get_queryset()
         self.assertQuerysetEqual(incidents, [self.incident1])
 
     def test_state_name_is_searched(self):

--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -27,6 +27,7 @@ from incident.tests.factories import (
     EquipmentBrokenFactory,
     IncidentPageFactory,
     IncidentPageWithBodyFactory,
+    IncidentUpdateWithBodyFactory,
     IncidentIndexPageFactory,
     IncidentUpdateFactory,
     InexactDateIncidentPageFactory,
@@ -507,7 +508,14 @@ class TestSearchFiltering(TestCase):
             ),
             body__6__video__alignment=ALIGNMENT_CHOICES[1][0],
         )
-
+        IncidentUpdateWithBodyFactory(
+            page=cls.incident1,
+            title='Coconut',
+            body__0__rich_text=RichText('Strawberry.'),
+        )
+        # Save required here to force update of index after
+        # IncidentUpdate created.
+        cls.incident1.save()
 
         cls.incident2 = IncidentPageWithBodyFactory(
             parent=cls.index,
@@ -608,6 +616,14 @@ class TestSearchFiltering(TestCase):
     def test_body_video_embed_alignments_are_not_searched(self):
         incidents = IncidentFilter({'search': 'right'}).get_queryset()
         self.assertQuerysetEqual(incidents, [])
+
+    def test_update_titles_are_searched(self):
+        incidents = IncidentFilter({'search': 'coconut'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
+
+    def test_update_bodies_are_searched(self):
+        incidents = IncidentFilter({'search': 'strawberry'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
 
 
 class TestAllFiltersAtOnce:

--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -475,6 +475,10 @@ class TestSearchFiltering(TestCase):
         cls.incident1 = IncidentPageWithBodyFactory(
             parent=cls.index,
             title='Fruit Incident',
+            introduction='Avocado',
+            teaser='Lemon',
+            teaser_image__attribution='Cherry',
+            image_caption=RichText('Banana'),
             state__name='Lime',
             state__abbreviation='LI',
             body__0__rich_text=RichText('Mango.'),
@@ -503,6 +507,55 @@ class TestSearchFiltering(TestCase):
             body__6__video__alignment=ALIGNMENT_CHOICES[1][0],
         )
 
+
+        cls.incident2 = IncidentPageWithBodyFactory(
+            parent=cls.index,
+            title='Vegetable Incident',
+            introduction='Celery',
+            teaser='Kale',
+            teaser_image__attribution='Radish',
+            image_caption=RichText('Spinach'),
+            state__name=' Radicchio',
+            state__abbreviation='RA',
+            body__0__rich_text=RichText('Cabbage.'),
+            body__1__aligned_image__caption=RichText('Lettuce'),
+            body__1__aligned_image__alignment=ALIGNMENT_CHOICES[2][0],
+            body__2__raw_html='<table><tr><td>Endive</td></tr></table>',
+            body__3__tweet__tweet=EmbedValue(
+                'https://twitter.com/FreedomofPress/status/1648023528459890688',
+                # Text of this tweet:
+                # Want the latest news on press freedom? Subscribe to
+                # our newsletter. It’s free. It’s easy to sign up. And
+                # you’ll be more informed than ever.
+            ),
+            body__4__blockquote__text=RichText('Corn'),
+            body__4__blockquote__source_text=RichText('Beet'),
+            body__4__blockquote__source_url='https://bell-pepper.com',
+            body__5__pull_quote__text='Chickpea',
+            body__6__video__caption=RichText('Leek'),
+            body__6__video__attribution='Shallot',
+            body__6__video__video=EmbedValue(
+                'https://www.youtube.com/watch?v=DEa0xegtIEk',
+            ),
+            body__6__video__alignment=ALIGNMENT_CHOICES[1][0],
+        )
+
+    def test_introduction_is_searched(self):
+        incidents = IncidentFilter({'search': 'avocado'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
+
+    def test_teaser_is_searched(self):
+        incidents = IncidentFilter({'search': 'lemon'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
+
+    def test_teaser_image_attribution_is_searched(self):
+        incidents = IncidentFilter({'search': 'cherry'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
+
+    def test_image_caption_is_searched(self):
+        incidents = IncidentFilter({'search': 'banana'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [self.incident1])
+
     def test_state_name_is_searched(self):
         incidents = IncidentFilter({'search': 'lime'}).get_queryset()
         self.assertQuerysetEqual(incidents, [self.incident1])
@@ -518,10 +571,6 @@ class TestSearchFiltering(TestCase):
     def test_body_image_alignments_are_not_searched(self):
         incidents = IncidentFilter({'search': 'full'}).get_queryset()
         self.assertQuerysetEqual(incidents, [])
-
-    def test_body_raw_html_is_searched(self):
-        incidents = IncidentFilter({'search': 'table'}).get_queryset()
-        self.assertQuerysetEqual(incidents, [self.incident1])
 
     def test_body_tweet_embeds_are_searched(self):
         incidents = IncidentFilter({'search': 'restrict'}).get_queryset()


### PR DESCRIPTION
This pull request:

1. Updates the incident `SearchFilter` to employ the `IndexEntry` model's pre-computed textsearch vectors for querying against. This improves performance since we are not having to calculate these ourselves. I did observe faster load times locally, but staging is the place to test this. I will note that the performance gains were dependent on the search term used, with the greatest gains coming when it was a term that appeared in many incidents.
2. Updates the IncidentPage model to tell wagtail to index more fields into its overall searchable data. These fields are:
  - Body blocks
    - Rich text  
    - Image captions
    - Image attributions
    - Text contained embedded tweetes
    - Blockquotes
    - Blockquote sources
    - Pull quotes
    - Video captions
    - Video attributions 
  - City
  - State name
  - Introduction
  - Teaser
  - Primary/teaser image caption
  - Primary/teaser image attribution
  - Updates
    - Title
    - Body body blocks (same as above, where applicable)

I think this tends to make the search more useful.

Refs #1573 