### PR TITLE
Replace `CONCAT` function with `||` operator on tsvector types

### DIFF
--- a/incident/tests/test_filtering.py
+++ b/incident/tests/test_filtering.py
@@ -80,6 +80,20 @@ class TestFiltering(TestCase):
 
         self.assertQuerysetEqual(incidents, [incident1])
 
+    def test_should_filter_by_search_text_for_stemmable_proper_noun(self):
+        """If the search query includes a proper name that might be
+        stemmed when converted into a TS-vector by the database,
+        e.g. Noblesteed -> nobleste, the text search filter should
+        still be able to locate a document containing the original
+        proper noun."""
+        body_text = "Garth Noblesteed had previously pleaded guilty on April 14, 2023"
+        incident1 = IncidentPageFactory(
+            title='Target',
+            body=[('rich_text', RichText(body_text))],
+        )
+        incidents = IncidentFilter({'search': 'noblesteed'}).get_queryset()
+        self.assertQuerysetEqual(incidents, [incident1])
+
     def test_should_filter_by_search_text_with_null_characters(self):
         """should filter by search text with null characters."""
         incident1 = IncidentPageFactory(

--- a/incident/utils/incident_filter.py
+++ b/incident/utils/incident_filter.py
@@ -18,12 +18,12 @@ from django.db.models import (
     OuterRef,
     PositiveSmallIntegerField,
     F,
+    Func,
     Q,
     Subquery,
     TextChoices,
     TextField,
 )
-from django.db.models.functions import Concat
 from django.db.models.fields.related import ManyToOneRel
 from django.db.utils import ProgrammingError
 from django.http import QueryDict
@@ -523,9 +523,11 @@ class SearchFilter(Filter):
 
     def filter(self, queryset, value):
         return queryset.annotate(
-            title_and_body_search=Concat(
+            title_and_body_search=Func(
                 F('index_entries__title'),
                 F('index_entries__body'),
+                function='',
+                arg_joiner='||',
             ),
         ).filter(title_and_body_search=SearchQuery(value))
 


### PR DESCRIPTION
## Description

Related to #1751 -- I believe there are still potentially things we might want to do with having different dictionaries process user input. However, it looks like one source of error is in our filtering code, which uses wagtail's search index data. The way it's using that data is not correct: it is concatenating the `title` and `body` columns of the index entry table, but in a way that returns the final result as a text representation, which is _not_ suitable for actually doing a search operation but may actually return a match on some queries (since the text representation contains text fragments of the original document).

Using `CONCAT` on two `tsvector` instances will combine them _as text_, if my reading of the documentation is right. This PR replaces our use of `CONCAT` (which Django provides in its library of DB functions) with directly using the `||` operator (which we kind of have to work around Django's lack of providing an API for this).

From the postgresql documentation:

https://www.postgresql.org/docs/current/functions-string.html#FUNCTIONS-STRING-OTHER

> `concat ( val1 "any" [, val2 "any" [, ...] ] ) → text`
> Concatenates the text representations of all the arguments.

Whereas:

https://www.postgresql.org/docs/current/functions-textsearch.html#TEXTSEARCH-OPERATORS-TABLE

> `tsvector || tsvector → tsvector`
> Concatenates two tsvectors.

The latter is correct for how we're using this operation in the `SearchFilter`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

There is a unit test for this, but you can try it yourself. 

1. Make an incident page that contains the word from #1751 in the page body somewhere: "Milstreed"
2.  Searching for this on `develop` should return nothing: https://pressfreedomtracker.us/all-incidents/?search=milstreed
3. On this branch, the same search should return the page with the word.
4. A search for the mis-spelled name, "Milstred" should _not_ return any results: http://localhost:8000/all-incidents/?search=milstred

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:

- [x] Verify that API responses are correct
- [x] Verify that visualizations using the API endpoints are functional

