### PR TITLE
Category API methodology enhancements

### DIFF
--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -21,6 +21,7 @@ from common.choices import CATEGORY_SYMBOL_CHOICES
 from common.models import (
     CategoryPage,
     CategoryIncidentFilter,
+    CategoryMethodologyItem,
     CommonTag,
     CustomImage,
     SimplePage,
@@ -113,6 +114,14 @@ class TaxonomyCategoryPageFactory(factory.django.DjangoModelFactory):
         model = TaxonomyCategoryPage
 
 
+class MethodologyItemFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CategoryMethodologyItem
+
+    label = 'Item Label'
+    description = 'Item Description'
+
+
 class CategoryPageFactory(wagtail_factories.PageFactory):
     class Meta:
         model = CategoryPage
@@ -179,6 +188,8 @@ class CategoryPageFactory(wagtail_factories.PageFactory):
     taxonomy = factory.RelatedFactory(TaxonomyCategoryPageFactory, 'category')
     page_symbol = factory.Iterator(CATEGORY_SYMBOL_CHOICES, getter=lambda c: c[0])
     viz_type = 'none'
+    methodology_item = factory.RelatedFactory(MethodologyItemFactory, 'page')
+    methodology_item2 = factory.RelatedFactory(MethodologyItemFactory, 'page')
 
     @factory.post_generation
     def incident_filters(self, create, extracted, **kwargs):

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -1,8 +1,15 @@
 from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers
+from wagtail.core.rich_text import expand_db_html
 
 from incident import choices
+
+
+class RichTextCharField(serializers.CharField):
+    def to_representation(self, value):
+        representation = super().to_representation(value)
+        return expand_db_html(representation)
 
 
 @extend_schema_field(OpenApiTypes.STR)
@@ -86,7 +93,7 @@ class ItemSerializer(serializers.Serializer):
 class CategorySerializer(serializers.Serializer):
     id = serializers.IntegerField()
     title = serializers.CharField()
-    methodology = serializers.CharField()
+    methodology = RichTextCharField()
     plural_name = serializers.CharField()
     slug = serializers.CharField()
     url = serializers.SerializerMethodField()

--- a/incident/api/serializers.py
+++ b/incident/api/serializers.py
@@ -90,6 +90,11 @@ class ItemSerializer(serializers.Serializer):
     title = serializers.CharField()
 
 
+class MethodologyItemSerializer(serializers.Serializer):
+    label = serializers.CharField()
+    description = serializers.CharField()
+
+
 class CategorySerializer(serializers.Serializer):
     id = serializers.IntegerField()
     title = serializers.CharField()
@@ -97,6 +102,7 @@ class CategorySerializer(serializers.Serializer):
     plural_name = serializers.CharField()
     slug = serializers.CharField()
     url = serializers.SerializerMethodField()
+    methodology_items = MethodologyItemSerializer(many=True)
 
     @extend_schema_field(OpenApiTypes.URI)
     def get_url(self, obj):

--- a/incident/api/tests/test_api.py
+++ b/incident/api/tests/test_api.py
@@ -346,7 +346,13 @@ class CategoryAPITest(APITestCase):
             'slug': self.category.slug,
             'url': self.category.get_full_url(),
             'methodology': self.category.methodology,
-            'plural_name': self.category.plural_name
+            'plural_name': self.category.plural_name,
+            'methodology_items': [
+                {
+                    'label': item.label,
+                    'description': item.description,
+                } for item in self.category.methodology_items.all()
+            ],
         })
         self.assertEqual(response.status_code, 200)
 

--- a/incident/api/tests/test_serializers.py
+++ b/incident/api/tests/test_serializers.py
@@ -17,3 +17,14 @@ class CategorySerializerTest(TestCase):
             self.category.get_full_url(),
             result.data['url']
         )
+
+    def test_resolves_methodology_links_in_html(self):
+        category_with_link = CategoryPageFactory(
+            parent=self.category.get_parent(),
+            methodology=f"""Click <a id="{self.category.pk}" linktype="page">here</a>."""
+        )
+        result = CategorySerializer(category_with_link)
+        self.assertIn(
+            self.category.url,
+            result.data['methodology'],
+        )


### PR DESCRIPTION
## Description

Fixes #1632

This pull request:

1. Adds methodology items to the categories API: these are represented as an array of sub-objects with two keys: label and description, both of which are text fields. E.g.:

```
    {
        "id": 5,
        "title": "Border Stop",
        "methodology_items": [
            {
                "label": "Item 1",
                "description": "Description 1"
            },
            {
                "label": "Item 2",
                "description": "Helpful Description"
            },
            {
                "label": "Item 3",
                "description": "Very helpful description"
            }
        ]
    },  
```
2. Passes the `methodology` field of the categories API through wagtail's rich text processor so that links are correctly rendered into HTML. Previously, links to other wagtail pages were not valid `a` tags.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

1. Locally, load up a category page in the admin.
2. Add some methodology items.
3. Add a link to the methodology to another wagtail page.
4. View the API at http://localhost:8000/api/edge/categories
5. The methodology items should be accurately rendered into the JSON under `methodology_items`
6. The `methodology` field itself should contain a valid hyperlink to the page or pages you chose.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:

- [x] Verify that API responses are correct
- [x] Verify that visualizations using the API endpoints are functional

### If you made changes to incident model metadata

No changes.

### If you made changes to blog

No changes.

### If you made changes to shared templates (e.g. card design, lead media, etc.)

No changes.

### If you made changes to email signup flow

No changes.

### If you made changes to "Submit and Incident" form

No changes.

### If it's a major change

No changes.

### If you made any frontend change

No frontend changes.
