### PR TITLE
Define a default value for NPM version to be used for container

### DIFF
--- a/devops/docker/NodeDockerfile
+++ b/devops/docker/NodeDockerfile
@@ -4,7 +4,7 @@ FROM node:16-alpine@sha256:1908564153449b1c46b329e6ce2307e226bc566294f822f11c5a8
 # Make npm output less verbose
 ENV NPM_CONFIG_LOGLEVEL warn
 
-ARG NPM_VER
+ARG NPM_VER=9.6.7
 
 # Upgrade npm to speicifed version
 RUN npm install npm@${NPM_VER} --location=global

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -5,7 +5,7 @@ FROM node:16-alpine@sha256:1908564153449b1c46b329e6ce2307e226bc566294f822f11c5a8
 ENV NPM_CONFIG_LOGLEVEL warn
 
 # Upgrade npm to speicifed version
-ARG NPM_VER
+ARG NPM_VER=9.6.7
 RUN npm install npm@${NPM_VER} --location=global
 
 # Oddly, node-sass requires both python and make to build bindings

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       context: .
       dockerfile: devops/docker/NodeDockerfile
       args:
-        NPM_VER: 9.6.0
+        NPM_VER: 9.6.7
         USERID: ${UID:?err}
     volumes:
       - ./:/django

--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: devops/docker/ProdDjangoDockerfile
       args:
-        NPM_VER: 9.6.0
+        NPM_VER: 9.6.7
         USERID: 1234
     image: quay.io/freedomofpress/pressfreedomtrackerus
     depends_on:


### PR DESCRIPTION
## Description

Related to https://github.com/freedomofpress/fpf-www-projects/issues/359

Changes proposed in this pull request: We have run into an issue where some environments do not set the `NPM_VER` argument to the production django dockerfile, which can cause unexpected major-version changes in the `npm install npm@${NPM_VER}` command.  This prevents that from happening.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

With this change, building a container from the node dockerfile and the production django dockerfile should succeed even if `NPM_VER` is not given as an argument. This can be tested by, for example, removing that argument from the prod-docker-compose.yaml file (see https://github.com/freedomofpress/freedom.press/blob/npm-version-default-value/prod-docker-compose.yaml#L25) and building the container with 

```
docker compose -f prod-docker-compose.yaml build
```

Without this change, that command will fail because it tries to install npm version 10 on an incompatible engine.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:
No changes

### If you made changes to incident model metadata
No changes
### If you made changes to blog
No changes.

### If you made changes to shared templates (e.g. card design, lead media, etc.)

No changes.
### If you made changes to email signup flow
No changes.
### If you made changes to "Submit and Incident" form

No changes.

### If it's a major change

Not a major change.

### If you made any frontend change

No frontend changes.
