### PR TITLE
Add focus-visible style

### DIFF
--- a/client/charts/js/components/Button.jsx
+++ b/client/charts/js/components/Button.jsx
@@ -29,11 +29,9 @@ export default function Button({ label, selected, selectable = true, onClick, to
 			/>
 		)}
 		<button
+			className="btn btn-bordered"
 			style={{
-				padding: 8,
-				border: 'none',
 				marginBottom: 3,
-				outline: 'solid 3px black',
 				backgroundColor: selected || (hovered && selectable) ? 'black' : 'white',
 				color: selected || (hovered && selectable) ? 'white' : selectable ? 'black' : 'grey',
 				cursor: selectable ? 'pointer' : 'default',

--- a/client/charts/js/components/__tests__/__snapshots__/Button.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/Button.test.js.snap
@@ -3,6 +3,7 @@
 exports[`renders Button with mocked data 1`] = `
 <React.Fragment>
   <button
+    className="btn btn-bordered"
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -10,13 +11,10 @@ exports[`renders Button with mocked data 1`] = `
     style={
       {
         "backgroundColor": "white",
-        "border": "none",
         "color": "black",
         "cursor": "pointer",
         "marginBottom": 3,
         "minWidth": 50,
-        "outline": "solid 3px black",
-        "padding": 8,
       }
     }
   >

--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -99,8 +99,8 @@
 
 	&-bordered
 		padding: 8px
-		border: none
-		outline: solid 3px black
+		border: 0
+		outline: solid 3px $black
 
 		&:focus, &:focus-visible
 			outline: $black solid 5px

--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -100,7 +100,7 @@
 	&-bordered
 		padding: 8px
 		border: 0
-		outline: solid 3px $black
+		outline: solid 3px #000000
 
 		&:focus, &:focus-visible
 			outline: $black solid 5px

--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -100,7 +100,7 @@
 	&-bordered
 		padding: 8px
 		border: 0
-		outline: solid 3px #000000
+		outline: solid 3px $black
 
 		&:focus, &:focus-visible
 			outline: $black solid 5px

--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -100,7 +100,7 @@
 	&-bordered
 		padding: 8px
 		border: 0
-		outline: solid 3px $black
+		outline: $black solid 3px
 
 		&:focus, &:focus-visible
 			outline: $black solid 5px

--- a/client/common/sass/components/_buttons.sass
+++ b/client/common/sass/components/_buttons.sass
@@ -11,8 +11,9 @@
 	text-decoration: none
 	z-index: 1
 
-	&:focus
+	&:focus, &:focus-visible
 		outline: $black solid 3px
+		z-index: 2
 
 	&:not([disabled]):hover
 		cursor: pointer
@@ -95,6 +96,14 @@
 		&[disabled]
 			color: $tag-inactive
 			border-color: $tag-inactive
+
+	&-bordered
+		padding: 8px
+		border: none
+		outline: solid 3px black
+
+		&:focus, &:focus-visible
+			outline: $black solid 5px
 
 	&-ghost
 		transition: color 0.01s ease-in 0.08s


### PR DESCRIPTION
## Description

Fixes #1678

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

- Make sure the buttons on the home page have a thicker black border around when focused
- Make sure all other elements look the same

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [x] Verify that it renders correctly in incident index page, if applicable
- [x] Verify that it renders correctly in individual incident page, if applicable
- [x] Verify that it renders correctly in blog index page, if applicable
- [x] Verify that it renders correctly in individual blog page, if applicable

### If you made any frontend change

![Screenshot 2023-08-14 at 11 17 38 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/f27bcecb-2e2a-49d9-a1d3-d83c9fb69a41)

