### PR TITLE
Add command to update blog page types by title

### DIFF
--- a/blog/management/commands/convert_blog_type.py
+++ b/blog/management/commands/convert_blog_type.py
@@ -1,0 +1,50 @@
+from django.core.management.base import BaseCommand
+
+from blog.models import BlogPage
+
+
+class Command(BaseCommand):
+    help = 'Bulk update blog pages to use another template'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--commit',
+            action='store_true',
+            help='Commit changes to the database',
+        )
+
+        parser.add_argument(
+            'select',
+            metavar='REGEX',
+            help='Regular expression to select page titles to convert'
+        )
+
+        parser.add_argument(
+            'template_type',
+            choices=[choice[0] for choice in BlogPage.BLOG_TEMPLATE_CHOICES],
+            help='Template type to convert pages to',
+        )
+
+    def handle(self, *args, **options):
+        select_regex = options['select']
+        pages = BlogPage.objects.filter(title__regex=select_regex)
+        selected_count = pages.count()
+        self.stdout.write(
+            f'Blog page titles matching {select_regex!r}: {selected_count}'
+        )
+
+        if selected_count < 1:
+            return
+        longest_title = max(len(page.title) for page in pages)
+        top_row = f'{"id":^4} | {"title":^{longest_title}} | current type'
+
+        self.stdout.write(top_row)
+        self.stdout.write('-' * len(top_row))
+        for i, page in enumerate(pages):
+            self.stdout.write(f'{page.pk:>4} | {page.title:<{longest_title}} | {page.blog_type}')
+            page.blog_type = options['template_type']
+        self.stdout.write('\n')
+
+        if options['commit']:
+            BlogPage.objects.bulk_update(pages, ['blog_type'])
+            self.stdout.write('Pages updated')

--- a/blog/tests/test_commands.py
+++ b/blog/tests/test_commands.py
@@ -1,0 +1,58 @@
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from wagtail.models import Site
+
+from ..models import BlogPage
+from .factories import (
+    BlogIndexPageFactory,
+    BlogPageFactory
+)
+
+
+class ConvertBlogTypeTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        s = Site.objects.get(is_default_site=True)
+
+        index = BlogIndexPageFactory(parent=s.root_page)
+        cls.blog_post = BlogPageFactory(
+            title='Blog Post 1',
+            blog_type=BlogPage.DEFAULT,
+            parent=index,
+        )
+        cls.newsletter_post = BlogPageFactory(
+            title='Newsletter 1',
+            blog_type=BlogPage.DEFAULT,
+            parent=index,
+        )
+        cls.special_post = BlogPageFactory(
+            title='Something very special',
+            blog_type=BlogPage.SPECIAL,
+            parent=index,
+        )
+
+    def test_output_if_no_pages_match_selection(self):
+        out = StringIO()
+        call_command('convert_blog_type', '^XYZ$', 'newsletter', stdout=out)
+        expected_output = "Blog page titles matching '^XYZ$': 0"
+        self.assertIn(expected_output, out.getvalue())
+
+    def test_output_if_pages_match_selection(self):
+        out = StringIO()
+        call_command('convert_blog_type', '^Blog', 'newsletter', stdout=out)
+
+        self.assertIn(self.blog_post.title, out.getvalue())
+
+    def test_updates_blog_page_type_when_commit_option_given(self):
+        out = StringIO()
+        call_command('convert_blog_type', '^News', 'newsletter', commit=True, stdout=out)
+
+        self.newsletter_post.refresh_from_db()
+        self.blog_post.refresh_from_db()
+        self.special_post.refresh_from_db()
+
+        self.assertEqual(self.newsletter_post.blog_type, BlogPage.NEWSLETTER)
+        self.assertEqual(self.special_post.blog_type, BlogPage.SPECIAL)
+        self.assertEqual(self.blog_post.blog_type, BlogPage.DEFAULT)


### PR DESCRIPTION
Fixes #1637

Adds a command `convert_blog_type` that takes two arguments: a regular expression and a blog page type. The command finds all blog pages whose titles match the regular expression and prints them, along with their current page type. If the command is run with `--commit`, then it updates all those pages to the given type. This, I hope, is explained with the `--help` flag. 

This command is a little more flexible than asked for by the issue, but I thought it might be helpful to have multiple options for converting pages, in case there's not a single, obvious way to select all blog pages (or if we need to bulk-convert some pages back).