### PR TITLE
Adds back teaser images for incident pages

### DIFF
--- a/common/templates/common/_video_or_image.html
+++ b/common/templates/common/_video_or_image.html
@@ -1,24 +1,26 @@
 {% load wagtailcore_tags wagtailembeds_tags wagtailimages_tags %}
 
 {% if video or image %}
-    <figure class="primary-banner-media">
-        {% if video %}
-            {% embed video %}
-        {% elif image.0.block_type == "image" %}
-						<div class="primary-banner-media__inner">
-							  {% image image.0.value width-910 alt=image.attribution|default:image.0.value.title %}
-            </div>
-        {% elif image.0.block_type == "vertical_bar_chart" %}
-            {% include 'common/blocks/vertical_bar_chart.html' with value=image.0.value static_graphic=true %}
-        {% elif image.0.block_type == "tree_map_chart" %}
-			      {% include 'common/blocks/tree_map_chart.html' with value=image.0.value static_graphic=true %}
-        {% elif image.0.block_type == "bubble_map_chart" %}
-						<div class="primary-banner-media__inner">
-                {% include 'common/blocks/bubble_map_chart.html' with value=image.0.value static_graphic=true %}
-						</div>
-        {% endif %}
-        {% if caption or image.attribution %}
-            <figcaption class="media-caption">
+		<figure class="primary-banner-media">
+				{% if video %}
+						{% embed video %}
+				{% elif image.0.block_type == "image" %}
+					<div class="primary-banner-media__inner">
+						{% image image.0.value width-910 alt=image.attribution|default:image.0.value.title %}
+					</div>
+				{% elif image.0.block_type == "vertical_bar_chart" %}
+					{% include 'common/blocks/vertical_bar_chart.html' with value=image.0.value static_graphic=true %}
+				{% elif image.0.block_type == "tree_map_chart" %}
+					{% include 'common/blocks/tree_map_chart.html' with value=image.0.value static_graphic=true %}
+				{% elif image.0.block_type == "bubble_map_chart" %}
+					<div class="primary-banner-media__inner">
+						{% include 'common/blocks/bubble_map_chart.html' with value=image.0.value static_graphic=true %}
+					</div>
+				{% elif image %}
+					{% image image width-910 alt=image.attribution|default:image.title %}
+				{% endif %}
+				{% if caption or image.attribution %}
+						<figcaption class="media-caption">
 				<div class="rich-text">{{ caption|richtext }}</div>
 				{% if image.attribution %}
 					<span
@@ -26,6 +28,6 @@
 					> — {{ image.attribution }}</span>
 				{% endif %}
 			</figcaption>
-        {% endif %}
-    </figure>
+				{% endif %}
+		</figure>
 {% endif %}


### PR DESCRIPTION
As reported by Kirstin in slack, the incident pages were not showing the teaser images. This is because while adding of charts as primary image, the logic for image in blog was changed, and that code is shared with incidents template as well.

I have put the code back for adding image in incident pages to that template. Also, ensured that both visualization and normal images work in blog pages.