### PR TITLE
Fix CircleCI npm update command 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
 
       - run:
           name: Upgrade NPM to consistent version with dev environment
-          command: npm install --location=global npm@9.6.4
+          command: sudo npm install --location=global npm@9.6.4
 
       - run:
           name: Obtain misc resources


### PR DESCRIPTION
This PR adds `sudo` to the command to update npm, which is needed for running it globally.