### PR TITLE
Convert category IDs given in query params to category titles

### DIFF
--- a/client/charts/js/components/FilterSidebar.jsx
+++ b/client/charts/js/components/FilterSidebar.jsx
@@ -45,7 +45,7 @@ export default function FilterSidebar({ serializedFilters, initialDataset = null
 		get: (searchParams, prop) => searchParams.get(prop),
 	})
 
-	let initialFilterParams = decode(urlParams)
+	let initialFilterParams = decode(urlParams, filters)
 
 	return (
 		<FiltersIntegration

--- a/client/charts/js/lib/queryString.js
+++ b/client/charts/js/lib/queryString.js
@@ -1,4 +1,32 @@
-function parseDateRange(urlParams, filterName) {
+function parseCategories(urlParams, filterName, filters) {
+	let params = urlParams[filterName]
+	let result
+	// Set-up object with keys as integer ids, values as titles.
+	let categories = Object.fromEntries(filters.filter(({id}) => id > 0).map(
+		({id, title}) => [id, title]
+	))
+
+	if (params) {
+		result = new Set(params.split(',').map((param) => {
+			// +string evaluates to NaN if string is not numeric
+			if (categories[+param]) {
+				return categories[+param]
+			} else {
+				return param
+			}
+		}))
+	} else {
+		result = new Set()
+	}
+
+	return {
+		enabled: true,
+		type: 'stringset',
+		parameters: result,
+	}
+}
+
+function parseDateRange(urlParams, filterName, filters) {
 	let lowerValue = urlParams[`${filterName}_lower`]
 	let upperValue = urlParams[`${filterName}_upper`]
 	return {
@@ -11,7 +39,7 @@ function parseDateRange(urlParams, filterName) {
 	}
 }
 
-function parseString(urlParams, filterName) {
+function parseString(urlParams, filterName, filters) {
 	return {
 		enabled: false,
 		type: 'string',
@@ -19,7 +47,7 @@ function parseString(urlParams, filterName) {
 	}
 }
 
-function parseStringSet(urlParams, filterName) {
+function parseStringSet(urlParams, filterName, filters) {
 	let params = urlParams[filterName]
 	let result
 	if (params) {
@@ -89,13 +117,13 @@ const queryFields = {
 	third_party_in_possession_of_communications: parseString,
 
 	tags: parseStringSet,
-	categories: parseStringSet,
+	categories: parseCategories,
 }
 
-export function decode(searchParams) {
+export function decode(searchParams, filters) {
 	let r = {}
 	for (const [filterName, parseFn] of Object.entries(queryFields)) {
-		r[filterName] = parseFn(searchParams, filterName)
+		r[filterName] = parseFn(searchParams, filterName, filters)
 	}
 	return r
 }


### PR DESCRIPTION
## Description

Part of #1741 and #1742

Adds code to the sidebar filter component on the database page to handle numeric category IDs given in the `categories` key in the querystring. I have not updated the filter summary component (aka the yellow chips) at all.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

When loading the database page, passing a category page's numeric ID in the querystring should function identically to passing its title. For example: http://localhost:8000/all-incidents/?categories=13 should cause the filter sidebar to exhibit exactly the same behavior as http://localhost:8000/all-incidents/?categories=Chilling%20Statement (if the Chilling Statement category has ID 13)

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:

No changes.

### If you made changes to incident model metadata

No changes.

### If you made changes to blog

No changes.

### If you made changes to shared templates (e.g. card design, lead media, etc.)

No changes.

### If you made changes to email signup flow

No changes.

### If you made changes to "Submit and Incident" form

No changes.

### If it's a major change

No changes.

### If you made any frontend change

Here's the change (it's basically the sidebar but it has data displaying instead of not displaying):

![image](https://github.com/freedomofpress/pressfreedomtracker.us/assets/561931/8efd99d5-ab88-41ce-9a2e-9c8987f8d90f)

