### PR TITLE
Fix homepage charts bar chart width

### DIFF
--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -343,8 +343,8 @@ export default function BarChart({
 		return (
 			<svg
 				ref={setSvgEl}
-				width={width}
-				height={height}
+				width="100%"
+				viewBox={[0, 0, width, height]}
 				style={{
 					marginTop: margins.top,
 					marginBottom: margins.bottom,

--- a/client/charts/js/components/HomepageMainCharts.jsx
+++ b/client/charts/js/components/HomepageMainCharts.jsx
@@ -25,6 +25,8 @@ export default function HomepageMainCharts(props) {
 	)
 }
 
+const mobileBreakpoint = 950
+
 function HomepageMainChartsWidth({
 	data: dataset,
 	width,
@@ -46,8 +48,8 @@ function HomepageMainChartsWidth({
 		{}
 	)
 
-	const chartWidth = width > 970 ? width / 3 : width
-	const chartHeight = width > 970 ? 500 : 480
+	const chartWidth = width > mobileBreakpoint ? width / 3 : width
+	const chartHeight = width > mobileBreakpoint ? 500 : 480
 
 	const datasetFiltered = filterDatasetByFiltersApplied(dataset, filtersApplied, currentDate)
 
@@ -83,7 +85,7 @@ function HomepageMainChartsWidth({
 						width={chartWidth}
 						height={chartHeight}
 						id={'homepage-treemap-chart-label'}
-						isHomePageDesktopView={width > 970}
+						isHomePageDesktopView={width > mobileBreakpoint}
 						minimumBarHeight={35}
 						categoryColumn={'categories'}
 						titleLabel={'incidents'}
@@ -120,7 +122,7 @@ function HomepageMainChartsWidth({
 						id={'homepage-bar-chart-label'}
 						width={chartWidth}
 						height={chartHeight}
-						isMobileView={width < 970}
+						isMobileView={width < mobileBreakpoint}
 						searchPageURL={(monthName) =>
 							getFilteredUrl(databasePath, { ...filtersApplied, monthName }, currentDate, categories)
 						}


### PR DESCRIPTION
## Description

Fixes #1723 

Changes proposed in this pull request:

Fixes the bar chart being the wrong width from about 1000px to 1018px.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

- Check out this branch, run the application and visit http://localhost:8000/
- Resize the browser viewport to about 1000px
- Verify that the width of all the charts are correct

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

![Screenshot 2023-08-17 at 9 24 27 AM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/9b5bbd09-6ac8-4c08-b125-f4455324f537)

