### PR TITLE
Updates to python 3.9.18 and bookworm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ compile-pip-dependencies: ## Uses pip-compile to update requirements.txt
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --output-file requirements.txt requirements.in && \
@@ -60,7 +60,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
@@ -70,7 +70,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 .PHONY: pip-upgrade
 pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 # in requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file requirements.txt requirements.in && \
@@ -79,7 +79,7 @@ pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 .PHONY: pip-dev-upgrade
 pip-dev-upgrade: ## Uses pip-compile to update all dev requirements that are not pinned
 # in dev-requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file dev-requirements.txt dev-requirements.in'
@@ -89,7 +89,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
@@ -97,7 +97,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 
 .PHONY: upgrade-pip-tools
 upgrade-pip-tools: ## Update the version of pip-tools used for other pip-related make commands
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.9-slim-bookworm \
 		bash -c 'pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package pip-tools --output-file pip-tools-requirements.txt pip-tools-requirements.in'
 
@@ -127,7 +127,7 @@ stylelint:
 .PHONY: flake8
 flake8: ## Runs flake8 linting in Python3 container.
 	@docker run --rm -v $(PWD):/code -w /code --name fpf_www_flake8 --rm \
-			python:3.9-slim \
+			python:3.9-slim-bookworm \
 			bash -c "pip install -q flake8 && flake8"
 
 .PHONY: check-migrations

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 for python:3.9.16-slim-buster on linux/amd64 as of 2023-06-01
-FROM python:3.9-slim-buster@sha256:6199d5aaae3f33f415501ec9737fad89c147bcc0ce47f2e62d8c59cb4f7f8243
+# sha256 for python:3.9.18-slim-bookworm on linux/amd64 as of 2023-09-15
+FROM python:3.9-slim-bookworm@sha256:44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libpq-dev \
     libssl-dev \
-    netcat \
+    netcat-traditional \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY devops/docker/django-start.sh /usr/local/bin

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -18,8 +18,8 @@ RUN npm install --global gulp-cli
 COPY ./ /src-files
 RUN cd /src-files && ( npm install && npm run build )
 
-# sha256 for python:3.9.16-slim-buster on linux/amd64 as of 2023-06-01
-FROM python:3.9-slim-buster@sha256:6199d5aaae3f33f415501ec9737fad89c147bcc0ce47f2e62d8c59cb4f7f8243
+# sha256 for python:3.9.18-slim-bookworm on linux/amd64 as of 2023-09-15
+FROM python:3.9-slim-bookworm@sha256:44b7f161ed03f85e96d423b9916cdc8cb0509fb970fd643bdbc9896d49e1cad0
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="pressfreedomtracker.us"
 
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libpq-dev \
     libssl-dev \
-    netcat \
+    netcat-traditional \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
## Description

Refs https://github.com/freedomofpress/fpf-www-projects/issues/344

Updates to python 3.9.18 which includes a security update to ssl https://github.com/python/cpython/releases/tag/v3.9.18
Also updates the image to use debian Bookworm instead of debian Buster

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Dependency update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
Build locally and see the python backend codes work and tests pass.
