### PR TITLE
Add placeholder for teaser images

### DIFF
--- a/client/charts/js/bubble-map-chart.js
+++ b/client/charts/js/bubble-map-chart.js
@@ -29,7 +29,11 @@ function engageCharts() {
 				dataKey={['dataset']}
 				dataParser={[(data) => d3.csvParse(data, d3.autoType)]}
 				loadingComponent={(
-					<svg viewBox="0 0 655 440" width="100%" style={{ display: fullSize ? 'none' : 'block' }} />
+					<svg
+						viewBox="0 0 655 440"
+						width="100%"
+						style={{ display: fullSize ? 'none' : 'block', backgroundColor: '#fafafa' }}
+					/>
 				)}
 			>
 				<BubbleMapChart

--- a/client/charts/js/bubble-map-chart.js
+++ b/client/charts/js/bubble-map-chart.js
@@ -28,6 +28,9 @@ function engageCharts() {
 				dataUrl={[`/api/edge/incidents/homepage_csv/?`]}
 				dataKey={['dataset']}
 				dataParser={[(data) => d3.csvParse(data, d3.autoType)]}
+				loadingComponent={(
+					<svg viewBox="0 0 655 440" width="100%" style={{ display: fullSize ? 'none' : 'block' }} />
+				)}
 			>
 				<BubbleMapChart
 					filterCategories={filterCategories}

--- a/client/charts/js/components/BarChartMini.jsx
+++ b/client/charts/js/components/BarChartMini.jsx
@@ -15,7 +15,7 @@ export default ({
 		<svg
 			viewBox={`0 0 ${width} ${height}`}
 			width="100%"
-			style={{ display: "block", marginBottom: "0.75rem" }}
+			style={{ display: "block", marginBottom: "0.75rem", backgroundColor: "#fafafa" }}
 		>
 			{data.map((row, i) => (
 				<rect

--- a/client/charts/js/components/IncidentsBubbleMap.jsx
+++ b/client/charts/js/components/IncidentsBubbleMap.jsx
@@ -21,6 +21,7 @@ export default ({
 	creditUrl = '',
 	categories,
 	interactive = true,
+	fullSize,
 }) => {
 	const aggregationLocalityMap = { state: groupByState, city: groupByCity }
 	const aggregationLocalityFnMap = { state: d => d.state, city: d => `${d.city}, ${d.state}` }
@@ -39,8 +40,8 @@ export default ({
 						description={description}
 						aggregationLocality={aggregationLocalityFnMap[aggregationLocality]}
 						incidentsOutsideUS={incidentsOutsideUS}
-						width={parent.width}
-						height={parent.width * 0.7}
+						width={fullSize ? parent.width : 655}
+						height={fullSize ? (parent.width * 0.7) : 440}
 						overridePaddings={{ map: 0, bottom: 0 }}
 						interactive={interactive}
 					/>

--- a/client/charts/js/components/USMap.jsx
+++ b/client/charts/js/components/USMap.jsx
@@ -101,7 +101,13 @@ export default function USMap({
 					y={tooltipPosition.y}
 				/>
 			)}
-			<svg width={width} height={height} aria-labelledby={id} ref={setSvgEl}>
+			<svg
+				width="100%"
+				viewBox={`0 0 ${width} ${height}`}
+				aria-labelledby={id}
+				ref={setSvgEl}
+				style={{display: 'block'}}
+			>
 				{description ? (<desc>{description}</desc>) : null}
 				<svg
 					width={width}

--- a/client/charts/js/tree-map-chart.js
+++ b/client/charts/js/tree-map-chart.js
@@ -44,7 +44,11 @@ function engageCharts() {
 				dataKey={dataKey}
 				dataParser={dataParser}
 				loadingComponent={(
-					<svg viewBox="0 0 655 440" width="100%" style={{ display: fullSize ? 'none' : 'block' }} />
+					<svg
+						viewBox="0 0 655 440"
+						width="100%"
+						style={{ display: fullSize ? 'none' : 'block', backgroundColor: '#fafafa' }}
+					/>
 				)}
 			>
 				<TreeMapChart

--- a/client/charts/js/tree-map-chart.js
+++ b/client/charts/js/tree-map-chart.js
@@ -43,6 +43,9 @@ function engageCharts() {
 				dataUrl={dataUrl}
 				dataKey={dataKey}
 				dataParser={dataParser}
+				loadingComponent={(
+					<svg viewBox="0 0 655 440" width="100%" style={{ display: fullSize ? 'none' : 'block' }} />
+				)}
 			>
 				<TreeMapChart
 					filterCategories={filterCategories}

--- a/client/charts/js/vertical-bar-chart.js
+++ b/client/charts/js/vertical-bar-chart.js
@@ -27,7 +27,11 @@ function engageCharts() {
 				dataUrl={`/api/edge/incidents/homepage_csv/?`}
 				dataKey="dataset"
 				loadingComponent={(
-					<svg viewBox="0 0 655 440" width="100%" style={{ display: fullSize ? 'none' : 'block' }} />
+					<svg
+						viewBox="0 0 655 440"
+						width="100%"
+						style={{ display: fullSize ? 'none' : 'block', backgroundColor: '#fafafa' }}
+					/>
 				)}
 			>
 				<IncidentsTimeBarChart

--- a/client/charts/js/vertical-bar-chart.js
+++ b/client/charts/js/vertical-bar-chart.js
@@ -26,6 +26,9 @@ function engageCharts() {
 			<DataLoader
 				dataUrl={`/api/edge/incidents/homepage_csv/?`}
 				dataKey="dataset"
+				loadingComponent={(
+					<svg viewBox="0 0 655 440" width="100%" style={{ display: fullSize ? 'none' : 'block' }} />
+				)}
 			>
 				<IncidentsTimeBarChart
 					filterCategories={filterCategories}

--- a/common/templates/common/blocks/bubble_map_chart.html
+++ b/common/templates/common/blocks/bubble_map_chart.html
@@ -33,7 +33,7 @@
 		{% endif %}
 	>
 		{% if mini_graphic is not None %}
-			<svg viewBox="0 0 655 440" width="100%" style="display: block" />
+			<svg viewBox="0 0 655 440" width="100%" style="display: block; background-color: #fafafa" />
 		{% endif %}
 	</div>
 </div>

--- a/common/templates/common/blocks/bubble_map_chart.html
+++ b/common/templates/common/blocks/bubble_map_chart.html
@@ -31,5 +31,9 @@
 		{% if mini_graphic is None %}
 			data-full-size="true"
 		{% endif %}
-	></div>
+	>
+		{% if mini_graphic is not None %}
+			<svg viewBox="0 0 655 440" width="100%" style="display: block" />
+		{% endif %}
+	</div>
 </div>

--- a/common/templates/common/blocks/tree_map_chart.html
+++ b/common/templates/common/blocks/tree_map_chart.html
@@ -33,7 +33,7 @@
 		data-url="{{ value.data_url }}"
 	>
 		{% if mini_graphic is not None %}
-			<svg viewBox="0 0 655 440" width="100%" style="display: block" />
+			<svg viewBox="0 0 655 440" width="100%" style="display: block; background-color: #fafafa" />
 		{% endif %}
 	</div>
 </div>

--- a/common/templates/common/blocks/tree_map_chart.html
+++ b/common/templates/common/blocks/tree_map_chart.html
@@ -31,5 +31,9 @@
 		data-branch-field-name="{{ value.branch_field_name }}"
 		data-branches="{{ value.branches }}"
 		data-url="{{ value.data_url }}"
-	></div>
+	>
+		{% if mini_graphic is not None %}
+			<svg viewBox="0 0 655 440" width="100%" style="display: block" />
+		{% endif %}
+	</div>
 </div>

--- a/common/templates/common/blocks/vertical_bar_chart.html
+++ b/common/templates/common/blocks/vertical_bar_chart.html
@@ -33,7 +33,7 @@
 		{% endif %}
 	>
 		{% if mini_graphic is not None %}
-			<svg viewBox="0 0 655 440" width="100%" style="display: block" />
+			<svg viewBox="0 0 655 440" width="100%" style="display: block; background-color: #fafafa" />
 		{% endif %}
 	</div>
 </div>

--- a/common/templates/common/blocks/vertical_bar_chart.html
+++ b/common/templates/common/blocks/vertical_bar_chart.html
@@ -31,5 +31,9 @@
 		{% if mini_graphic is None %}
 			data-full-size="true"
 		{% endif %}
-	></div>
+	>
+		{% if mini_graphic is not None %}
+			<svg viewBox="0 0 655 440" width="100%" style="display: block" />
+		{% endif %}
+	</div>
 </div>


### PR DESCRIPTION
fixes #1689 

Adds a placeholder for teaser images so that the layout doesn't shift as much, also adds a gray background for the mini bar chart. I've left it as just a blank svg for now, but open to other placeholders if we want!

https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/da85c4fc-483d-4338-b9c3-08a3dadd6a0e

