### PR TITLE
Process numeric categories in FilterSummary.jsx

### DIFF
--- a/client/charts/js/components/FilterSummary.jsx
+++ b/client/charts/js/components/FilterSummary.jsx
@@ -15,7 +15,11 @@ const symbolMap = {
 	"Other Incident": "other_incident",
 }
 
-export default function FilterSidebar() {
+export default function FilterSummary({ serializedFilters }) {
+	const categoryFilters = JSON.parse(serializedFilters)
+
+	const idMap = categoryFilters.reduce((acc, val) => ({ ...acc, [val.id]: val.title }), {});
+
 	const searchParams = new URLSearchParams(window.location.search)
 	const {
 		categories: categoriesStr,
@@ -25,7 +29,16 @@ export default function FilterSidebar() {
 		...restFilters
 	} = Object.fromEntries(searchParams)
 
-	const categories = categoriesStr ? categoriesStr.split(',').map(d => d.trim()) : []
+	const categories = [...new Set(
+		(categoriesStr ? categoriesStr.split(',').map(d => d.trim()) : [])
+			.map(category => {
+				if (symbolMap[category]) return category;
+				if (idMap[category]) return idMap[category];
+				return null;
+			})
+			.filter(d => d)
+	)]
+
 	const tags = tagsStr ? tagsStr.split(',').map(d => d.trim()) : []
 
 	const clearFilter = (filterKey, newFilterValue) => {
@@ -50,7 +63,7 @@ export default function FilterSidebar() {
 						className="btn btn-tag"
 						aria-label={`Removes filter: ${category.toLowerCase()}`}
 					>
-						<div className={classNames("category", `category-${symbolMap[category]}`)}></div>
+						{symbolMap[category] && <div className={classNames("category", `category-${symbolMap[category]}`)}></div>}
 						<span>{category.toLowerCase()}</span>
 						<span className="close-icon" />
 					</button>

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -92,7 +92,7 @@
 				</details>
 			</div>
 
-			<div class="incident-index__body-header-filters" id="filter-summary"></div>
+			<div class="incident-index__body-header-filters" id="filter-summary" data-serialized-filters="{{ serialized_filters }}"></div>
 
 			<div class="incident-index__column-header incident-index__column-header--incident">Incident</div>
 			<div class="incident-index__column-header incident-index__column-header--incident-details">Incident Details</div>


### PR DESCRIPTION
## Description

Fixes #1742 
Fixes #1741 

Changes proposed in this pull request:

Similar to #1746, this applies the same logic to the chips used for the filter summary to display the category titles. This similarly reads from the serialized filters to get the ids matched to titles.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

## Testing

Run the application locally, and use [any one](http://localhost:8000/equipment-search-seizure-or-damage/?) of the category pages to follow the [link to the database page](http://localhost:8000/all-incidents/?categories=7). The page should have the proper filter chips at the top with the category title, and the sidebar should be functional.

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made any frontend change
Now, if you go to http://localhost:8000/all-incidents/?categories=Leak+Case%2CChilling+Statement,4

you should see:

![Screenshot 2023-09-22 at 4 51 32 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/b7e1aca9-764f-4587-b03d-b0e8d5a49a6b)


