### PR TITLE
Blog index special post cards

### DIFF
--- a/blog/choices.py
+++ b/blog/choices.py
@@ -1,0 +1,7 @@
+from django.db.models import TextChoices
+
+
+class BlogTemplateType(TextChoices):
+    DEFAULT = 'default', 'Default Blog'
+    NEWSLETTER = 'newsletter', 'Newsletter'
+    SPECIAL = 'special', 'Special Blog'

--- a/blog/management/commands/convert_blog_type.py
+++ b/blog/management/commands/convert_blog_type.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from blog.models import BlogPage
+from blog.choices import BlogTemplateType
 
 
 class Command(BaseCommand):
@@ -21,7 +22,7 @@ class Command(BaseCommand):
 
         parser.add_argument(
             'template_type',
-            choices=[choice[0] for choice in BlogPage.BLOG_TEMPLATE_CHOICES],
+            choices=[choice[0] for choice in BlogTemplateType.choices],
             help='Template type to convert pages to',
         )
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -19,6 +19,7 @@ from wagtail.contrib.routable_page.models import RoutablePageMixin, path
 
 from common.utils import DEFAULT_PAGE_KEY, paginate
 
+from blog.choices import BlogTemplateType
 from blog.feeds import BlogIndexPageFeed
 from blog.utils import BlogFilter
 from statistics.blocks import StatisticsBlock
@@ -165,23 +166,14 @@ class BlogIndexPageFeature(Orderable):
 
 
 class BlogPage(MetadataPageMixin, MediaPageMixin, Page):
-    DEFAULT = 'default'
-    NEWSLETTER = 'newsletter'
-    SPECIAL = 'special'
-    BLOG_TEMPLATE_CHOICES = (
-        (DEFAULT, 'Default Blog'),
-        (NEWSLETTER, 'Newsletter'),
-        (SPECIAL, 'Special Blog'),
-    )
-
     publication_datetime = models.DateTimeField(
         help_text='Past or future date of publication'
     )
 
     blog_type = models.CharField(
         max_length=20,
-        choices=BLOG_TEMPLATE_CHOICES,
-        default=DEFAULT,
+        choices=BlogTemplateType.choices,
+        default=BlogTemplateType.DEFAULT,
         help_text='Select template used to display this post.',
     )
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -107,6 +107,12 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, MediaPageMixin, Page):
             orphans=5
         )
 
+        context['type_choices'] = [
+            (BlogTemplateType.DEFAULT, 'Articles'),
+            (BlogTemplateType.SPECIAL, 'Special Sections'),
+            (BlogTemplateType.NEWSLETTER, 'Newsletters'),
+        ]
+        context['post_filters'] = post_filters
         context['entries_page'] = entries
         context['paginator'] = paginator
 

--- a/blog/templates/blog/_blog_list.html
+++ b/blog/templates/blog/_blog_list.html
@@ -1,30 +1,32 @@
 {% load wagtailcore_tags common_tags %}
-
 <section class="blog-list {% if type %}blog-list--{{ type }}{% endif %}">
+	{% if not post_filters.author and not post_filters.organization %}
+		<div class="button-row">
+			<a class="btn btn-secondary button-row--item{% if not post_filters.blog_type %} button-row--active{% endif %}" href="?{% query_transform request type=None %}"><span>All posts</span></a>
+			{% for value, label in type_choices %}
+				<a class="btn btn-secondary button-row--item{% if value == post_filters.blog_type %} button-row--active{% endif %}" href="?{% query_transform request type=value %}"><span>{{ label }}</span></a>
+			{% endfor %}
+		</div>
+	{% endif %}
+
 	<h2 class="heading-regular">{{ heading | safe }}</h2>
 
 	<ol class="blog-list__posts {% if type %}blog-list__posts--{{ type }}{% endif %} {% if ajax_load and blogs.has_other_pages %}js-article-loading-parent{% endif %}">
 		{% for blog in blogs %}
 			<li
 				class="blog-list__item
-					{% if type %}blog-list__item--{{ type }}{% endif %}
+					{% if blog.blog_type == 'special' %}blog-list__item--special{% endif %}
 					{% if ajax_load %}js-article-loading-item{% endif %}"
 			>
-				{% include 'blog/_blog_card.html' with post=blog size=card_size|default:'small' photo=blog.teaser_graphic only %}
+				{% if blog.blog_type == 'special' %}
+					{% include 'blog/_special_blog_card.html' with post=blog only %}
+				{% else %}
+					{% include 'blog/_blog_card.html' with post=blog size=card_size|default:'small' photo=blog.teaser_graphic only %}
+				{% endif %}
+
 			</li>
 		{% endfor %}
 	</ol>
-
-	{% if type == 'featured' %}
-		<div class="blog-list__featured-scroller">
-			<button class="blog-list__featured-scroller--button blog-list__featured-scroller--button-prev">
-				{% include 'common/arrow-prev.svg' %}
-			</button>
-			<button class="blog-list__featured-scroller--button blog-list__featured-scroller--button-next">
-				{% include 'common/arrow-next.svg' %}
-			</button>
-		</div>
-	{% endif %}
 
 	{% if request and blogs.has_other_pages %}
 	<div class="blog-list__pagination">

--- a/blog/templates/blog/_special_blog_card.html
+++ b/blog/templates/blog/_special_blog_card.html
@@ -1,0 +1,18 @@
+{% load wagtailcore_tags wagtailimages_tags wagtailimages_tags %}
+
+{% image post.teaser_image scale-100 as tmp_photo %}
+<article class="special-blog-card">
+	<img src="{{ tmp_photo.url }}" alt="{{ post.teaser_image.title }}" width="{{ tmp_photo.width }}" height="{{ tmp_photo.height }}">
+	<div class="special-blog-card__info">
+		<a class="text-link text-link--card" href="{% pageurl post %}">
+			<h2 class="special-blog-card__title">{{ post.title }}</h2>
+		</a>
+		<p class="special-blog-card__metadata">
+			{{ post.publication_datetime|date:"F j, Y" }}
+			{% if post.author %}
+				— {{ post.author }}
+			{% endif %}
+		</p>
+		<p>{{ post.teaser_text }}</p>
+	</div>
+</article>

--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -23,6 +23,6 @@
 		</section>
 	{% endif %}
 
-	{% include 'blog/_blog_list.html' with blogs=entries_page heading=incident_listing_heading ajax_load=True request=request only %}
+	{% include 'blog/_blog_list.html' with blogs=entries_page heading=incident_listing_heading ajax_load=True request=request post_filters=post_filters type_choices=type_choices only %}
 
 {% endblock %}

--- a/blog/tests/test_commands.py
+++ b/blog/tests/test_commands.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from django.test import TestCase
 from wagtail.models import Site
 
-from ..models import BlogPage
+from ..choices import BlogTemplateType
 from .factories import (
     BlogIndexPageFactory,
     BlogPageFactory
@@ -19,17 +19,17 @@ class ConvertBlogTypeTest(TestCase):
         index = BlogIndexPageFactory(parent=s.root_page)
         cls.blog_post = BlogPageFactory(
             title='Blog Post 1',
-            blog_type=BlogPage.DEFAULT,
+            blog_type=BlogTemplateType.DEFAULT,
             parent=index,
         )
         cls.newsletter_post = BlogPageFactory(
             title='Newsletter 1',
-            blog_type=BlogPage.DEFAULT,
+            blog_type=BlogTemplateType.DEFAULT,
             parent=index,
         )
         cls.special_post = BlogPageFactory(
             title='Something very special',
-            blog_type=BlogPage.SPECIAL,
+            blog_type=BlogTemplateType.SPECIAL,
             parent=index,
         )
 
@@ -53,6 +53,6 @@ class ConvertBlogTypeTest(TestCase):
         self.blog_post.refresh_from_db()
         self.special_post.refresh_from_db()
 
-        self.assertEqual(self.newsletter_post.blog_type, BlogPage.NEWSLETTER)
-        self.assertEqual(self.special_post.blog_type, BlogPage.SPECIAL)
-        self.assertEqual(self.blog_post.blog_type, BlogPage.DEFAULT)
+        self.assertEqual(self.newsletter_post.blog_type, BlogTemplateType.NEWSLETTER)
+        self.assertEqual(self.special_post.blog_type, BlogTemplateType.SPECIAL)
+        self.assertEqual(self.blog_post.blog_type, BlogTemplateType.DEFAULT)

--- a/blog/tests/test_filtering.py
+++ b/blog/tests/test_filtering.py
@@ -41,6 +41,14 @@ class TestFiltering(TestCase):
         filters = BlogFilter.from_querystring(get_query)
         self.assertIsNone(filters.author)
 
+    def test_should_ignore_unparsable_data_for_blog_type(self):
+        """BlogFilter should set invalid blog_type data to None"""
+        get_query = {
+            'type': 'AAA',
+        }
+        filters = BlogFilter.from_querystring(get_query)
+        self.assertIsNone(filters.blog_type)
+
     def test_should_filter_blog_pages_by_author(self):
         """BlogFilter should filter BlogPages by author"""
         filters = BlogFilter(organization=None, author=self.post1.author.pk, blog_type=None)

--- a/blog/utils.py
+++ b/blog/utils.py
@@ -1,3 +1,6 @@
+from .choices import BlogTemplateType
+
+
 def string_to_int_or_none(s):
     """Converts a valid digit string to an integer, or None if not valid"""
     if s:
@@ -16,7 +19,10 @@ class BlogFilter(object):
         those values"""
         author_id = string_to_int_or_none(query.get('author'))
         organization_id = string_to_int_or_none(query.get('organization'))
-        blog_type = query.get('type')
+        try:
+            blog_type = BlogTemplateType(query.get('type'))
+        except ValueError:
+            blog_type = None
 
         return cls(organization_id, author_id, blog_type)
 

--- a/client/common/js/cardLink.js
+++ b/client/common/js/cardLink.js
@@ -29,4 +29,10 @@ document.addEventListener('DOMContentLoaded', () => {
 			cardLink(card)
 		})
 	}
+
+	if (document.querySelector('.special-blog-card')) {
+		document.querySelectorAll('.special-blog-card').forEach((card) => {
+			cardLink(card)
+		})
+	}
 })

--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -32,6 +32,7 @@
 @import components/site-summary
 @import components/menu
 @import components/categories-block
+@import components/button-row
 @import components/details-table
 @import components/list-table
 @import components/rich-text

--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -20,6 +20,7 @@
 @import components/disclose
 @import components/incident-card
 @import components/blog-card
+@import components/blog-card-special
 @import components/blog-list
 @import components/special-blog
 @import components/text-field

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -57,3 +57,13 @@
 
 		p
 			margin: 0
+
+	&::before
+		content: ' '
+		background: linear-gradient(0deg, #000 0%, rgba(0, 0, 0, 0.00) 100%)
+		z-index: 1
+		position: absolute
+		height: 600px
+		/* 1440px + 32px (margin left) + 32px (margin right) */
+		width: 1504px
+		max-width: 100%

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -29,6 +29,7 @@
 		margin: 0
 		line-height: 1.2
 		font-size: $font-size-h2
+		font-weight: 400
 		color: $white
 		text-decoration: var(--title-text-decoration)
 		+desktop-up

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -6,6 +6,8 @@
 	border-color: $black
 	height: 600px
 	cursor: pointer
+	margin-left: -32px
+	margin-right: -32px
 
 	--scale: 1
 	--title-text-decoration: none

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -56,6 +56,9 @@
 		p
 			margin: 0
 
+		.text-link--card
+			text-decoration: none
+
 	&::before
 		content: ' '
 		background: linear-gradient(0deg, #000 0%, rgba(0, 0, 0, 0.00) 100%)

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -1,0 +1,57 @@
+.special-blog-card
+	display: grid
+	grid-template: "container"
+	overflow: hidden
+	border-top: 1px solid
+	border-color: $black
+	height: 600px
+	cursor: pointer
+
+	--scale: 1
+	--title-text-decoration: none
+
+	&:hover
+		--scale: 1.08
+		--title-text-decoration: underline
+
+	> *
+		grid-area: container
+
+	img
+		width: 100%
+		height: 100%
+		object-fit: cover
+		place-self: center
+		transition: transform 0.15s ease-in-out
+		transform: scale(var(--scale))
+
+	&__title
+		margin: 0
+		line-height: 1.2
+		font-size: $font-size-h2
+		color: $white
+		text-decoration: var(--title-text-decoration)
+		+desktop-up
+			font-size: $font-size-h3-desktop
+
+	&__metadata
+		font-size: $font-size-p
+		font-weight: 700
+
+		+desktop-up
+			font-size: $font-size-p-desktop
+			line-height: 1
+
+	&__info
+		z-index: 10
+		display: flex
+		flex-direction: column
+		gap: 1rem
+		place-self: end left
+		color: $white
+		padding: 0 1.5rem 1rem
+		+tablet-up
+			max-width: 75%
+
+		p
+			margin: 0

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -2,8 +2,6 @@
 	display: grid
 	grid-template: "container"
 	overflow: hidden
-	border-top: 1px solid
-	border-color: $black
 	height: 600px
 	cursor: pointer
 	margin-left: -32px

--- a/client/common/sass/components/_blog-list.sass
+++ b/client/common/sass/components/_blog-list.sass
@@ -16,6 +16,7 @@
 
 	&__posts
 		padding: 0
+		grid-auto-flow: dense
 		+grid-container
 
 		&--featured-flex
@@ -60,6 +61,9 @@
 
 			+mobile-down
 				flex: 0 0 328px
+
+		&--special
+			grid-column: 1 / -1
 
 	&__pagination
 		text-align: center

--- a/client/common/sass/components/_button-row.sass
+++ b/client/common/sass/components/_button-row.sass
@@ -12,7 +12,7 @@
 	&--item
 		list-style-type: none
 		display: inline-block
-		padding: 1rem
+		padding: 0.5rem 0.75rem
 		border: solid 3px
 		border-color: $black
 		margin-left: -3px

--- a/client/common/sass/components/_button-row.sass
+++ b/client/common/sass/components/_button-row.sass
@@ -1,0 +1,27 @@
+.button-row
+	display: flex
+	flex-flow: row wrap
+	list-style: none
+	margin-bottom: 32px
+	padding: 0
+
+	&--active
+		color: $white
+		background-color: $black
+
+	&--item
+		list-style-type: none
+		display: inline-block
+		padding: 1rem
+		border: solid 3px
+		border-color: $black
+		margin-left: -3px
+		margin-top: -3px
+		font-weight: 700
+
+		&:hover
+			span::before
+				filter: invert(1)
+
+		&:focus
+			z-index: 2

--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -15,6 +15,7 @@ from wagtail.rich_text import RichText
 import factory
 from faker import Faker
 
+from blog.choices import BlogTemplateType
 from blog.models import BlogIndexPage, BlogPage
 from blog.devdata import BlogIndexPageFactory, BlogPageFactory
 from common.models import (
@@ -287,7 +288,7 @@ class Command(BaseCommand):
             parent=blog_index_page,
             organization__parent=org_index_page,
             author=author1,
-            blog_type=BlogPage.NEWSLETTER
+            blog_type=BlogTemplateType.NEWSLETTER
         )
 
         # special blog pages
@@ -296,7 +297,7 @@ class Command(BaseCommand):
             parent=blog_index_page,
             organization__parent=org_index_page,
             author=author2,
-            blog_type=BlogPage.SPECIAL
+            blog_type=BlogTemplateType.SPECIAL
         )
 
         for page in random.sample(list(BlogPage.objects.all()), 3):

--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -63,9 +63,25 @@ def richtext_aside(value):
 
 @register.simple_tag
 def query_transform(request, **kwargs):
+    """Modify the get parameters of a Django request object
+
+    :param request: The Django request from which to obtain GET
+        parameters.
+    :param kwargs: Keyword arguments are used to provide the new
+        parameters. Any argument given here will be updated/added to
+        the result, unless the value is given as ``None``, in which
+        case that key will be removed from the result.
+    :return: A URL-encoded string of the new GET parameters.
+    :rtype: str
+
+    """
     updated = request.GET.copy()
     for k, v in kwargs.items():
-        updated[k] = v
+        if v is None:
+            if k in updated:
+                del updated[k]
+        else:
+            updated[k] = v
     return updated.urlencode()
 
 


### PR DESCRIPTION
Fixes #1617 

This pull request:

1. Adds type filter buttons to the top of the blog index page (when not also filtering by author or organization), for newsletters, articles, and special sections.
2. Creates a new template for showing full-width, background image blog cards. I've tried to make this match the design, but it's possible some of the width or height values will need to be adjusted to make potential images visually appealing across mobile/tablet/desktop widths. As part of testing, please experiment here, I'm sure there are things I didn't try.