### PR TITLE
Add Database Filter Summary

### DIFF
--- a/client/charts/js/components/FilterSummary.jsx
+++ b/client/charts/js/components/FilterSummary.jsx
@@ -48,7 +48,6 @@ export default function FilterSidebar() {
 							"categories", categories.filter(d => d !== category).join(',')
 						)}
 						className="btn btn-tag"
-						tabIndex={0}
 						aria-label={`Removes filter: ${category.toLowerCase()}`}
 					>
 						<div className={classNames("category", `category-${symbolMap[category]}`)}></div>
@@ -62,7 +61,6 @@ export default function FilterSidebar() {
 					<button
 						onClick={() => clearFilter("date_lower")}
 						className="btn btn-tag"
-						tabIndex={0}
 						aria-label={`Removes start date: ${date_lower}`}
 					>
 						<span>from: {date_lower}</span>
@@ -75,7 +73,6 @@ export default function FilterSidebar() {
 					<button
 						onClick={() => clearFilter("date_upper")}
 						className="btn btn-tag"
-						tabIndex={0}
 						aria-label={`Removes end date: ${date_upper}`}
 					>
 						<span>to: {date_upper}</span>
@@ -87,10 +84,9 @@ export default function FilterSidebar() {
 				<li key={tag}>
 					<button
 						onClick={() => clearFilter(
-							"tags", categories.filter(d => d !== tag).join(',')
+							"tags", tags.filter(d => d !== tag).join(',')
 						)}
 						className="btn btn-tag"
-						tabIndex={0}
 						aria-label={`Removes tag: ${tag.toLowerCase()}`}
 					>
 						<span>{tag.toLowerCase()}</span>
@@ -103,7 +99,6 @@ export default function FilterSidebar() {
 					<button
 						onClick={() => clearFilter(filterKey)}
 						className="btn btn-tag"
-						tabIndex={0}
 						aria-label={`Removes filter: ${restFilters[filterKey].replaceAll("_", " ").toLowerCase()}`}
 					>
 						<span>{restFilters[filterKey].replaceAll("_", " ").toLowerCase()}</span>

--- a/client/charts/js/components/FilterSummary.jsx
+++ b/client/charts/js/components/FilterSummary.jsx
@@ -49,6 +49,7 @@ export default function FilterSidebar() {
 						)}
 						className="btn btn-tag"
 						tabIndex={0}
+						aria-label={`Removes filter: ${category.toLowerCase()}`}
 					>
 						<div className={classNames("category", `category-${symbolMap[category]}`)}></div>
 						<span>{category.toLowerCase()}</span>
@@ -62,6 +63,7 @@ export default function FilterSidebar() {
 						onClick={() => clearFilter("date_lower")}
 						className="btn btn-tag"
 						tabIndex={0}
+						aria-label={`Removes start date: ${date_lower}`}
 					>
 						<span>from: {date_lower}</span>
 						<span className="close-icon" />
@@ -74,6 +76,7 @@ export default function FilterSidebar() {
 						onClick={() => clearFilter("date_upper")}
 						className="btn btn-tag"
 						tabIndex={0}
+						aria-label={`Removes end date: ${date_upper}`}
 					>
 						<span>to: {date_upper}</span>
 						<span className="close-icon" />
@@ -88,6 +91,7 @@ export default function FilterSidebar() {
 						)}
 						className="btn btn-tag"
 						tabIndex={0}
+						aria-label={`Removes tag: ${tag.toLowerCase()}`}
 					>
 						<span>{tag.toLowerCase()}</span>
 						<span className="close-icon" />
@@ -100,6 +104,7 @@ export default function FilterSidebar() {
 						onClick={() => clearFilter(filterKey)}
 						className="btn btn-tag"
 						tabIndex={0}
+						aria-label={`Removes filter: ${restFilters[filterKey].replaceAll("_", " ").toLowerCase()}`}
 					>
 						<span>{restFilters[filterKey].replaceAll("_", " ").toLowerCase()}</span>
 						<span className="close-icon" />

--- a/client/charts/js/components/FilterSummary.jsx
+++ b/client/charts/js/components/FilterSummary.jsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import classNames from 'classnames'
+
+const symbolMap = {
+	"Arrest / Criminal Charge": "arrest",
+	"Border Stop": "border_stop",
+	"Denial of Access": "denial_of_access",
+	"Equipment Search or Seizure": "equipment_search",
+	"Assault": "assault",
+	"Leak Case": "leak_case",
+	"Subpoena / Legal Order": "subpoena",
+	"Equipment Damage": "equipment_damage",
+	"Prior Restraint": "prior_restraint",
+	"Chilling Statement": "chilling_statement",
+	"Other Incident": "other_incident",
+}
+
+export default function FilterSidebar() {
+	const searchParams = new URLSearchParams(window.location.search)
+	const {
+		categories: categoriesStr,
+		tags: tagsStr,
+		date_lower,
+		date_upper,
+		...restFilters
+	} = Object.fromEntries(searchParams)
+
+	const categories = categoriesStr.split(',').map(d => d.trim())
+	const tags = tagsStr.split(',').map(d => d.trim())
+
+	const clearFilter = (filterKey, newFilterValue) => {
+		const url = new URL(window.location);
+		const newSearchParams = new URLSearchParams(window.location.search)
+
+		if (newFilterValue) newSearchParams.set(filterKey, newFilterValue)
+		else newSearchParams.delete(filterKey)
+
+		url.search = newSearchParams.toString()
+		window.location = url.toString()
+	}
+
+	return (
+		<ul className="filters-summary">
+			{categories.map(category => (
+				<li key={category}>
+					<button
+						onClick={() => clearFilter(
+							"categories", categories.filter(d => d !== category).join(',')
+						)}
+						className="btn btn-tag"
+						tabIndex={0}
+					>
+						<div className={classNames("category", `category-${symbolMap[category]}`)}></div>
+						<span>{category.toLowerCase()}</span>
+						<span className="close-icon" />
+					</button>
+				</li>
+			))}
+			{date_lower && (
+				<li>
+					<button
+						onClick={() => clearFilter("date_lower")}
+						className="btn btn-tag"
+						tabIndex={0}
+					>
+						<span>from: {date_lower}</span>
+						<span className="close-icon" />
+					</button>
+				</li>
+			)}
+			{date_upper && (
+				<li>
+					<button
+						onClick={() => clearFilter("date_upper")}
+						className="btn btn-tag"
+						tabIndex={0}
+					>
+						<span>to: {date_upper}</span>
+						<span className="close-icon" />
+					</button>
+				</li>
+			)}
+			{tags.map(tag => (
+				<li key={tag}>
+					<button
+						onClick={() => clearFilter(
+							"tags", categories.filter(d => d !== tag).join(',')
+						)}
+						className="btn btn-tag"
+						tabIndex={0}
+					>
+						<span>{tag.toLowerCase()}</span>
+						<span className="close-icon" />
+					</button>
+				</li>
+			))}
+			{Object.keys(restFilters).map(filterKey => (
+				<li key={restFilters[filterKey]}>
+					<button
+						onClick={() => clearFilter(filterKey)}
+						className="btn btn-tag"
+						tabIndex={0}
+					>
+						<span>{restFilters[filterKey].replaceAll("_", " ").toLowerCase()}</span>
+						<span className="close-icon" />
+					</button>
+				</li>
+			))}
+		</ul>
+	)
+}

--- a/client/charts/js/components/FilterSummary.jsx
+++ b/client/charts/js/components/FilterSummary.jsx
@@ -25,8 +25,8 @@ export default function FilterSidebar() {
 		...restFilters
 	} = Object.fromEntries(searchParams)
 
-	const categories = categoriesStr.split(',').map(d => d.trim())
-	const tags = tagsStr.split(',').map(d => d.trim())
+	const categories = categoriesStr ? categoriesStr.split(',').map(d => d.trim()) : []
+	const tags = tagsStr ? tagsStr.split(',').map(d => d.trim()) : []
 
 	const clearFilter = (filterKey, newFilterValue) => {
 		const url = new URL(window.location);

--- a/client/charts/js/components/FiltersIntegration.jsx
+++ b/client/charts/js/components/FiltersIntegration.jsx
@@ -19,7 +19,7 @@ import {
 } from '../lib/utilities'
 
 
-function filterReducer(state, {type, payload}) {
+export function filterReducer(state, {type, payload}) {
 	switch (type) {
 		case TOGGLE_PARAMETER_ITEM:
 			let { item } = payload

--- a/client/charts/js/filter-summary.js
+++ b/client/charts/js/filter-summary.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import FilterSummary from "./components/FilterSummary";
+
+function renderSummary() {
+	let el = document.getElementById("filter-summary");
+	let root = createRoot(el);
+	root.render(<FilterSummary {...(el.dataset)} />);
+}
+
+// First render
+renderSummary();
+
+// Hot module reloading
+if (module.hot) {
+	module.hot.accept("components/FilterSummary", () => {
+		console.clear();
+		renderSummary();
+	});
+}

--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -132,13 +132,20 @@
 	margin: 0
 	padding: 0
 
+	+desktop-up
+		&:not(:empty)
+			margin-bottom: 32px
+
+	+tablet-down
+		margin-bottom: 8px
+
 	li
 		display: inline-block
-		margin: 2px
+		margin: 2px 2px 2px 0
 		text-transform: capitalize
 
 	button
-		border: none
+		border: 0
 		display: flex
 		align-items: center
 

--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -127,3 +127,24 @@
 			.filters__suggestion-tooltip
 				display: inline
 				margin-left: 0.5rem
+
+.filters-summary
+	margin: 0
+	padding: 0
+
+	li
+		display: inline-block
+		margin: 2px
+		text-transform: capitalize
+
+	button
+		border: none
+		display: flex
+		align-items: center
+
+		.close-icon
+			width: 8px
+			height: 8px
+			background-image: url(../icons/cross.svg)
+			background-size: contain
+			margin-left: 8px

--- a/client/common/sass/components/_filters.sass
+++ b/client/common/sass/components/_filters.sass
@@ -141,7 +141,7 @@
 
 	li
 		display: inline-block
-		margin: 2px 2px 2px 0
+		margin: 4px 8px 4px 0
 		text-transform: capitalize
 
 	button

--- a/client/common/sass/components/_incident-index.sass
+++ b/client/common/sass/components/_incident-index.sass
@@ -39,9 +39,6 @@
 .incident-index__body-header-filters
 	grid-column: 1 / -1
 
-	+desktop-up
-		margin-bottom: 32px
-
 .incident-index__sort-details
 	&[open]
 		> summary::before

--- a/client/common/sass/components/_incident-index.sass
+++ b/client/common/sass/components/_incident-index.sass
@@ -36,6 +36,12 @@
 	+desktop-up
 		margin-bottom: 32px
 
+.incident-index__body-header-filters
+	grid-column: 1 / -1
+
+	+desktop-up
+		margin-bottom: 32px
+
 .incident-index__sort-details
 	&[open]
 		> summary::before

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -5,6 +5,7 @@
 {% block body %}
 	{{ block.super }}
 	{% render_bundle 'filterSidebar' 'js' %}
+	{% render_bundle 'filterSummary' 'js' %}
 {% endblock %}
 
 {% block main %}
@@ -90,6 +91,9 @@
 					</div>
 				</details>
 			</div>
+
+			<div class="incident-index__body-header-filters" id="filter-summary"></div>
+
 			<div class="incident-index__column-header incident-index__column-header--incident">Incident</div>
 			<div class="incident-index__column-header incident-index__column-header--incident-details">Incident Details</div>
 			<div class="incident-index__column-header incident-index__column-header--category-details">Category Details</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ var common = {
 		statistics: __dirname + '/client/statistics/js/searchstats.js',
 		charts: __dirname + '/client/charts/js/index.js',
 		filterSidebar: __dirname + '/client/charts/js/filter-sidebar.js',
+		filterSummary: __dirname + '/client/charts/js/filter-summary.js',
 		verticalBarChart: __dirname + '/client/charts/js/vertical-bar-chart.js',
 		treeMapChart: __dirname + '/client/charts/js/tree-map-chart.js',
 		bubbleMapChart: __dirname + '/client/charts/js/bubble-map-chart.js',


### PR DESCRIPTION
## Description

Fixes #1706 

This PR adds the current filters as little pills to the top of the database page, allowing users to clear specific filters by clicking on each pill. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

- Run the application locally, and test adding some filters on this page: http://localhost:8000/all-incidents/
- The summary should show up above the database entries.
- Ensure that desktop, mobile, and tablet all look good

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.


![Screenshot 2023-08-25 at 4 54 19 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/632a2a1d-625f-4435-a645-88a6d16ec0b8)
