### PR TITLE
Replace Docker Compose v1 with v2 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 ---
+refs:
+  setup_remote_docker: &setup_remote_docker
+    setup_remote_docker:
+      version: 20.10.18
 version: 2.1
 commands:
   check-changed-files-or-halt:
@@ -79,7 +83,7 @@ jobs:
           name: Ensure we can run dev-env
           command: |
             make dev-init
-            docker-compose up -d
+            docker compose up --detach
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 5; done;
             make dev-tests
             make dev-jest-tests
@@ -98,7 +102,7 @@ jobs:
           name: Yank docker logs
           command: |
             mkdir -p ~/dockercomposelogs || true
-            docker-compose logs > ~/dockercomposelogs/dev.log
+            docker compose logs > ~/dockercomposelogs/dev.log
           when: always
 
       - store_artifacts:
@@ -117,7 +121,7 @@ jobs:
           name: Ensure we can run dev-env
           command: |
             make dev-init
-            docker-compose up -d
+            docker compose up --detach
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 5; done;
           no_output_timeout: 5m
 
@@ -141,25 +145,24 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker:
-          version: 20.10.7
+      - *setup_remote_docker
 
       - run:
           name: Ensure we can run prod-env
           command: |
-            docker-compose -f prod-docker-compose.yaml build
-            docker-compose -f prod-docker-compose.yaml up -d
+            docker compose -f prod-docker-compose.yaml build
+            docker compose -f prod-docker-compose.yaml up -d
             docker run --rm --network tracker_app curlimages/curl:7.80.0 -4 --retry 24 --retry-delay 5 --retry-all-errors http://app:8000/health/ok/
-            docker-compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py createdevdata --no-download"
-            docker-compose -f prod-docker-compose.yaml exec django pip install --require-hashes -r /django/requirements.txt
-            docker-compose -f prod-docker-compose.yaml exec django ./scripts/pytest
+            docker compose -f prod-docker-compose.yaml exec django /bin/bash -c "./manage.py createdevdata --no-download"
+            docker compose -f prod-docker-compose.yaml exec django pip install --require-hashes -r /django/requirements.txt
+            docker compose -f prod-docker-compose.yaml exec django ./scripts/pytest
           no_output_timeout: 5m
 
       - run:
           name: Yank docker logs
           command: |
             mkdir -p ~/dockercomposelogs || true
-            docker-compose -f prod-docker-compose.yaml logs > ~/dockercomposelogs/prod.log
+            docker compose -f prod-docker-compose.yaml logs > ~/dockercomposelogs/prod.log
           when: always
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2023.04.2
     working_directory: ~/tracker
     steps:
       - checkout
@@ -112,7 +112,7 @@ jobs:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2023.04.2
     working_directory: ~/tracker
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
+		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file ci-requirements.txt ci-requirements.in && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
 
 .PHONY: pip-upgrade

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ open-browser: ## Opens a web-browser pointing to the compose env
 
 .PHONY: dev-import-db
 dev-import-db: ## Import a postgres export file located at import.db
-	docker-compose exec -it postgresql bash -c "cat /django/import.db | sed 's/OWNER\ TO\ [a-z]*/OWNER\ TO\ postgres/g' | psql securedropdb -U postgres &> /dev/null"
+	docker compose exec -it postgresql bash -c "cat /django/import.db | sed 's/OWNER\ TO\ [a-z]*/OWNER\ TO\ postgres/g' | psql securedropdb -U postgres &> /dev/null"
 
 .PHONY: save-db
 dev-save-db: ## Export developer db to file
@@ -33,7 +33,7 @@ ci-tests: ## Runs testinfra against a pre-running CI container (useful for debug
 
 .PHONY: dev-tests
 dev-tests: ## Run django tests against developer environment
-	docker-compose exec django /bin/bash -ec \
+	docker compose exec django /bin/bash -ec \
 		"coverage run ./manage.py test --noinput --failfast; \
 		coverage html ; \
 		coverage xml ; \
@@ -41,7 +41,7 @@ dev-tests: ## Run django tests against developer environment
 
 .PHONY: dev-jest-tests
 dev-jest-tests: ## Run django tests against developer environment
-	docker-compose exec node npm test
+	docker compose exec node npm test
 
 .PHONY: compile-pip-dependencies
 compile-pip-dependencies: ## Uses pip-compile to update requirements.txt
@@ -117,11 +117,11 @@ help: ## Prints this message and exits
 
 .PHONY: eslint
 eslint:
-	docker-compose exec node npm run js-lint
+	docker compose exec node npm run js-lint
 
 .PHONY: stylelint
 stylelint:
-	docker-compose exec node npm run stylelint
+	docker compose exec node npm run stylelint
 
 .PHONY: flake8
 flake8: ## Runs flake8 linting in Python3 container.
@@ -131,11 +131,11 @@ flake8: ## Runs flake8 linting in Python3 container.
 
 .PHONY: check-migrations
 check-migrations: ## Check for ungenerated migrations
-	docker-compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"
+	docker compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"
 
 .PHONY: bandit
 bandit: ## Runs bandit static code analysis in Python3 container.
-	@docker-compose run --rm django ./scripts/bandit
+	@docker compose run --rm django ./scripts/bandit
 
 .PHONY: npm-audit
 npm-audit: ## Checks NodeJS NPM dependencies for vulnerabilities


### PR DESCRIPTION
I've replaced `docker-compose` with `docker compose` everywhere I could find in the CircleCI config and the Makefile (which is used by the CircleCI config). This is the command (I think?) we are using locally for development, so it should match CI. What this does, basically, is start using docker compose version 2:

https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/

I've also updated what version of Ubuntu VMs CircleCI is using, so that we have access to that version of docker/docker compose. 

Also made a minor fix to the `compile-pip-dependencies` command to also update the ci requirements.