### PR TITLE
Docker compose health checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,7 @@ jobs:
           name: Ensure we can run dev-env
           command: |
             make dev-init
-            docker compose up --detach
-            while ! curl --output /dev/null --silent --head --fail http://localhost:8000; do sleep 5; done;
+            docker compose up --wait
           no_output_timeout: 5m
 
       - run:

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -10,11 +10,11 @@ RUN apt-get update && apt-get install -y \
     netcat-traditional \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY devops/docker/django-start.sh /usr/local/bin
-RUN  chmod +x /usr/local/bin/django-start.sh
-
 COPY dev-requirements.txt /requirements.txt
 RUN pip install --no-deps --require-hashes -r /requirements.txt
+
+COPY devops/docker/django-start.sh /usr/local/bin
+RUN  chmod +x /usr/local/bin/django-start.sh
 
 ARG USERID
 RUN getent passwd "${USERID?USERID must be supplied}" || adduser --uid "${USERID}" --disabled-password --gecos "" gcorn

--- a/devops/docker/NodeDockerfile
+++ b/devops/docker/NodeDockerfile
@@ -9,7 +9,7 @@ ARG NPM_VER=9.6.7
 # Upgrade npm to speicifed version
 RUN npm install npm@${NPM_VER} --location=global
 
-RUN apk add --no-cache paxctl python3 make g++
+RUN apk add --no-cache paxctl python3 make g++ jq
 RUN paxctl -cm /usr/local/bin/node
 
 COPY devops/docker/node-start.sh /usr/bin/node-start.sh

--- a/devops/docker/django-start.sh
+++ b/devops/docker/django-start.sh
@@ -2,26 +2,6 @@
 # Container entrypoint script for Django applications.
 set -e
 
-
-wait_for_node() {
-    if [ "${DEPLOY_ENV}" == "dev" ]; then
-        echo "Waiting for node to start..."
-        while [ ! -f .node_complete ]
-        do
-            sleep 2
-        done
-        rm -v .node_complete
-    fi
-}
-
-wait_for_postgres() {
-    echo "Waiting for postgres to start..."
-    until nc -z "${DJANGO_DB_HOST}" "${DJANGO_DB_PORT}"
-    do
-        sleep 2
-    done
-}
-
 django_start() {
     ./manage.py migrate
     if [ "${DJANGO_COLLECT_STATIC}" == "yes" ]; then
@@ -38,6 +18,4 @@ django_start() {
     fi
 }
 
-wait_for_postgres
-wait_for_node
 django_start

--- a/devops/docker/node-start.sh
+++ b/devops/docker/node-start.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
 #
-# Start installing node dependencies and leave downstream containers
-# a file to poll when we are ready to go
+# Start installing node dependencies
 
 set -x
 
 npm install && \
-    touch .node_complete && \
     npm run start

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,8 +63,10 @@ services:
       args:
         USERID: ${UID:?err}
     depends_on:
-      - node
-      - postgresql
+      node:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
     environment:
       DJANGO_CREATEDEVDATA: "${DJANGO_CREATEDEVDATA:-no}"
       DJANGO_DB_PASSWORD: trackerpassword

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,11 @@ services:
       POSTGRES_USER: tracker
       POSTGRES_DB: trackerdb
     user: postgres
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-U", "tracker", "--dbname", "trackerdb"]
+      timeout: 45s
+      interval: 10s
+      retries: 10
     networks:
       app:
         aliases:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,10 @@ services:
       - ./:/django
     working_dir: /django
     user: ${UID:?err}
+    healthcheck:
+      test: jq '.status' webpack-stats.json |grep -q -e compiling -e error -e done
+      interval: 10s
+      start_period: 1m30s
     networks:
       - app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,6 +67,12 @@ services:
         condition: service_healthy
       postgresql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8000/health/ok/?monitor"]
+      start_period: 10s
+      interval: 30s
+      timeout: 20s
+      retries: 4
     environment:
       DJANGO_CREATEDEVDATA: "${DJANGO_CREATEDEVDATA:-no}"
       DJANGO_DB_PASSWORD: trackerpassword

--- a/tracker/settings/dev.py
+++ b/tracker/settings/dev.py
@@ -36,13 +36,27 @@ structlog.configure(
     cache_logger_on_first_use=cache_logger,
 )
 
+
+def silence_monitoring(record):
+    if 'GET /health/ok/?monitor' in record.getMessage():
+        return False
+    return True
+
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "silence_monitoring": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": silence_monitoring,
+        },
+    },
     "handlers": {
         "normal": {
             "class": "logging.StreamHandler",
             "formatter": "plain_console",
+            "filters": ["silence_monitoring"],
         },
         "null": {
             "class": "logging.NullHandler"


### PR DESCRIPTION
## Description

Adds docker health checks for development containers.

This allows us to remove:

1. The use of the `.node_complete` file as a way of signaling to other containers.
2. Potential race conditions between webpack compilations and Django's attempting to look for the `webpack-stats.json` file
3. The explicit use of `ping` in CI jobs to wait for the Django container to be ready.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

This PR should "just work" in that `docker compose up` and its variants all still bring the docker system up, and without the need for intermediate files or anything else mentioned in the description.

### Post-deployment actions

None

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

