### PR TITLE
Fix searchPageURL references

### DIFF
--- a/client/charts/js/components/CategoryPageChart.jsx
+++ b/client/charts/js/components/CategoryPageChart.jsx
@@ -4,7 +4,7 @@ import Flashing from '../../../common/js/components/Flashing'
 import ChartDescription from "./ChartDescription"
 import BarChart from "./BarChart"
 import {
-	goToFilterPage,
+	getFilteredUrl,
 	groupByYearsSorted,
 } from '../lib/utilities.js'
 
@@ -49,9 +49,9 @@ function CategoryPageChartWidth({
 							width={width}
 							height={chartHeight}
 							isMobileView={width < 480}
-							openSearchPage={(year) => {
-								goToFilterPage(databasePath, {category, year}, new Date(), categories)
-							}}
+							searchPageURL={(year) =>
+								getFilteredUrl(databasePath, {category, year}, new Date(), categories)
+							}
 						/>
 					)}
 				</div>

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -482,7 +482,6 @@ export default function TreeMap({
 										}}
 										onClick={() => toggleSelectedCategory(d.category)}
 										onMouseEnter={() => setHoveredElement(d.category)}
-										onMouseUp={() => openSearchPage(d.category)}
 										cursor={interactive ? 'pointer' : 'inherit'}
 										pointerEvents={interactive ? "auto" : "none"}
 										tabIndex="0"

--- a/client/charts/js/components/__tests__/BarChart.test.js
+++ b/client/charts/js/components/__tests__/BarChart.test.js
@@ -13,7 +13,6 @@ test('renders BarChart with mocked data', () => {
 			isMobileView={false}
 			width={480}
 			height={500}
-			searchPageURL={() => ""}
 		/>
 	)).toMatchSnapshot();
 });

--- a/client/charts/js/components/__tests__/BarChart.test.js
+++ b/client/charts/js/components/__tests__/BarChart.test.js
@@ -13,7 +13,7 @@ test('renders BarChart with mocked data', () => {
 			isMobileView={false}
 			width={480}
 			height={500}
-			openSearchPage={() => {}}
+			searchPageURL={() => ""}
 		/>
 	)).toMatchSnapshot();
 });

--- a/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
@@ -87,7 +87,7 @@ exports[`renders BarChart with mocked data 1`] = `
     <AnimatedDataset
       attrs={
         {
-          "cursor": "pointer",
+          "cursor": "inherit",
           "fill": [Function],
           "height": [Function],
           "shapeRendering": "crispEdges",
@@ -164,11 +164,9 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
-        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Nov: 0 incidents"
-            href=""
             role="link"
           />
         }
@@ -181,7 +179,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -207,11 +205,9 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
-        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Dec: 0 incidents"
-            href=""
             role="link"
           />
         }
@@ -224,7 +220,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -250,11 +246,9 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
-        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Jan: 0 incidents"
-            href=""
             role="link"
           />
         }
@@ -267,7 +261,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -293,11 +287,9 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
-        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Feb: 0 incidents"
-            href=""
             role="link"
           />
         }
@@ -310,7 +302,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -336,11 +328,9 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
-        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Mar: 0 incidents"
-            href=""
             role="link"
           />
         }
@@ -353,7 +343,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }
@@ -379,11 +369,9 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
-        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Apr: 0 incidents"
-            href=""
             role="link"
           />
         }
@@ -396,7 +384,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "pointer",
+              "cursor": "inherit",
               "opacity": 0,
             }
           }

--- a/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
@@ -87,7 +87,7 @@ exports[`renders BarChart with mocked data 1`] = `
     <AnimatedDataset
       attrs={
         {
-          "cursor": "inherit",
+          "cursor": "pointer",
           "fill": [Function],
           "height": [Function],
           "shapeRendering": "crispEdges",
@@ -164,9 +164,11 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
+        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Nov: 0 incidents"
+            href=""
             role="link"
           />
         }
@@ -179,7 +181,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "inherit",
+              "cursor": "pointer",
               "opacity": 0,
             }
           }
@@ -205,9 +207,11 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
+        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Dec: 0 incidents"
+            href=""
             role="link"
           />
         }
@@ -220,7 +224,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "inherit",
+              "cursor": "pointer",
               "opacity": 0,
             }
           }
@@ -246,9 +250,11 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
+        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Jan: 0 incidents"
+            href=""
             role="link"
           />
         }
@@ -261,7 +267,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "inherit",
+              "cursor": "pointer",
               "opacity": 0,
             }
           }
@@ -287,9 +293,11 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
+        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Feb: 0 incidents"
+            href=""
             role="link"
           />
         }
@@ -302,7 +310,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "inherit",
+              "cursor": "pointer",
               "opacity": 0,
             }
           }
@@ -328,9 +336,11 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
+        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Mar: 0 incidents"
+            href=""
             role="link"
           />
         }
@@ -343,7 +353,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "inherit",
+              "cursor": "pointer",
               "opacity": 0,
             }
           }
@@ -369,9 +379,11 @@ exports[`renders BarChart with mocked data 1`] = `
       }
     >
       <DynamicWrapper
+        wrap={[Function]}
         wrapperComponent={
           <a
             aria-label="Apr: 0 incidents"
+            href=""
             role="link"
           />
         }
@@ -384,7 +396,7 @@ exports[`renders BarChart with mocked data 1`] = `
           shapeRendering="crispEdges"
           style={
             {
-              "cursor": "inherit",
+              "cursor": "pointer",
               "opacity": 0,
             }
           }

--- a/client/charts/js/lib/utilities.js
+++ b/client/charts/js/lib/utilities.js
@@ -85,11 +85,6 @@ export function getFilteredUrl(databasePath, filtersApplied, currentDate, catego
 	return `${baseUrl}${parameters.join('&')}`
 }
 
-export function goToFilterPage(databasePath, filtersApplied, currentDate, categories) {
-	const url = getFilteredUrl(databasePath, filtersApplied, currentDate, categories)
-	window.location = url
-}
-
 export function filterDatasetByTag(dataset, tag) {
 	return dataset.filter(
 		(d) =>


### PR DESCRIPTION
Fixes a `searchPageURL` reference that I missed in a previous round of work. This fixes the bar chart link in the category pages.