### PR TITLE
Improve CSRF error handling for FormPage submissions

### DIFF
--- a/client/common/sass/components/_forms.sass
+++ b/client/common/sass/components/_forms.sass
@@ -19,6 +19,10 @@
 
 	+constrain-to-desktop
 
+	&__top-level-error
+		font-style: italic
+		color: $error
+
 .form
 
 	+desktop-up

--- a/common/tests/test_views.py
+++ b/common/tests/test_views.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.core.files.base import ContentFile
 from django.urls import reverse
 from django.utils.http import urlencode
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, RequestFactory
 from wagtail.documents.models import Document
 from common.models import CommonTag
 from common.wagtail_hooks import CommonTagAdmin
@@ -20,6 +20,9 @@ from mailchimp_marketing.api_client import ApiClientError
 from emails.devdata import EmailSettingsFactory
 from emails.models import Subscription
 from common.utils import ApiError
+from common.views import csrf_failure
+
+from .factories import SimplePageFactory
 
 User = get_user_model()
 
@@ -402,3 +405,32 @@ class HealthCheckTestCase(TestCase):
         mock_open.side_effect = FileNotFoundError
         self.response = self.client.get('/health/version/')
         self.assertEqual(self.response.status_code, 200)
+
+
+class CsrfFailureTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.site = Site.objects.get(is_default_site=True)
+        cls.page = SimplePageFactory(parent=cls.site.root_page)
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_returns_403_for_non_wagtail_page_objects(self):
+        request = self.factory.post(reverse('wagtailadmin_login'))
+
+        response = csrf_failure(request)
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_403_for_non_formpage_objects(self):
+        request = self.factory.post(self.page.get_url())
+
+        response = csrf_failure(request)
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_403_if_site_not_present(self):
+        self.site.delete()
+        request = self.factory.post(self.page.get_url())
+
+        response = csrf_failure(request)
+        self.assertEqual(response.status_code, 403)

--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -2,3 +2,4 @@ from common.utils.paginate import *  # noqa: F403, F401
 from common.utils.echo import *  # noqa: F403, F401
 from common.utils.unescape import *  # noqa: F403, F401
 from common.utils.mailchimp import *  # noqa: F403, F401
+from common.utils.pages import *  # noqa: F403, F401

--- a/common/utils/pages.py
+++ b/common/utils/pages.py
@@ -1,0 +1,16 @@
+from wagtail.core.models import Site
+
+
+def get_page_for_request(request):
+    """Look up the page instance that is being requested by a Request object
+
+    Returns ``None`` if the page is not found, the ``Page`` instance otherwise.
+    """
+    site = Site.find_for_request(request)
+    if site:
+        path = request.path
+        path_components = [component for component in path.split("/") if component]
+        page, args, kwargs = site.root_page.specific.route(request, path_components)
+        return page
+
+    return None

--- a/common/views.py
+++ b/common/views.py
@@ -5,7 +5,12 @@ import marshmallow
 import structlog
 import mailchimp_marketing
 from django.conf import settings
-from django.http import HttpResponse, JsonResponse
+from django.http import (
+    HttpResponse,
+    JsonResponse,
+    HttpResponseForbidden,
+    Http404,
+)
 from django.middleware.csrf import get_token
 from django.shortcuts import render
 from django.utils.text import capfirst
@@ -21,7 +26,7 @@ from common.models import CommonTag
 from emails.models import SubscriptionSchema
 from incident.models import IncidentPage, TopicPage
 from .forms import TagMergeForm
-from .utils import subscribe_for_site, MailchimpError
+from .utils import subscribe_for_site, MailchimpError, get_page_for_request
 
 
 VERSION_INFO_SHORT_PATH = os.environ.get(
@@ -247,3 +252,17 @@ def health_version(request):
     """Also a health check, but returns the commit short-hash."""
     version_short_text = read_version_info_file(VERSION_INFO_SHORT_PATH)
     return HttpResponse(version_short_text, content_type="text/plain")
+
+
+def csrf_failure(request, reason=""):
+    try:
+        page = get_page_for_request(request)
+    except Http404:
+        return HttpResponseForbidden()
+
+    try:
+        return page.redirect_for_csrf_error(request, reason)
+    except AttributeError:
+        pass
+
+    return HttpResponseForbidden()

--- a/forms/templates/forms/form_page.html
+++ b/forms/templates/forms/form_page.html
@@ -21,6 +21,11 @@
     <section class="formpage-form">
         <form class="form" action="{% pageurl page %}" method="post">
             {% csrf_token %}
+			{% if top_level_error %}
+				<p class="formpage-form__top-level-error">
+					{{ top_level_error }}
+				</p>
+			{% endif %}
             {% for group in page.groups %}
                 <fieldset class="fieldset fieldset--spaced">
                     <h4 class="heading-regular">{{ group.title }}</h4>

--- a/forms/tests/test_views.py
+++ b/forms/tests/test_views.py
@@ -1,0 +1,36 @@
+from django.test import TestCase, RequestFactory, Client
+from wagtail.models import Site
+
+from .factories import FormPageFactory
+
+
+class CsrfFailureTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.get(is_default_site=True)
+        cls.form_page = FormPageFactory(parent=site.root_page)
+
+    def setUp(self):
+        self.csrf_client = Client(enforce_csrf_checks=True)
+        self.factory = RequestFactory()
+
+    def test_csrf_failure_redirects_to_original_form_page(self):
+        submission_data = {}
+        for field in self.form_page.get_form_fields():
+            submission_data[field.clean_name] = 'value'
+        response = self.csrf_client.post(
+            self.form_page.get_url(),
+            data=submission_data,
+            follow=True,
+        )
+
+        self.assertRedirects(
+            response,
+            self.form_page.get_url(),
+        )
+        self.assertEqual(
+            response.context['top_level_error'],
+            'Submission failed, please try again.',
+        )
+        form = response.context['form']
+        self.assertEqual(form.initial, submission_data)

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -229,6 +229,9 @@ MAILCHIMP_API_KEY = os.environ.get('MAILCHIMP_API_KEY', '')
 
 RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY', '')
 RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY', '')
+
+CSRF_FAILURE_VIEW = 'common.views.csrf_failure'
+
 NOCAPTCHA = True
 
 # django-taggit


### PR DESCRIPTION
## Description

Fixes #1674

Changes proposed in this pull request:

1. Adds a CSRF error handler view that's under our control
2. Configures the view so that if (1) the URL being requested is a wagtail page, and (2) the page implements the method `redirect_for_csrf_error`, the view will redirect to whatever is returned by that method. Otherwise, a 403 response is returned, which is the current behavior.
3. Adds `redirect_for_csrf_error` to `FormPage` to store the submitted data in the Django session, then redirect to back to itself.
4. Modify form pages so that, when loading the form, it looks in the session for data from step 3 to populate the form. Also, if it finds such data, add a top level message saying "Submission failed, please try again." -- this can be adjusted, though I'm not sure how specific we want to be, like "CSRF validation failed, please clear cookies and try again" (or something).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Test by faking a CSRF error when submitting a form to a form page (like the submit an incident page, or a custom one you create). I found that you can reliably get the error by clearing the "csrftoken" cookie before submitting. The result of this should be that you're redirected back to the form page with the same data you originally submitted, except also with an error message at the top of the form.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to "Submit and Incident" form

- [ ] Verify that the form renders correctly and submit correctly as well

### If you made any frontend change

![image](https://github.com/freedomofpress/pressfreedomtracker.us/assets/561931/f0f6f321-b94f-4884-abe3-bfbfc12b3738)
