### PR TITLE
Update dev and prod docker images to use latest python 3.9 container

### DIFF
--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 as of 2021-07-22
-FROM python:3.9-slim-buster@sha256:4e69709296a8ae67d97ba072e7f4973125939f3a13cd276c1e8ca1f7b7d49aa3
+# sha256 for python:3.9.16-slim-buster on linux/amd64 as of 2023-06-01
+FROM python:3.9-slim-buster@sha256:6199d5aaae3f33f415501ec9737fad89c147bcc0ce47f2e62d8c59cb4f7f8243
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -17,8 +17,8 @@ RUN npm install --global gulp-cli
 COPY ./ /src-files
 RUN cd /src-files && ( npm install && npm run build )
 
-# sha256 as of 2020-03-23 for 3.9-slim-buster
-FROM python@sha256:aab965875430293ae0f7fe8a369947e598eb568dca0cac2f934d87737101df5b
+# sha256 for python:3.9.16-slim-buster on linux/amd64 as of 2023-06-01
+FROM python:3.9-slim-buster@sha256:6199d5aaae3f33f415501ec9737fad89c147bcc0ce47f2e62d8c59cb4f7f8243
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="pressfreedomtracker.us"
 


### PR DESCRIPTION
Part of https://github.com/freedomofpress/fpf-www-projects/issues/340