### PR TITLE
Fix Homepage Charts

### DIFF
--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -137,15 +137,16 @@ export default function BarChart({
 				)}
 				<svg
 					ref={setSvgEl}
-					width={width}
-					height={height}
+					width="100%"
 					aria-labelledby={id}
 					style={{
 						marginTop: margins.top,
 						marginBottom: margins.bottom,
 						marginRight: margins.right,
 						marginLeft: margins.left,
+						display: "block",
 					}}
+					viewBox={[0, 0, width, height]}
 				>
 					{description ? (<desc>{description}</desc>) : null}
 					<g>

--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -108,7 +108,6 @@ function HomepageMainChartsWidth({
 							getFilteredUrl(databasePath, { ...filtersApplied, state }, currentDate, categories)
 						}
 						addBottomBorder={true}
-						overridePaddings={{ bottom: 47 }}
 					/>
 				</div>
 				<div className={'hpChart'}>

--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -108,7 +108,7 @@ function HomepageMainChartsWidth({
 							getFilteredUrl(databasePath, { ...filtersApplied, state }, currentDate, categories)
 						}
 						addBottomBorder={true}
-						overridePaddings={{ bottom: 46 }}
+						overridePaddings={{ bottom: 47 }}
 					/>
 				</div>
 				<div className={'hpChart'}>

--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -108,6 +108,7 @@ function HomepageMainChartsWidth({
 							getFilteredUrl(databasePath, { ...filtersApplied, state }, currentDate, categories)
 						}
 						addBottomBorder={true}
+						overridePaddings={{ bottom: 46 }}
 					/>
 				</div>
 				<div className={'hpChart'}>

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -234,7 +234,7 @@ export default function TreeMap({
 	}
 
 	if (!isMobile) {
-		chartWidthPaddingBefore = datasetCategoriesLabelsLegend[datasetCategoriesLabelsLegend.length - 1].labelStartingY
+		chartWidthPaddingBefore = datasetCategoriesLabelsLegend[datasetCategoriesLabelsLegend.length - 1]?.labelStartingY
 			+ paddings.top + labelHeight * 1.5
 	}
 

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -270,16 +270,17 @@ export default function TreeMap({
 			)}
 			<div>
 				<svg
-					width={width}
-					height={height}
+					width="100%"
 					aria-labelledby={id}
 					style={{
 						marginTop: margins.top,
 						marginRight: margins.right,
 						marginBottom: margins.bottom,
 						marginLeft: margins.left,
-						pointerEvents: interactive ? "auto" : "none"
+						pointerEvents: interactive ? "auto" : "none",
+						display: "block",
 					}}
+					viewBox={[0, 0, width, height]}
 					ref={setSvgEl}
 				>
 					<line

--- a/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/BarChart.test.js.snap
@@ -4,16 +4,24 @@ exports[`renders BarChart with mocked data 1`] = `
 <React.Fragment>
   <svg
     aria-labelledby=""
-    height={500}
     style={
       {
+        "display": "block",
         "marginBottom": 0,
         "marginLeft": 0,
         "marginRight": 2,
         "marginTop": 0,
       }
     }
-    width={480}
+    viewBox={
+      [
+        0,
+        0,
+        480,
+        500,
+      ]
+    }
+    width="100%"
   >
     <g>
       <AnimatedDataset

--- a/client/charts/sass/HomepageMainCharts.sass
+++ b/client/charts/sass/HomepageMainCharts.sass
@@ -11,4 +11,5 @@
 	display: table
 	flex-grow: 1
 	flex-basis: 0
+	min-width: 0
 	width: 100%

--- a/client/charts/sass/HomepageMainCharts.sass
+++ b/client/charts/sass/HomepageMainCharts.sass
@@ -5,7 +5,10 @@
 .hpChartContainer
 	+large-screen
 		display: flex
+		align-items: end
 
 .hpChart
-	margin: auto
 	display: table
+	flex-grow: 1
+	flex-basis: 0
+	width: 100%

--- a/client/charts/sass/HomepageMainCharts.sass
+++ b/client/charts/sass/HomepageMainCharts.sass
@@ -4,12 +4,10 @@
 
 .hpChartContainer
 	+large-screen
-		display: flex
-		align-items: end
+		display: grid
+		grid-auto-flow: column
+		grid-auto-columns: 1fr
 
 .hpChart
 	display: table
-	flex-grow: 1
-	flex-basis: 0
-	min-width: 0
 	width: 100%


### PR DESCRIPTION
closes #1711 

![Screenshot 2023-08-01 at 10 13 54 AM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/2a54afb0-e513-4599-9dc3-dc0b00e20820)

Some of the earlier work getting the map to the right size caused some issues on the homepage alignment, this fixes that.