### PR TITLE
CSV API Performance

### DIFF
--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -303,3 +303,4 @@ class CSVIncidentSerializer(VariableFieldSerializer):
     tags = serializers.CharField(source='tag_summary')
     categories = serializers.CharField(source='category_summary')
     state = serializers.CharField(source='state_abbreviation')
+    links = serializers.CharField(source='link_summary')

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -304,3 +304,5 @@ class CSVIncidentSerializer(VariableFieldSerializer):
     categories = serializers.CharField(source='category_summary')
     state = serializers.CharField(source='state_abbreviation')
     links = serializers.CharField(source='link_summary')
+    equipment_broken = serializers.CharField(source='equipment_broken_summary')
+    equipment_seized = serializers.CharField(source='equipment_seized_summary')

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -258,11 +258,43 @@ class CSVIncidentSerializer(VariableFieldSerializer):
     teaser = serializers.CharField()
     primary_video = serializers.URLField()
     image_caption = serializers.CharField()
+    release_date = serializers.DateField()
+    detention_date = serializers.DateField()
+    unnecessary_use_of_force = serializers.BooleanField()
+    case_number = serializers.CharField()
+    case_type = serializers.CharField()
+    is_search_warrant_obtained = serializers.BooleanField()
+    border_point = serializers.CharField()
+    denial_of_entry = serializers.BooleanField()
+    stopped_previously = serializers.BooleanField()
+    charged_under_espionage_act = serializers.BooleanField()
+    name_of_business = serializers.CharField()
 
     # Choice fields -- data is on IncidentPage but choice text
     # requires an annotation
     status_of_seized_equipment = serializers.CharField(
         source='status_of_seized_equipment_display'
+    )
+    arrest_status = serializers.CharField(source='arrest_status_display')
+    actor = serializers.CharField(source='actor_display')
+    target_us_citizenship_status = serializers.CharField(
+        source='target_us_citizenship_status_display',
+    )
+    did_authorities_ask_for_device_access = serializers.CharField(
+        source='did_authorities_ask_for_device_access_display',
+    )
+    did_authorities_ask_about_work = serializers.CharField(
+        source='did_authorities_ask_about_work_display',
+    )
+    assailant = serializers.CharField(source='assailant_display')
+    was_journalist_targeted = serializers.CharField(
+        source='was_journalist_targeted_display',
+    )
+    third_party_business = serializers.CharField(
+        source='third_party_business_display',
+    )
+    status_of_prior_restraint = serializers.CharField(
+        source='status_of_prior_restraint_display',
     )
 
     # Computed fields requiring an annotation

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -302,3 +302,4 @@ class CSVIncidentSerializer(VariableFieldSerializer):
     url = serializers.CharField()
     tags = serializers.CharField(source='tag_summary')
     categories = serializers.CharField(source='category_summary')
+    state = serializers.CharField(source='state_abbreviation')

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -247,8 +247,26 @@ class FlatIncidentSerializer(BaseIncidentSerializer):
 
 
 class CSVIncidentSerializer(VariableFieldSerializer):
+    # Ordinary fields directly on IncidentPage/Page
     title = serializers.CharField()
     date = serializers.DateField()
+    exact_date_unknown = serializers.BooleanField()
+    city = serializers.CharField()
+    longitude = serializers.FloatField()
+    latitude = serializers.FloatField()
+    introduction = serializers.CharField()
+    teaser = serializers.CharField()
+    primary_video = serializers.URLField()
+    image_caption = serializers.CharField()
+
+    # Choice fields -- data is on IncidentPage but choice text
+    # requires an annotation
+    status_of_seized_equipment = serializers.CharField(
+        source='status_of_seized_equipment_display'
+    )
+
+    # Computed fields requiring an annotation
+    arresting_authority = serializers.CharField(source='arresting_authority_title')
     url = serializers.CharField()
     tags = serializers.CharField(source='tag_summary')
     categories = serializers.CharField(source='category_summary')

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -99,7 +99,27 @@ class CategorySerializer(serializers.Serializer):
             return obj.get_full_url()
 
 
-class BaseIncidentSerializer(serializers.Serializer):
+class VariableFieldSerializer(serializers.Serializer):
+    """A serializer that takes a set of field names its context with
+    the key `requested_fields` that controls what fields should be
+    returned.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        requested_fields = kwargs.get('context', {}).get('requested_fields', set())
+
+        super().__init__(*args, **kwargs)
+
+        if requested_fields:
+            # Drop any fields that are not specified in
+            # `requested_fields`.
+            existing = set(self.fields)
+            for field_name in existing - requested_fields:
+                self.fields.pop(field_name)
+
+
+class BaseIncidentSerializer(VariableFieldSerializer):
     title = serializers.CharField()
     url = serializers.SerializerMethodField()
     first_published_at = serializers.DateTimeField()
@@ -150,21 +170,6 @@ class BaseIncidentSerializer(serializers.Serializer):
     third_party_business = serializers.CharField(source='get_third_party_business_display')
     legal_order_type = serializers.CharField(source='get_legal_order_type_display')
     status_of_prior_restraint = serializers.CharField(source='get_status_of_prior_restraint_display')
-
-    def __init__(self, *args, **kwargs):
-        request = kwargs.get('context', {}).get('request')
-        str_fields = request.GET.get('fields', '') if request else None
-        fields = str_fields.split(',') if str_fields else None
-
-        super().__init__(*args, **kwargs)
-
-        if fields is not None:
-            # Drop any fields that are not specified in the `fields`
-            # argument.
-            allowed = set(fields)
-            existing = set(self.fields)
-            for field_name in existing - allowed:
-                self.fields.pop(field_name)
 
     @extend_schema_field(OpenApiTypes.URI)
     def get_url(self, obj):
@@ -239,3 +244,11 @@ class FlatIncidentSerializer(BaseIncidentSerializer):
     subpoena_statuses = FlatListField(
         child=ChoiceField(choices.SUBPOENA_STATUS)
     )
+
+
+class CSVIncidentSerializer(VariableFieldSerializer):
+    title = serializers.CharField()
+    date = serializers.DateField()
+    url = serializers.CharField()
+    tags = serializers.CharField(source='tag_summary')
+    categories = serializers.CharField(source='category_summary')

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -99,6 +99,9 @@ class PerformantCSVTestCase(TestCase):
             third_party_business=choices.ThirdPartyBusiness.TRAVEL,
             status_of_prior_restraint=choices.STATUS_OF_PRIOR_RESTRAINT[1][0],
         )
+        IncidentLinkFactory.create_batch(3, page=cls.incident)
+        IncidentLinkFactory(page=cls.incident, publication='Galactic Express')
+
         IncidentPageFactory()
 
     def setUp(self):
@@ -119,6 +122,7 @@ class PerformantCSVTestCase(TestCase):
             'third_party_business',
             'status_of_prior_restraint',
             'state',
+            'links',
         ]
         url = reverse(
             'incidentpage-list',
@@ -150,6 +154,12 @@ class PerformantCSVTestCase(TestCase):
         self.assertEqual(
             self.result['state'],
             self.incident.state.abbreviation,
+        )
+
+    def test_links_are_correct(self):
+        self.assertEqual(
+            self.result['links'],
+            ', '.join(str(link) for link in self.incident.links.all())
         )
 
     def test_tags_are_correct(self):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -118,6 +118,7 @@ class PerformantCSVTestCase(TestCase):
             'was_journalist_targeted',
             'third_party_business',
             'status_of_prior_restraint',
+            'state',
         ]
         url = reverse(
             'incidentpage-list',
@@ -143,6 +144,12 @@ class PerformantCSVTestCase(TestCase):
             self.result['url'].endswith(
                 f'/{self.incident_index.slug}/{self.incident.slug}/'
             ),
+        )
+
+    def test_state_is_correct(self):
+        self.assertEqual(
+            self.result['state'],
+            self.incident.state.abbreviation,
         )
 
     def test_tags_are_correct(self):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -128,6 +128,33 @@ class PerformantCSVTestCase(TestCase):
             ),
         )
 
+    def test_tags_are_correct(self):
+        self.assertEqual(
+            self.result['tags'],
+            ', '.join(tag.title for tag in self.incident.tags.all())
+        )
+
+    def test_categories_are_correct(self):
+        self.assertEqual(
+            self.result['categories'],
+            ', '.join(
+                categorization.category.title for categorization in self.incident.categories.all()
+            )
+        )
+
+    def test_choice_field_is_correct(self):
+        self.assertEqual(
+            self.result['status_of_seized_equipment'],
+            self.incident.get_status_of_seized_equipment_display(),
+        )
+
+    def test_arresting_authority_is_correct(self):
+        self.assertEqual(
+            self.result['arresting_authority'],
+            'Police Squad!',
+        )
+
+
 class HomePageCSVTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -90,6 +90,14 @@ class PerformantCSVTestCase(TestCase):
             state=cls.state,
             status_of_seized_equipment=choices.STATUS_OF_SEIZED_EQUIPMENT[0][0],
             arresting_authority__title='Police Squad!',
+            actor=choices.ACTORS[0][0],
+            target_us_citizenship_status=choices.CITIZENSHIP_STATUS_CHOICES[0][0],
+            did_authorities_ask_for_device_access=choices.MAYBE_BOOLEAN[0][0],
+            did_authorities_ask_about_work=choices.MAYBE_BOOLEAN[0][0],
+            assailant=choices.ACTORS[0][0],
+            was_journalist_targeted=choices.MAYBE_BOOLEAN[1][0],
+            third_party_business=choices.ThirdPartyBusiness.TRAVEL,
+            status_of_prior_restraint=choices.STATUS_OF_PRIOR_RESTRAINT[1][0],
         )
         IncidentPageFactory()
 
@@ -100,7 +108,16 @@ class PerformantCSVTestCase(TestCase):
             'url',
             'categories',
             'status_of_seized_equipment',
+            'arrest_status',
             'arresting_authority',
+            'actor',
+            'target_us_citizenship_status',
+            'did_authorities_ask_for_device_access',
+            'did_authorities_ask_about_work',
+            'assailant',
+            'was_journalist_targeted',
+            'third_party_business',
+            'status_of_prior_restraint',
         ]
         url = reverse(
             'incidentpage-list',
@@ -146,6 +163,54 @@ class PerformantCSVTestCase(TestCase):
         self.assertEqual(
             self.result['status_of_seized_equipment'],
             self.incident.get_status_of_seized_equipment_display(),
+        )
+
+    def test_arrest_status_is_correct(self):
+        self.assertEqual(
+            self.result['arrest_status'],
+            self.incident.get_arrest_status_display(),
+        )
+
+    def test_assailant_is_correct(self):
+        self.assertEqual(
+            self.result['assailant'],
+            self.incident.get_assailant_display(),
+        )
+
+    def test_authorities_device_access_is_correct(self):
+        self.assertEqual(
+            self.result['did_authorities_ask_for_device_access'],
+            self.incident.get_did_authorities_ask_for_device_access_display(),
+        )
+
+    def test_authorities_work_access_is_correct(self):
+        self.assertEqual(
+            self.result['did_authorities_ask_about_work'],
+            self.incident.get_did_authorities_ask_about_work_display(),
+        )
+
+    def test_actor_is_correct(self):
+        self.assertEqual(
+            self.result['actor'],
+            self.incident.get_actor_display(),
+        )
+
+    def test_was_journalist_targeted_is_correct(self):
+        self.assertEqual(
+            self.result['was_journalist_targeted'],
+            self.incident.get_was_journalist_targeted_display(),
+        )
+
+    def test_third_party_business_is_correct(self):
+        self.assertEqual(
+            self.result['third_party_business'],
+            self.incident.get_third_party_business_display(),
+        )
+
+    def test_status_of_prior_restraint_is_correct(self):
+        self.assertEqual(
+            self.result['status_of_prior_restraint'],
+            self.incident.get_status_of_prior_restraint_display(),
         )
 
     def test_arresting_authority_is_correct(self):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -18,6 +18,7 @@ from incident.tests.factories import (
     IncidentUpdateFactory,
     IncidentLinkFactory,
     StateFactory,
+    EquipmentSeizedFactory,
 )
 
 
@@ -98,7 +99,9 @@ class PerformantCSVTestCase(TestCase):
             was_journalist_targeted=choices.MAYBE_BOOLEAN[1][0],
             third_party_business=choices.ThirdPartyBusiness.TRAVEL,
             status_of_prior_restraint=choices.STATUS_OF_PRIOR_RESTRAINT[1][0],
+            equipment_damage=True,
         )
+        EquipmentSeizedFactory.create_batch(3, incident=cls.incident)
         IncidentLinkFactory.create_batch(3, page=cls.incident)
         IncidentLinkFactory(page=cls.incident, publication='Galactic Express')
 
@@ -123,6 +126,8 @@ class PerformantCSVTestCase(TestCase):
             'status_of_prior_restraint',
             'state',
             'links',
+            'equipment_broken',
+            'equipment_seized',
         ]
         url = reverse(
             'incidentpage-list',
@@ -160,6 +165,18 @@ class PerformantCSVTestCase(TestCase):
         self.assertEqual(
             self.result['links'],
             ', '.join(str(link) for link in self.incident.links.all())
+        )
+
+    def test_equipment_broken_is_correct(self):
+        self.assertEqual(
+            self.result['equipment_broken'],
+            ', '.join(e.summary for e in self.incident.equipment_broken.all())
+        )
+
+    def test_equipment_seized_is_correct(self):
+        self.assertEqual(
+            self.result['equipment_seized'],
+            ', '.join(e.summary for e in self.incident.equipment_seized.all())
         )
 
     def test_tags_are_correct(self):

--- a/incident/api/tests/test_csv.py
+++ b/incident/api/tests/test_csv.py
@@ -1,4 +1,5 @@
 import csv
+from urllib import parse
 
 from django.test import TestCase
 from django.urls import reverse
@@ -67,6 +68,65 @@ class MinimalIncidentCSVTestCase(TestCase):
         result = dict(zip(headers, next(reader)))
         self.assertEqual(result['state'], '')
 
+
+class PerformantCSVTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.get(is_default_site=True)
+        root_page = site.root_page
+        cls.incident_index = IncidentIndexPageFactory.build(
+            slug='incident-index',
+        )
+        root_page.add_child(instance=cls.incident_index)
+
+        cls.state = StateFactory(abbreviation='NM')
+        cls.cats = CategoryPageFactory.create_batch(3, parent=root_page)
+        cls.tags = CommonTagFactory.create_batch(3)
+        cls.incident = IncidentPageFactory(
+            arrest=True,
+            parent=cls.incident_index,
+            categories=cls.cats,
+            tags=cls.tags,
+            state=cls.state,
+            status_of_seized_equipment=choices.STATUS_OF_SEIZED_EQUIPMENT[0][0],
+            arresting_authority__title='Police Squad!',
+        )
+        IncidentPageFactory()
+
+    def setUp(self):
+        fields = [
+            'title',
+            'tags',
+            'url',
+            'categories',
+            'status_of_seized_equipment',
+            'arresting_authority',
+        ]
+        url = reverse(
+            'incidentpage-list',
+            kwargs={'version': 'edge'},
+        ) + '?' + parse.urlencode({'fields': ','.join(fields)})
+
+        with self.assertNumQueries(1):
+            self.response = self.client.get(
+                url,
+                HTTP_ACCEPT='text/csv',
+            )
+        content_lines = self.response.content.splitlines()
+        reader = csv.reader(line.decode('utf-8') for line in content_lines)
+
+        self.headers = next(reader)
+        self.result = dict(zip(self.headers, next(reader)))
+
+    def test_requests_are_successful(self):
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_url_has_correct_path(self):
+        self.assertTrue(
+            self.result['url'].endswith(
+                f'/{self.incident_index.slug}/{self.incident.slug}/'
+            ),
+        )
 
 class HomePageCSVTestCase(TestCase):
     @classmethod

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -178,6 +178,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
             annotated_fields = {
                 'categories': 'category_summary',
                 'tags': 'tag_summary',
+                'links': 'link_summary',
                 'arresting_authority': 'arresting_authority_title',
                 'status_of_seized_equipment': 'status_of_seized_equipment_display',
                 'arrest_status': 'arrest_status_display',

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -190,6 +190,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
                 'third_party_business': 'third_party_business_display',
                 'status_of_prior_restraint': 'status_of_prior_restraint_display',
                 'url': 'url',
+                'state': 'state_abbreviation',
             }
             result_fields = []
             annotations = []

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -134,8 +134,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
     def requested_fields(self):
         if fields := self.request.GET.get('fields'):
             return set(map(str.strip, fields.split(',')))
-        else:
-            return set()
+        return set()
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -146,8 +145,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
     def can_apply_csv_serializer(self):
         if self.requested_fields:
             return self.requested_fields <= CSVIncidentSerializer().fields.keys()
-        else:
-            return False
+        return False
 
     def get_renderer_context(self):
         context = super().get_renderer_context()
@@ -166,8 +164,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
             # that.
             if self.can_apply_csv_serializer:
                 return CSVIncidentSerializer
-            else:
-                return FlatIncidentSerializer
+            return FlatIncidentSerializer
         return super().get_serializer_class()
 
     def paginate_queryset(self, queryset):

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -179,6 +179,8 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
                 'categories': 'category_summary',
                 'tags': 'tag_summary',
                 'links': 'link_summary',
+                'equipment_broken': 'equipment_broken_summary',
+                'equipment_seized': 'equipment_seized_summary',
                 'arresting_authority': 'arresting_authority_title',
                 'status_of_seized_equipment': 'status_of_seized_equipment_display',
                 'arrest_status': 'arrest_status_display',

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -180,6 +180,15 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
                 'tags': 'tag_summary',
                 'arresting_authority': 'arresting_authority_title',
                 'status_of_seized_equipment': 'status_of_seized_equipment_display',
+                'arrest_status': 'arrest_status_display',
+                'actor': 'actor_display',
+                'target_us_citizenship_status': 'target_us_citizenship_status_display',
+                'did_authorities_ask_for_device_access': 'did_authorities_ask_for_device_access_display',
+                'did_authorities_ask_about_work': 'did_authorities_ask_about_work_display',
+                'assailant': 'assailant_display',
+                'was_journalist_targeted': 'was_journalist_targeted_display',
+                'third_party_business': 'third_party_business_display',
+                'status_of_prior_restraint': 'status_of_prior_restraint_display',
                 'url': 'url',
             }
             result_fields = []

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -180,6 +180,8 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
             annotated_fields = {
                 'categories': 'category_summary',
                 'tags': 'tag_summary',
+                'arresting_authority': 'arresting_authority_title',
+                'status_of_seized_equipment': 'status_of_seized_equipment_display',
                 'url': 'url',
             }
             result_fields = []

--- a/incident/api/views.py
+++ b/incident/api/views.py
@@ -176,6 +176,7 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
         return super().paginate_queryset(queryset)
 
     def get_queryset(self):
+        incident_filter = IncidentFilter(self.request.GET)
         if self.csv_format_is_requested and self.can_apply_csv_serializer:
             annotated_fields = {
                 'categories': 'category_summary',
@@ -198,11 +199,10 @@ class IncidentViewSet(viewsets.ReadOnlyModelViewSet):
                 v for k, v in annotated_fields.items()
                 if k in requested_fields
             }
-            return models.IncidentPage.objects.live()\
+            return incident_filter.get_queryset()\
                 .for_csv(annotations, self.request)\
                 .values(*result_fields)
 
-        incident_filter = IncidentFilter(self.request.GET)
         incidents = incident_filter.get_queryset()
 
         return incidents.with_most_recent_update().with_public_associations()

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -115,6 +115,33 @@ class IncidentQuerySet(PageQuerySet):
                 ).values('tag_summary'),
                 output_field=models.CharField()
             ),
+            'link_summary': Subquery(
+                IncidentPage.objects.only('links').annotate(
+                    link_summary=StringAgg(
+                        expression=Concat(
+                            'links__title',
+                            Value(' ('),
+                            'links__url',
+                            Value(')'),
+                            Case(
+                                When(
+                                    links__publication__isnull=True,
+                                    then=Value(''),
+                                ),
+                                default=Concat(
+                                    Value(' via '),
+                                    'links__publication',
+                                ),
+                            ),
+                            output_field=models.CharField(),
+                        ),
+                        delimiter=', ',
+                    )
+                ).filter(
+                    pk=OuterRef('pk')
+                ).values('link_summary'),
+                output_field=models.CharField()
+            ),
             'category_summary': Subquery(
                 IncidentPage.objects.only('categories').annotate(
                     category_summary=StringAgg(

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -144,7 +144,34 @@ class IncidentQuerySet(PageQuerySet):
             'arresting_authority_title': models.F('arresting_authority__title'),
             'status_of_seized_equipment_display': annotation_for_choices_display(
                 'status_of_seized_equipment', choices.STATUS_OF_SEIZED_EQUIPMENT
-            )
+            ),
+            'arrest_status_display': annotation_for_choices_display(
+                'arrest_status', choices.ARREST_STATUS,
+            ),
+            'actor_display': annotation_for_choices_display(
+                'actor', choices.ACTORS,
+            ),
+            'target_us_citizenship_status_display': annotation_for_choices_display(
+                'target_us_citizenship_status', choices.CITIZENSHIP_STATUS_CHOICES,
+            ),
+            'did_authorities_ask_for_device_access_display': annotation_for_choices_display(
+                'did_authorities_ask_for_device_access', choices.MAYBE_BOOLEAN,
+            ),
+            'did_authorities_ask_about_work_display': annotation_for_choices_display(
+                'did_authorities_ask_about_work', choices.MAYBE_BOOLEAN,
+            ),
+            'assailant_display': annotation_for_choices_display(
+                'assailant', choices.ACTORS,
+            ),
+            'was_journalist_targeted_display': annotation_for_choices_display(
+                'was_journalist_targeted', choices.MAYBE_BOOLEAN,
+            ),
+            'third_party_business_display': annotation_for_choices_display(
+                'third_party_business', choices.ThirdPartyBusiness.choices,
+            ),
+            'status_of_prior_restraint_display': annotation_for_choices_display(
+                'status_of_prior_restraint', choices.STATUS_OF_PRIOR_RESTRAINT,
+            ),
         }
         annotations_to_apply = {
             label: expression for label, expression in available_annotations.items()

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -115,6 +115,36 @@ class IncidentQuerySet(PageQuerySet):
                 ).values('tag_summary'),
                 output_field=models.CharField()
             ),
+            'equipment_broken_summary': Subquery(
+                IncidentPage.objects.only('equipment_broken').annotate(
+                    equipment_broken_summary=StringAgg(
+                        expression=Concat(
+                            'equipment_broken__equipment__name',
+                            Value(': count of '),
+                            'equipment_broken__quantity',
+                            output_field=models.CharField(),
+                        ),
+                        delimiter=', '
+                    ),
+                ).filter(
+                    pk=OuterRef('pk'),
+                ).values('equipment_broken_summary'),
+            ),
+            'equipment_seized_summary': Subquery(
+                IncidentPage.objects.only('equipment_seized').annotate(
+                    equipment_seized_summary=StringAgg(
+                        expression=Concat(
+                            'equipment_seized__equipment__name',
+                            Value(': count of '),
+                            'equipment_seized__quantity',
+                            output_field=models.CharField(),
+                        ),
+                        delimiter=', '
+                    ),
+                ).filter(
+                    pk=OuterRef('pk'),
+                ).values('equipment_seized_summary'),
+            ),
             'link_summary': Subquery(
                 IncidentPage.objects.only('links').annotate(
                     link_summary=StringAgg(

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -141,6 +141,7 @@ class IncidentQuerySet(PageQuerySet):
                 Value('/'),
                 output_field=models.CharField()
             ),
+            'state_abbreviation': models.F('state__abbreviation'),
             'arresting_authority_title': models.F('arresting_authority__title'),
             'status_of_seized_equipment_display': annotation_for_choices_display(
                 'status_of_seized_equipment', choices.STATUS_OF_SEIZED_EQUIPMENT

--- a/incident/utils/db.py
+++ b/incident/utils/db.py
@@ -1,4 +1,4 @@
-from django.db.models import Func, DateField
+from django.db.models import Func, DateField, CharField
 from django.contrib.postgres import fields
 
 
@@ -23,3 +23,9 @@ class CurrentDate(Func):
     """
     template = 'CURRENT_DATE'
     output_field = DateField()
+
+
+class Left(Func):
+    function = "LEFT"
+    arity = 2
+    output_field = CharField()


### PR DESCRIPTION
This pull request tries to improve the performance of the CSV-formatted API requests. It was inspired by the fact that we are using this API for our data visualizations, and these can be quite slow in production. For example, here's a page with one: https://pressfreedomtracker.us/blog/celebrating-5-years-since-launch-of-the-us-press-freedom-tracker/

It makes a request to the endpoint: https://pressfreedomtracker.us/api/edge/incidents/?format=csv&limit=99999&fields=date,title,url,categories

Of note:
* CSV formatted (I have learned the CSV format is _preferred_ over the JSON format for data visualizations, which was new info for me).
* `limit=99999` implies no pagination, though this is the default behavior for CSV requests
* Only 4 specific fields mentioned: date, title, url, categories
* No filtering

With this in mind, in this PR I have modified how our incident API view works so that (1) the existing functionality is preserved, but (2) in cases where it's possible, we give a faster response time. The insight I'm applying here is that it is less Django Rest Framework (DRF)'s serializer that's slowing us down (we are already using its most performant type of serializer), but Django's serializing of database rows into model instances. So we can improve performance by never doing that, using SQL expressions to generate the data we need, and then calling [`.values()` on our QuerySet](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#values) to avoid Django's models altogether. 

I've done this by creating a parallel set of code that takes effect for a user's requests to the incident API if it meets all of these requirements:
1. The user has asked for CSV format
2. The user has asked for a subset of fields I've enabled, which are mostly either ones that are "simple" values that don't require any type of processing, or ones I've written SQL expressions for that processing. 
3. The user has not requested any filters

These limitations are mostly there in the interest of expediency: I want to get this out there and I don't want to break anything. For each data field, I have to write some code deriving it as a database expression. Requirement 1 allows me to focus on one output format only. Requirement 2 limits how much code has to be written right now, especially when we have a lot of fields and I don't know which ones to prioritize (ideally the ones used in data visualizations across the site, or regularly requested by other API users). Requirement 3 is because I'm not exactly sure how the filters will interact with this method. I want to enable filters eventually, but I'm imagining it will initially have to be only a subset of ones supported (kind of like the home page CSV endpoint has support for date filters only).

All this is to say:

Under this PR, compared to develop, I'm seeing much faster times for requests like:

```
$ time curl -s "http://localhost:8000/api/edge/incidents/?format=csv&limit=9999&fields=title,date,url,categories"
```

(where I have ~1800 incidents in my local db).

And if there are any specific fields or filters we'd like to add before merging this PR, please let me know.