### PR TITLE
Updates django to 3.2.19

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -197,9 +197,9 @@ decorator==5.1.1 \
     # via
     #   ipdb
     #   ipython
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements.txt
     #   django-anymail

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 bleach>=4.1.0
-Django>=3.2.18,<3.3
+Django>=3.2.19,<3.3
 django-anymail
 django-csp>=3.7
 django-modelcluster

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,9 +33,9 @@ charset-normalizer==2.0.12 \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
     --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
     # via requests
-django==3.2.18 \
-    --hash=sha256:08208dfe892eb64fff073ca743b3b952311104f939e7f6dae954fe72dcc533ba \
-    --hash=sha256:4d492d9024c7b3dfababf49f94511ab6a58e2c9c3c7207786f1ba4eb77750706
+django==3.2.19 \
+    --hash=sha256:031365bae96814da19c10706218c44dff3b654cc4de20a98bd2d29b9bde469f0 \
+    --hash=sha256:21cc991466245d659ab79cb01204f9515690f8dae00e5eabde307f14d24d4d7d
     # via
     #   -r requirements.in
     #   django-anymail


### PR DESCRIPTION
Fixes vulnerability: https://pyup.io/v/55264/2ff/

It's mostly to do with form validation with file uploads, so I don't think it's super urgent and can be deployed in our usual deploy days.
