### PR TITLE
Reorganize node chart-generator Dockerfile, add dev mode to script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:2023.07.2
     working_directory: ~/tracker
     steps:
       - checkout
@@ -114,7 +114,7 @@ jobs:
     environment:
       SETUPTOOLS_USE_DISTUTILS: stdlib
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:2023.07.2
     working_directory: ~/tracker
     steps:
       - checkout

--- a/devops/docker/NodeChartPregeneratorDockerfile
+++ b/devops/docker/NodeChartPregeneratorDockerfile
@@ -1,6 +1,10 @@
 # sha256 as of 2023-09-08
 FROM node:20-alpine@sha256:c843f4a4060246a25f62c80b3d4cf4a6b4c4639cdce421e4f2ee3102257225b4
 
+ARG NPM_VER=9.6.7
+# Upgrade npm to specified version
+RUN npm install npm@${NPM_VER} --location=global
+
 RUN apk add --no-cache paxctl python3 make g++
 RUN paxctl -cm /usr/local/bin/node
 
@@ -19,9 +23,6 @@ RUN chown -R "${USERID}" /opt/chart-pregenerator
 WORKDIR /opt/chart-pregenerator
 USER ${USERID}
 
-ARG NPM_VER=9.6.7
-# Upgrade npm to specified version
-RUN npm install npm@${NPM_VER}
 RUN npm install
 
 COPY devops/docker/node-chart-pregenerator-start.sh /usr/bin/node-chart-pregenerator-start.sh

--- a/devops/docker/NodeChartPregeneratorDockerfile
+++ b/devops/docker/NodeChartPregeneratorDockerfile
@@ -1,7 +1,7 @@
 # sha256 as of 2023-09-08
-FROM node:20-alpine@sha256:c843f4a4060246a25f62c80b3d4cf4a6b4c4639cdce421e4f2ee3102257225b4
+FROM node:20.8.0-alpine@sha256:80cc2c520781c1a4681e59df6791d81a432a6cb3da0c385d8d62e9f16acf8e5f
 
-ARG NPM_VER=9.6.7
+ARG NPM_VER=10.2.0
 # Upgrade npm to specified version
 RUN npm install npm@${NPM_VER} --location=global
 

--- a/devops/docker/NodeChartPregeneratorDockerfile
+++ b/devops/docker/NodeChartPregeneratorDockerfile
@@ -15,7 +15,7 @@ ENV NPM_CONFIG_LOGLEVEL warn
 ARG USERID
 RUN getent passwd "${USERID?USERID must be supplied}" || adduser -D -g "" -u "${USERID}" pft_node
 COPY chart_pregenerator /opt/chart-pregenerator
-RUN chown -R pft_node /opt/chart-pregenerator
+RUN chown -R "${USERID}" /opt/chart-pregenerator
 WORKDIR /opt/chart-pregenerator
 USER ${USERID}
 

--- a/devops/docker/NodeChartPregeneratorDockerfile
+++ b/devops/docker/NodeChartPregeneratorDockerfile
@@ -1,14 +1,6 @@
 # sha256 as of 2023-09-08
 FROM node:20-alpine@sha256:c843f4a4060246a25f62c80b3d4cf4a6b4c4639cdce421e4f2ee3102257225b4
 
-# Make npm output less verbose
-ENV NPM_CONFIG_LOGLEVEL warn
-
-ARG NPM_VER=9.6.7
-
-# Upgrade npm to speicifed version
-RUN npm install npm@${NPM_VER} --location=global
-
 RUN apk add --no-cache paxctl python3 make g++
 RUN paxctl -cm /usr/local/bin/node
 
@@ -17,10 +9,21 @@ RUN apk --no-cache add msttcorefonts-installer fontconfig && \
     update-ms-fonts && \
     fc-cache -f
 
-COPY devops/docker/node-chart-pregenerator-start.sh /usr/bin/node-chart-pregenerator-start.sh
+# Make npm output less verbose
+ENV NPM_CONFIG_LOGLEVEL warn
 
 ARG USERID
 RUN getent passwd "${USERID?USERID must be supplied}" || adduser -D -g "" -u "${USERID}" pft_node
-
+COPY chart_pregenerator /opt/chart-pregenerator
+RUN chown -R pft_node /opt/chart-pregenerator
+WORKDIR /opt/chart-pregenerator
 USER ${USERID}
+
+ARG NPM_VER=9.6.7
+# Upgrade npm to specified version
+RUN npm install npm@${NPM_VER}
+RUN npm install
+
+COPY devops/docker/node-chart-pregenerator-start.sh /usr/bin/node-chart-pregenerator-start.sh
+
 CMD [ "/usr/bin/node-chart-pregenerator-start.sh" ]

--- a/devops/docker/node-chart-pregenerator-start.sh
+++ b/devops/docker/node-chart-pregenerator-start.sh
@@ -2,4 +2,8 @@
 
 set -x
 
-npm install && npm run dev
+if [ "${DEPLOY_ENV}" == "dev" ]; then
+    npm install && npm run dev
+else
+    npm run start
+fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
     environment:
       DJANGO_HOST: app
       PORT: *chart-port
+      DEPLOY_ENV: dev
     ports:
       - target: *chart-port
         published: *chart-port

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       context: .
       dockerfile: devops/docker/NodeChartPregeneratorDockerfile
       args:
-        NPM_VER: 9.6.0
+        NPM_VER: 9.6.7
         USERID: ${UID:?err}
     volumes:
       - ./:/django


### PR DESCRIPTION
## Description

In production, we run containers with readonly root. This means that we do not want to run `npm install` at runtime. However, we still want to do that in development. So, we need something like we do with the Django container, where it can be optionally run in "dev mode" that allows restarting and incrementally installing dependencies. This commit adds that to the script, and changes the Dockerfile somewhat to make it work.

## Type of change

- [ ] Bug fix (sort of... I think this points to a need for infra to better explain what production is)

## Testing

I will deploy this to the experimental cluster for testing. Devs, please test it in development mode (you may want to wipe out your local container and rebuild).

### Post-deployment actions

If this looks good in dev and we merge it into `chart-pregenerator`, I can enable builds for pushes to that branch so that they will automatically deploy, since the container will not crash on startup. Further configuration will be required on that point, but let's get this in first.