### PR TITLE
Fix Chart Downloader

### DIFF
--- a/client/charts/js/components/ChartDownloader.jsx
+++ b/client/charts/js/components/ChartDownloader.jsx
@@ -91,7 +91,7 @@ const ChartDownloader = ({
 							</text>
 						` : ""}
 					` : ""}
-					<svg width="${imageWidth}" height="${imageHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}">
+					<svg width="${imageWidth}" height="${imageHeight}">
 						${svgStringData}
 					</svg>
 				</svg>


### PR DESCRIPTION
## Description

Fixes the chart downloader.

Before:
![Searched and seized equipment of journalists across the U S](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/aaf73557-6931-4c2a-b6bd-440ce2d11114)

After: 
![chart](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/607b9211-ffa3-4a98-80d0-029485c5e26d)


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Run the application locally, and try downloading any chart. The downloaded chart should look correct.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
