### PR TITLE
Remove vullnerability audit checks from PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,6 @@ jobs:
     working_directory: ~/tracker
     steps:
       - checkout
-      - check-changed-files-or-halt:
-          pattern: ^package-lock.json$
-
       - run:
           name: Upgrade NPM to consistent version with dev environment
           command: sudo npm install --location=global npm@9.6.7
@@ -198,8 +195,16 @@ workflows:
   version: 2
   tracker_ci:
     jobs:
-      - safety_check
-      - npm_audit
+      - safety_check:
+          filters:
+            branches:
+              only:
+                - develop
+      - npm_audit:
+          filters:
+            branches:
+              only:
+                - develop
       - lint
       - dev
       - prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     docker:
-      - image: cimg/node:18.16
+      - image: cimg/node:20.7
     working_directory: ~/tracker
     steps:
       - checkout
@@ -60,7 +60,7 @@ jobs:
 
       - run:
           name: Upgrade NPM to consistent version with dev environment
-          command: sudo npm install --location=global npm@9.6.4
+          command: sudo npm install --location=global npm@9.6.7
 
       - run:
           name: Obtain misc resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,18 +35,6 @@ jobs:
           name: Check Python dependencies for CVEs
           command: make safety
 
-      - run:
-          name: Update bandit to the latest version
-          command: pip install --upgrade bandit
-
-      - run:
-          name: Static code analysis for vulnerabilities
-          command: ./scripts/bandit
-
-      - run:
-          name: Run flake8 tests
-          command: flake8
-
   npm_audit:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
@@ -85,10 +73,27 @@ jobs:
             make dev-init
             docker compose up --detach
             while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 5; done;
-            make dev-tests
-            make dev-jest-tests
-            make check-migrations
           no_output_timeout: 5m
+
+      - run:
+          name: Run flake8
+          command: make flake8
+
+      - run:
+          name: Validate migrations
+          command: make check-migrations
+
+      - run:
+          name: Static code analysis for vulnerabilities
+          command: make bandit
+
+      - run:
+          name: Run python tests
+          command: make dev-tests
+
+      - run:
+          name: Run JS tests
+          command: make dev-jest-tests
 
       - store_artifacts:
           path: htmlcov

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -9,3 +9,4 @@ flake8
 ipdb>=0.13.9
 selenium
 colorama<1
+bandit

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,6 +36,10 @@ backcall==0.2.0 \
     --hash=sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e \
     --hash=sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
     # via ipython
+bandit==1.7.5 \
+    --hash=sha256:75665181dc1e0096369112541a056c59d1c5f66f9bb74a8d686c3c362b83f549 \
+    --hash=sha256:bdfc739baa03b880c2d15d0431b31c658ffc348e907fe197e54e0389dd59e11e
+    # via -r dev-requirements.in
 beautifulsoup4==4.9.3 \
     --hash=sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35 \
     --hash=sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25 \
@@ -348,6 +352,14 @@ flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
     # via -r dev-requirements.in
+gitdb==4.0.10 \
+    --hash=sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a \
+    --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7
+    # via gitpython
+gitpython==3.1.36 \
+    --hash=sha256:4bb0c2a6995e85064140d31a33289aa5dce80133a23d36fcd372d716c54d3ebf \
+    --hash=sha256:8d22b5cfefd17c79914226982bb7851d6ade47545b1735a9d010a2a4c26d8388
+    # via bandit
 google-api-core==2.10.1 \
     --hash=sha256:92d17123cfe399b5ef7e026c63babf978d8475e1ac877919eb7933e25dea2273 \
     --hash=sha256:e16c15a11789bc5a3457afb2818a3540a03f341e6e710d7f9bbf6cde2ef4a7c8
@@ -569,6 +581,10 @@ lxml==4.9.1 \
 mailchimp-marketing==3.0.75 \
     --hash=sha256:34ca29268823504ddc873b29724905bab7f8eeb42ddb53f66077a2224cd3f02f
     # via -r requirements.txt
+markdown-it-py==3.0.0 \
+    --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
+    --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
+    # via rich
 markupsafe==2.1.1 \
     --hash=sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003 \
     --hash=sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88 \
@@ -625,6 +641,10 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
     # via flake8
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
+    --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
+    # via markdown-it-py
 openpyxl==3.0.10 \
     --hash=sha256:0ab6d25d01799f97a9464630abacbb34aafecdcaa0ef3cba6d6b3499867d0355 \
     --hash=sha256:e47805627aebcf860edb4edf7987b1309c1b3632f3750538ed962bbcc3bd7449
@@ -645,6 +665,10 @@ parso==0.8.3 \
     --hash=sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0 \
     --hash=sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75
     # via jedi
+pbr==5.11.1 \
+    --hash=sha256:567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b \
+    --hash=sha256:aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3
+    # via stevedore
 pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
     --hash=sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c
@@ -797,6 +821,7 @@ pygments==2.15.1 \
     # via
     #   -r requirements.txt
     #   ipython
+    #   rich
 pyinstrument==4.4.0 \
     --hash=sha256:09167ece8802bc03a63e97536dcefd9c1a340dae686f40914cf995099bc0d0af \
     --hash=sha256:0bbd169b92147ec5d67ed160c300dda504059cfd81e953ed5b059e8ef92bb482 \
@@ -945,6 +970,7 @@ pyyaml==6.0 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via
     #   -r requirements.txt
+    #   bandit
     #   drf-spectacular
 requests==2.31.0 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
@@ -956,6 +982,10 @@ requests==2.31.0 \
     #   google-cloud-storage
     #   mailchimp-marketing
     #   wagtail
+rich==13.5.3 \
+    --hash=sha256:87b43e0543149efa1253f485cd845bb7ee54df16c9617b8a893650ab84b4acb6 \
+    --hash=sha256:9257b468badc3d347e146a4faa268ff229039d4c2d176ab0cffb4c4fbc73d5d9
+    # via bandit
 rsa==4.8 \
     --hash=sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17 \
     --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
@@ -983,6 +1013,10 @@ smartypants==2.0.1 \
     # via
     #   -r requirements.txt
     #   typogrify
+smmap==5.0.1 \
+    --hash=sha256:dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62 \
+    --hash=sha256:e6d8668fa5f93e706934a62d7b4db19c8d9eb8cf2adbb75ef1b675aa332b69da
+    # via gitdb
 sniffio==1.2.0 \
     --hash=sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663 \
     --hash=sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de
@@ -1009,6 +1043,10 @@ stack-data==0.2.0 \
     --hash=sha256:45692d41bd633a9503a5195552df22b583caf16f0b27c4e58c98d88c8b648e12 \
     --hash=sha256:999762f9c3132308789affa03e9271bbbe947bf78311851f4d485d8402ed858e
     # via ipython
+stevedore==5.1.0 \
+    --hash=sha256:8cc040628f3cea5d7128f2e76cf486b2251a4e543c7b938f58d9a377f6694a2d \
+    --hash=sha256:a54534acf9b89bc7ed264807013b505bf07f74dbe4bcfa37d32bd063870b087c
+    # via bandit
 structlog==22.3.0 \
     --hash=sha256:b403f344f902b220648fa9f286a23c0cc5439a5844d271fec40562dbadbc70ad \
     --hash=sha256:e7509391f215e4afb88b1b80fa3ea074be57a5a17d794bd436a5c949da023333

--- a/incident/models/export.py
+++ b/incident/models/export.py
@@ -123,7 +123,7 @@ def _serialize_field(obj, field):
                 val = teaser_image.get_rendition('fill-1330x880').url
     elif field.name == 'slug':
         val = obj.get_full_url()
-    elif type(field) == models.ForeignKey:
+    elif isinstance(field, models.ForeignKey):
         val = getattr(obj, field.name)
         if val:
             val = str(val)


### PR DESCRIPTION
This is intended to stop these from running on non-deployment pull requests, and only trigger them when we are merging from `develop` into `prod`.

## Description

Part of https://github.com/freedomofpress/fpf-www-projects/issues/360

Applies CircleCI filters to the `npm_audit` and `safety_check` jobs so they will only run on the `develop` branch. This is to stop them from running on all PRs except for ones we make to deploy the site from `develop` into `prod`.

I've also done a little housekeeping:
1. Updated the version of node used for the audit check
2. Tried to make the `build_dev` check easier to read by breaking it into multiple steps.
3. Moved `bandit` into the `build_dev` check so it still runs on every PR.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

## Testing

Things to verify about this change:
1. This PR should not have the npm audit or safety check jobs appear on it.
4. After this is merged, the PR to deploy the site again _should_ have those jobs on it.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If it's a major change

No major changes.

### If you made any frontend change

No frontend changes.
