### PR TITLE
Special blog card responsiveness

### DIFF
--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -4,8 +4,16 @@
 	overflow: hidden
 	height: 600px
 	cursor: pointer
-	margin-left: -32px
-	margin-right: -32px
+	margin-left: -16px
+	margin-right: -16px
+
+	+tablet-up
+		margin-left: -24px
+		margin-right: -24px
+
+	+desktop-up
+		margin-left: -32px
+		margin-right: -32px
 
 	--scale: 1
 	--title-text-decoration: none

--- a/client/common/sass/components/_blog-card-special.sass
+++ b/client/common/sass/components/_blog-card-special.sass
@@ -20,6 +20,7 @@
 	img
 		width: 100%
 		height: 100%
+		max-height: 600px
 		object-fit: cover
 		place-self: center
 		transition: transform 0.15s ease-in-out


### PR DESCRIPTION
Fixes #1700

Adds media queries for negative margins (to match the responsive container-level padding) and a height fix for Chrome, as detailed in ticket. Thanks @SaptakS  for investigating the answers for these!

## Press release style description

Fixes a bug where the Special Blog Post banners would not display correctly in Chrome or at certain screen sizes.