### PR TITLE
Fix graphics without links

### DIFF
--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -49,7 +49,7 @@ export default function BarChart({
 	id = '',
 	numberOfTicks = 4,
 	description,
-	searchPageURL = () => {},
+	searchPageURL,
 	// function prop received from ChartDownloader that binds the svg element to allow
 	// it to be downloaded
 	setSvgEl = () => {},
@@ -216,20 +216,38 @@ export default function BarChart({
 					/>
 					{dataset.map((d) => (
 						<g key={d[x]}>
-							<a
-								href={searchPageURL(xFormat(d[x]))}
-								role="link"
-								aria-label={`${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`}
-							>
+							{searchPageURL ? (
+								<a
+									href={searchPageURL(xFormat(d[x]))}
+									role="link"
+									aria-label={`${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`}
+								>
+									<rect
+										x={xScaleOverLayer(d[x])}
+										y={yScale(d[y])}
+										height={computeBarheight(d[y])}
+										width={xScaleOverLayer.bandwidth()}
+										style={{
+											opacity: 0,
+											cursor: 'pointer',
+										}}
+										onMouseEnter={() => setHoveredElement((tooltipXFormat || xFormat)(d[x]))}
+										onMouseMove={updateTooltipPosition}
+										onMouseLeave={() => setHoveredElement(null)}
+										shapeRendering="crispEdges"
+									>
+										<title>
+											{xFormat(d[x])}: {yFormat(d[y])} {titleLabel}
+										</title>
+									</rect>
+								</a>
+							) : (
 								<rect
 									x={xScaleOverLayer(d[x])}
 									y={yScale(d[y])}
 									height={computeBarheight(d[y])}
 									width={xScaleOverLayer.bandwidth()}
-									style={{
-										opacity: 0,
-										cursor: 'pointer',
-									}}
+									style={{ opacity: 0 }}
 									onMouseEnter={() => setHoveredElement((tooltipXFormat || xFormat)(d[x]))}
 									onMouseMove={updateTooltipPosition}
 									onMouseLeave={() => setHoveredElement(null)}
@@ -239,7 +257,7 @@ export default function BarChart({
 										{xFormat(d[x])}: {yFormat(d[y])} {titleLabel}
 									</title>
 								</rect>
-							</a>
+							)}
 						</g>
 					))}
 					<AnimatedDataset
@@ -322,47 +340,82 @@ export default function BarChart({
 						keyFn={(d) => d}
 					/>
 				</g>
-				<AnimatedDataset
-					dataset={dataset}
-					tag="a"
-					attrs={{
-						href: d => searchPageURL(d[x]),
-						role: "link",
-						ariaLabel: d => `${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`,
-					}}
-					keyFn={(d) => d.index}
-				>
+				{searchPageURL ? (
 					<AnimatedDataset
-						tag="rect"
+						dataset={dataset}
+						tag="a"
 						attrs={{
-							x: (d) => xScale(d[x]),
-							y: (d) => yScale(d[y]),
-							height: (d) => computeBarheight(d[y]),
-							width: xScale.bandwidth(),
-							fill: (d) =>
-								sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
-							strokeWidth: borders.normal,
-							stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
-							cursor: 'pointer',
-							shapeRendering: 'crispEdges',
+							href: d => searchPageURL(d[x]),
+							role: "link",
+							ariaLabel: d => `${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`,
 						}}
-						duration={250}
 						keyFn={(d) => d.index}
-					/>
-					<text
-						x={width / 2}
-						y={height - paddings.mobile / 2 - 7}
-						textAnchor="middle"
-						style={{
-							fill: 'black',
-							fontFamily: 'var(--font-base)',
-							fontWeight: 500,
-							fontSize: '14px',
-						}}
 					>
-						{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
-					</text>
-				</AnimatedDataset>
+						<AnimatedDataset
+							tag="rect"
+							attrs={{
+								x: (d) => xScale(d[x]),
+								y: (d) => yScale(d[y]),
+								height: (d) => computeBarheight(d[y]),
+								width: xScale.bandwidth(),
+								fill: (d) =>
+									sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
+								strokeWidth: borders.normal,
+								stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
+								cursor: 'pointer',
+								shapeRendering: 'crispEdges',
+							}}
+							duration={250}
+							keyFn={(d) => d.index}
+						/>
+						<text
+							x={width / 2}
+							y={height - paddings.mobile / 2 - 7}
+							textAnchor="middle"
+							style={{
+								fill: 'black',
+								fontFamily: 'var(--font-base)',
+								fontWeight: 500,
+								fontSize: '14px',
+							}}
+						>
+							{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
+						</text>
+					</AnimatedDataset>
+				) : (
+					<>
+						<AnimatedDataset
+							dataset={dataset}
+							tag="rect"
+							attrs={{
+								x: (d) => xScale(d[x]),
+								y: (d) => yScale(d[y]),
+								height: (d) => computeBarheight(d[y]),
+								width: xScale.bandwidth(),
+								fill: (d) =>
+									sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
+								strokeWidth: borders.normal,
+								stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
+								shapeRendering: 'crispEdges',
+							}}
+							duration={250}
+							keyFn={(d) => d.index}
+						/>
+						<text
+							x={width / 2}
+							y={height - paddings.mobile / 2 - 7}
+							textAnchor="middle"
+							style={{
+								fill: 'black',
+								fontFamily: 'var(--font-base)',
+								fontWeight: 500,
+								fontSize: '14px',
+							}}
+						>
+							{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
+						</text>
+					</>
+				)}
 				<Slider
 					elements={dataset.map((d) => d[x])}
 					xScale={xSlider}

--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import * as d3 from 'd3'
 import { AnimatedDataset } from 'react-animated-dataset'
+import DynamicWrapper from './DynamicWrapper'
 import Slider from './Slider'
 import Tooltip from './Tooltip'
 
@@ -216,38 +217,25 @@ export default function BarChart({
 					/>
 					{dataset.map((d) => (
 						<g key={d[x]}>
-							{searchPageURL ? (
-								<a
-									href={searchPageURL(xFormat(d[x]))}
-									role="link"
-									aria-label={`${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`}
-								>
-									<rect
-										x={xScaleOverLayer(d[x])}
-										y={yScale(d[y])}
-										height={computeBarheight(d[y])}
-										width={xScaleOverLayer.bandwidth()}
-										style={{
-											opacity: 0,
-											cursor: 'pointer',
-										}}
-										onMouseEnter={() => setHoveredElement((tooltipXFormat || xFormat)(d[x]))}
-										onMouseMove={updateTooltipPosition}
-										onMouseLeave={() => setHoveredElement(null)}
-										shapeRendering="crispEdges"
-									>
-										<title>
-											{xFormat(d[x])}: {yFormat(d[y])} {titleLabel}
-										</title>
-									</rect>
-								</a>
-							) : (
+							<DynamicWrapper
+								wrapperComponent={
+									<a
+										href={searchPageURL && searchPageURL(xFormat(d[x]))}
+										role="link"
+										aria-label={`${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`}
+									/>
+								}
+								wrap={searchPageURL}
+							>
 								<rect
 									x={xScaleOverLayer(d[x])}
 									y={yScale(d[y])}
 									height={computeBarheight(d[y])}
 									width={xScaleOverLayer.bandwidth()}
-									style={{ opacity: 0 }}
+									style={{
+										opacity: 0,
+										cursor: searchPageURL ? 'pointer' : 'inherit',
+									}}
 									onMouseEnter={() => setHoveredElement((tooltipXFormat || xFormat)(d[x]))}
 									onMouseMove={updateTooltipPosition}
 									onMouseLeave={() => setHoveredElement(null)}
@@ -257,7 +245,7 @@ export default function BarChart({
 										{xFormat(d[x])}: {yFormat(d[y])} {titleLabel}
 									</title>
 								</rect>
-							)}
+							</DynamicWrapper>
 						</g>
 					))}
 					<AnimatedDataset
@@ -340,82 +328,53 @@ export default function BarChart({
 						keyFn={(d) => d}
 					/>
 				</g>
-				{searchPageURL ? (
-					<AnimatedDataset
-						dataset={dataset}
-						tag="a"
-						attrs={{
-							href: d => searchPageURL(d[x]),
-							role: "link",
-							ariaLabel: d => `${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`,
-						}}
-						keyFn={(d) => d.index}
-					>
-						<AnimatedDataset
-							tag="rect"
-							attrs={{
-								x: (d) => xScale(d[x]),
-								y: (d) => yScale(d[y]),
-								height: (d) => computeBarheight(d[y]),
-								width: xScale.bandwidth(),
-								fill: (d) =>
-									sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
-								strokeWidth: borders.normal,
-								stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
-								cursor: 'pointer',
-								shapeRendering: 'crispEdges',
-							}}
-							duration={250}
-							keyFn={(d) => d.index}
-						/>
-						<text
-							x={width / 2}
-							y={height - paddings.mobile / 2 - 7}
-							textAnchor="middle"
-							style={{
-								fill: 'black',
-								fontFamily: 'var(--font-base)',
-								fontWeight: 500,
-								fontSize: '14px',
-							}}
-						>
-							{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
-						</text>
-					</AnimatedDataset>
-				) : (
-					<>
+				<DynamicWrapper
+					wrapperComponent={
 						<AnimatedDataset
 							dataset={dataset}
-							tag="rect"
+							tag="a"
 							attrs={{
-								x: (d) => xScale(d[x]),
-								y: (d) => yScale(d[y]),
-								height: (d) => computeBarheight(d[y]),
-								width: xScale.bandwidth(),
-								fill: (d) =>
-									sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
-								strokeWidth: borders.normal,
-								stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
-								shapeRendering: 'crispEdges',
+								href: d => searchPageURL && d && searchPageURL(d[x]),
+								role: "link",
+								ariaLabel: d => d && `${xFormat(d[x])}: ${yFormat(d[y])} ${titleLabel}`,
 							}}
-							duration={250}
 							keyFn={(d) => d.index}
 						/>
-						<text
-							x={width / 2}
-							y={height - paddings.mobile / 2 - 7}
-							textAnchor="middle"
-							style={{
-								fill: 'black',
-								fontFamily: 'var(--font-base)',
-								fontWeight: 500,
-								fontSize: '14px',
-							}}
-						>
-							{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
-						</text>
-					</>
-				)}
+					}
+					wrap={searchPageURL}
+				>
+					<AnimatedDataset
+						dataset={searchPageURL ? undefined : dataset}
+						tag="rect"
+						attrs={{
+							x: (d) => xScale(d[x]),
+							y: (d) => yScale(d[y]),
+							height: (d) => computeBarheight(d[y]),
+							width: xScale.bandwidth(),
+							fill: (d) =>
+								sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
+							strokeWidth: borders.normal,
+							stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
+							cursor: searchPageURL ? 'pointer' : 'inherit',
+							shapeRendering: 'crispEdges',
+						}}
+						duration={250}
+						keyFn={(d) => d.index}
+					/>
+					<text
+						x={width / 2}
+						y={height - paddings.mobile / 2 - 7}
+						textAnchor="middle"
+						style={{
+							fill: 'black',
+							fontFamily: 'var(--font-base)',
+							fontWeight: 500,
+							fontSize: '14px',
+						}}
+					>
+						{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
+					</text>
+				</DynamicWrapper>
 				<Slider
 					elements={dataset.map((d) => d[x])}
 					xScale={xSlider}

--- a/client/charts/js/components/DynamicWrapper.jsx
+++ b/client/charts/js/components/DynamicWrapper.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+/**
+ * DynamicWrapper allows for elements to be allowed to conditionally wrap, based on
+ * whether the wrap prop is true or false.
+ *
+ * @param wrap
+ * @param children
+ * @param wrapperComponent
+ * @returns {React.DetailedReactHTMLElement<{}, HTMLElement>|*}
+ * @constructor
+ */
+export default function DynamicWrapper({ wrap = true, children, wrapperComponent }) {
+	if (wrap && wrapperComponent) return React.cloneElement(wrapperComponent, {}, children)
+	else return children
+}

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -287,17 +287,66 @@ export default function TreeMap({
 						style={{ stroke: 'black', strokeWidth: isHomePageDesktopView ? borderWidth.normal : 0 }}
 						shapeRendering="crispEdges"
 					/>
-					<AnimatedDataset
-						dataset={datasetStackedByCategory}
-						tag="a"
-						attrs={{
-							href: d => searchPageURL(d.category),
-							role: "link",
-							ariaLabel: d => d.category,
-						}}
-						keyFn={(d) => d.category}
-					>
+					{searchPageURL ? (
 						<AnimatedDataset
+							dataset={datasetStackedByCategory}
+							tag="a"
+							attrs={{
+								href: d => searchPageURL(d.category),
+								role: "link",
+								ariaLabel: d => d.category,
+							}}
+							keyFn={(d) => d.category}
+						>
+							<AnimatedDataset
+								tag="rect"
+								init={{
+									opacity: 0,
+									[chartWidthDimension]: chartWidthPaddingBefore,
+									[chartLengthDimension]: isMobile ? chartLength - chartLengthPaddingAfter : 0,
+									[chartWidthTitle]: chartWidth - (chartWidthPaddingBefore + chartWidthPaddingAfter),
+									[chartLengthTitle]: 0,
+								}}
+								attrs={{
+									opacity: 1,
+									[chartWidthDimension]: chartWidthPaddingBefore,
+									[chartLengthDimension]: (d) => chartLength - lengthScale(d.startingPoint),
+									[chartWidthTitle]: chartWidth - (chartWidthPaddingBefore + chartWidthPaddingAfter),
+									[chartLengthTitle]: (d) => computeBarHeight(d.startingPoint, d.endPoint),
+									fill: (d) =>
+										hoveredElement === d.category || hoveredElement === null
+											? d.numberOfIncidents === 0
+												? 'white'
+												: findColor(d.category)
+											: 'white',
+									stroke: (d) => (hoveredElement === d.category ? findColor(d.category) : 'black'),
+									strokeWidth: isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile,
+									cursor: 'pointer',
+									pointerEvents: (d) => (d.numberOfIncidents === 0 ? 'none' : null),
+									shapeRendering: 'crispEdges',
+								}}
+								events={{
+									// In a future, if we update our version of d3-selection the first
+									// argument will be a MouseEvent, eliminating the need for d3event here
+									onMouseMove: () => {
+										updateTooltipPosition(d3event)
+									},
+									onMouseLeave: () => {
+										setTooltipPosition({ x: 0, y: 0 })
+										setHoveredElement(null)
+									},
+									// In a future, if we update our version of d3-selection this may
+									// need to be updated to take arguments (MouseEvent, d) instead
+									onMouseEnter: d => setHoveredElement(d.category),
+								}}
+								durationByAttr={{ fill: 0, stroke: 0 }}
+								keyFn={(d) => d.category}
+								duration={250}
+							/>
+						</AnimatedDataset>
+					) : (
+						<AnimatedDataset
+							dataset={datasetStackedByCategory}
 							tag="rect"
 							init={{
 								opacity: 0,
@@ -320,7 +369,6 @@ export default function TreeMap({
 										: 'white',
 								stroke: (d) => (hoveredElement === d.category ? findColor(d.category) : 'black'),
 								strokeWidth: isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile,
-								cursor: 'pointer',
 								pointerEvents: (d) => (d.numberOfIncidents === 0 ? 'none' : null),
 								shapeRendering: 'crispEdges',
 							}}
@@ -342,7 +390,7 @@ export default function TreeMap({
 							keyFn={(d) => d.category}
 							duration={250}
 						/>
-					</AnimatedDataset>
+					)}
 					<AnimatedDataset
 						dataset={datasetStackedByCategory}
 						tag="line"

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import * as d3 from 'd3'
 import { AnimatedDataset } from 'react-animated-dataset'
+import DynamicWrapper from './DynamicWrapper'
 import Tooltip from './Tooltip'
 import { colors } from '../lib/utilities.js'
 
@@ -287,66 +288,23 @@ export default function TreeMap({
 						style={{ stroke: 'black', strokeWidth: isHomePageDesktopView ? borderWidth.normal : 0 }}
 						shapeRendering="crispEdges"
 					/>
-					{searchPageURL ? (
-						<AnimatedDataset
-							dataset={datasetStackedByCategory}
-							tag="a"
-							attrs={{
-								href: d => searchPageURL(d.category),
-								role: "link",
-								ariaLabel: d => d.category,
-							}}
-							keyFn={(d) => d.category}
-						>
+					<DynamicWrapper
+						wrapperComponent={
 							<AnimatedDataset
-								tag="rect"
-								init={{
-									opacity: 0,
-									[chartWidthDimension]: chartWidthPaddingBefore,
-									[chartLengthDimension]: isMobile ? chartLength - chartLengthPaddingAfter : 0,
-									[chartWidthTitle]: chartWidth - (chartWidthPaddingBefore + chartWidthPaddingAfter),
-									[chartLengthTitle]: 0,
-								}}
+								dataset={datasetStackedByCategory}
+								tag="a"
 								attrs={{
-									opacity: 1,
-									[chartWidthDimension]: chartWidthPaddingBefore,
-									[chartLengthDimension]: (d) => chartLength - lengthScale(d.startingPoint),
-									[chartWidthTitle]: chartWidth - (chartWidthPaddingBefore + chartWidthPaddingAfter),
-									[chartLengthTitle]: (d) => computeBarHeight(d.startingPoint, d.endPoint),
-									fill: (d) =>
-										hoveredElement === d.category || hoveredElement === null
-											? d.numberOfIncidents === 0
-												? 'white'
-												: findColor(d.category)
-											: 'white',
-									stroke: (d) => (hoveredElement === d.category ? findColor(d.category) : 'black'),
-									strokeWidth: isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile,
-									cursor: 'pointer',
-									pointerEvents: (d) => (d.numberOfIncidents === 0 ? 'none' : null),
-									shapeRendering: 'crispEdges',
+									href: d => d && searchPageURL && searchPageURL(d.category),
+									role: "link",
+									ariaLabel: d => d.category,
 								}}
-								events={{
-									// In a future, if we update our version of d3-selection the first
-									// argument will be a MouseEvent, eliminating the need for d3event here
-									onMouseMove: () => {
-										updateTooltipPosition(d3event)
-									},
-									onMouseLeave: () => {
-										setTooltipPosition({ x: 0, y: 0 })
-										setHoveredElement(null)
-									},
-									// In a future, if we update our version of d3-selection this may
-									// need to be updated to take arguments (MouseEvent, d) instead
-									onMouseEnter: d => setHoveredElement(d.category),
-								}}
-								durationByAttr={{ fill: 0, stroke: 0 }}
 								keyFn={(d) => d.category}
-								duration={250}
 							/>
-						</AnimatedDataset>
-					) : (
+						}
+						wrap={searchPageURL}
+					>
 						<AnimatedDataset
-							dataset={datasetStackedByCategory}
+							dataset={searchPageURL ? undefined : datasetStackedByCategory}
 							tag="rect"
 							init={{
 								opacity: 0,
@@ -369,6 +327,7 @@ export default function TreeMap({
 										: 'white',
 								stroke: (d) => (hoveredElement === d.category ? findColor(d.category) : 'black'),
 								strokeWidth: isHomePageDesktopView ? borderWidth.normal : borderWidth.mobile,
+								cursor: searchPageURL ? 'pointer' : 'inherit',
 								pointerEvents: (d) => (d.numberOfIncidents === 0 ? 'none' : null),
 								shapeRendering: 'crispEdges',
 							}}
@@ -390,7 +349,7 @@ export default function TreeMap({
 							keyFn={(d) => d.category}
 							duration={250}
 						/>
-					)}
+					</DynamicWrapper>
 					<AnimatedDataset
 						dataset={datasetStackedByCategory}
 						tag="line"

--- a/client/charts/js/components/USMap.jsx
+++ b/client/charts/js/components/USMap.jsx
@@ -168,18 +168,37 @@ export default function USMap({
 					</g>
 					<g role="list" aria-label="U.S. Map">
 						{dataset.filter(hasLatLon).map((d) => (
-							<a
-								href={searchPageURL(d.usCode)}
-								role="link"
-								aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
-							>
+							searchPageURL ? (
+								<a
+									href={searchPageURL(d.usCode)}
+									role="link"
+									aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
+								>
+									<circle
+										role="listitem"
+										aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
+										cx={projection([d.longitude, d.latitude])[0]}
+										cy={projection([d.longitude, d.latitude])[1]}
+										r={markerScale(d.numberOfIncidents) + 5}
+										style={{ opacity: 0, cursor: 'pointer' }}
+										onMouseMove={updateTooltipPosition}
+										onMouseEnter={(mouseEvent) => {
+											setHoveredElement(`${aggregationLocality(d)}`)
+										}}
+										onMouseLeave={() => {
+											setHoveredElement(null)
+										}}
+										key={aggregationLocality(d)}
+									/>
+								</a>
+							) : (
 								<circle
 									role="listitem"
 									aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
 									cx={projection([d.longitude, d.latitude])[0]}
 									cy={projection([d.longitude, d.latitude])[1]}
 									r={markerScale(d.numberOfIncidents) + 5}
-									style={{ opacity: 0, cursor: 'pointer' }}
+									style={{ opacity: 0 }}
 									onMouseMove={updateTooltipPosition}
 									onMouseEnter={(mouseEvent) => {
 										setHoveredElement(`${aggregationLocality(d)}`)
@@ -189,12 +208,12 @@ export default function USMap({
 									}}
 									key={aggregationLocality(d)}
 								/>
-							</a>
+							)
 						))}
 					</g>
 				</svg>
 
-				{incidentsOutsideUS && (
+				{incidentsOutsideUS && searchPageURL && (
 					<g>
 						<a
 							href={searchPageURL()}

--- a/client/charts/js/components/USMap.jsx
+++ b/client/charts/js/components/USMap.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import * as d3 from 'd3'
 import * as topojson from 'topojson-client'
 import { AnimatedDataset } from 'react-animated-dataset'
+import DynamicWrapper from './DynamicWrapper'
 import us from '../data/us-states.json'
 import Tooltip from './Tooltip'
 
@@ -168,37 +169,23 @@ export default function USMap({
 					</g>
 					<g role="list" aria-label="U.S. Map">
 						{dataset.filter(hasLatLon).map((d) => (
-							searchPageURL ? (
-								<a
-									href={searchPageURL(d.usCode)}
-									role="link"
-									aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
-								>
-									<circle
-										role="listitem"
+							<DynamicWrapper
+								wrapperComponent={
+									<a
+										href={searchPageURL && searchPageURL(d.usCode)}
+										role="link"
 										aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
-										cx={projection([d.longitude, d.latitude])[0]}
-										cy={projection([d.longitude, d.latitude])[1]}
-										r={markerScale(d.numberOfIncidents) + 5}
-										style={{ opacity: 0, cursor: 'pointer' }}
-										onMouseMove={updateTooltipPosition}
-										onMouseEnter={(mouseEvent) => {
-											setHoveredElement(`${aggregationLocality(d)}`)
-										}}
-										onMouseLeave={() => {
-											setHoveredElement(null)
-										}}
-										key={aggregationLocality(d)}
 									/>
-								</a>
-							) : (
+								}
+								wrap={searchPageURL}
+							>
 								<circle
 									role="listitem"
 									aria-label={`${aggregationLocality(d)}: ${d.numberOfIncidents} incidents`}
 									cx={projection([d.longitude, d.latitude])[0]}
 									cy={projection([d.longitude, d.latitude])[1]}
 									r={markerScale(d.numberOfIncidents) + 5}
-									style={{ opacity: 0 }}
+									style={{ opacity: 0, cursor: searchPageURL ? 'pointer' : 'inherit' }}
 									onMouseMove={updateTooltipPosition}
 									onMouseEnter={(mouseEvent) => {
 										setHoveredElement(`${aggregationLocality(d)}`)
@@ -208,7 +195,7 @@ export default function USMap({
 									}}
 									key={aggregationLocality(d)}
 								/>
-							)
+							</DynamicWrapper>
 						))}
 					</g>
 				</svg>

--- a/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
@@ -157,9 +157,13 @@ exports[`renders BarChart with mocked data 1`] = `
       tag="rect"
     />
     <g>
-      <a
-        aria-label="Nov: 0 incidents"
-        role="link"
+      <DynamicWrapper
+        wrapperComponent={
+          <a
+            aria-label="Nov: 0 incidents"
+            role="link"
+          />
+        }
       >
         <rect
           height={0}
@@ -169,7 +173,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -185,12 +189,16 @@ exports[`renders BarChart with mocked data 1`] = `
             incidents
           </title>
         </rect>
-      </a>
+      </DynamicWrapper>
     </g>
     <g>
-      <a
-        aria-label="Dec: 0 incidents"
-        role="link"
+      <DynamicWrapper
+        wrapperComponent={
+          <a
+            aria-label="Dec: 0 incidents"
+            role="link"
+          />
+        }
       >
         <rect
           height={0}
@@ -200,7 +208,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -216,12 +224,16 @@ exports[`renders BarChart with mocked data 1`] = `
             incidents
           </title>
         </rect>
-      </a>
+      </DynamicWrapper>
     </g>
     <g>
-      <a
-        aria-label="Jan: 0 incidents"
-        role="link"
+      <DynamicWrapper
+        wrapperComponent={
+          <a
+            aria-label="Jan: 0 incidents"
+            role="link"
+          />
+        }
       >
         <rect
           height={0}
@@ -231,7 +243,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -247,12 +259,16 @@ exports[`renders BarChart with mocked data 1`] = `
             incidents
           </title>
         </rect>
-      </a>
+      </DynamicWrapper>
     </g>
     <g>
-      <a
-        aria-label="Feb: 0 incidents"
-        role="link"
+      <DynamicWrapper
+        wrapperComponent={
+          <a
+            aria-label="Feb: 0 incidents"
+            role="link"
+          />
+        }
       >
         <rect
           height={0}
@@ -262,7 +278,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -278,12 +294,16 @@ exports[`renders BarChart with mocked data 1`] = `
             incidents
           </title>
         </rect>
-      </a>
+      </DynamicWrapper>
     </g>
     <g>
-      <a
-        aria-label="Mar: 0 incidents"
-        role="link"
+      <DynamicWrapper
+        wrapperComponent={
+          <a
+            aria-label="Mar: 0 incidents"
+            role="link"
+          />
+        }
       >
         <rect
           height={0}
@@ -293,7 +313,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -309,12 +329,16 @@ exports[`renders BarChart with mocked data 1`] = `
             incidents
           </title>
         </rect>
-      </a>
+      </DynamicWrapper>
     </g>
     <g>
-      <a
-        aria-label="Apr: 0 incidents"
-        role="link"
+      <DynamicWrapper
+        wrapperComponent={
+          <a
+            aria-label="Apr: 0 incidents"
+            role="link"
+          />
+        }
       >
         <rect
           height={0}
@@ -324,7 +348,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -340,7 +364,7 @@ exports[`renders BarChart with mocked data 1`] = `
             incidents
           </title>
         </rect>
-      </a>
+      </DynamicWrapper>
     </g>
     <AnimatedDataset
       attrs={


### PR DESCRIPTION
Fixes the bug we are currently seeing with the bubble map not rendering.

![Screenshot 2023-06-23 at 10 55 59 AM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/ef4db9db-6d0f-4a6d-b2fc-0e407870560c)

Essentially, the map was expecting the dots to be able to link out to another page, but on blog posts we don't link out to the database page. Fixing this uncovered the fact that the `<a>` will still get rendered when we don't have a url to link to, which will render fine but is bad for accessibility. To fix this, I've made these changes that check whether we have a url to link to, and only renders the wrapping `<a>` tag if we do.