### PR TITLE
Add www.youtube.com to CSP `frame-src` directive

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -267,6 +267,7 @@ CSP_FRAME_SRC = (
     # For recaptcha
     "https://www.google.com/recaptcha/",
     "https://recaptcha.google.com/recaptcha/",
+    "https://www.youtube.com",
 )
 CSP_CONNECT_SRC = [
     "'self'",


### PR DESCRIPTION
Fixes #1707  

This addition is needed for YouTube embeds.