### PR TITLE
Fix category page chart with zero incidents in a year

### DIFF
--- a/client/charts/js/lib/utilities.js
+++ b/client/charts/js/lib/utilities.js
@@ -193,15 +193,21 @@ export function groupByMonthSorted(dataset, isLastSixMonths, currentDate) {
 }
 
 export function groupByYearsSorted(dataset) {
-	const datasetGroupedByYear = d3
+	const yearsGrouped = d3
 		.groups(
 			dataset.map((d) => ({ year: d.date.getUTCFullYear() })),
 			(d) => d.year
-		)
+		);
+	// We get all the years so that we don't skip years with 0 incidents
+	const yearsExtent = d3.extent(yearsGrouped, d => d[0])
+	const yearsGroupedMapped = Object.fromEntries(yearsGrouped)
+	const allYearsGrouped = d3.range(yearsExtent[0], yearsExtent[1] + 1)
+		.map(year => [year, yearsGroupedMapped[year] || []])
+
+	const datasetGroupedByYear = allYearsGrouped
 		.map((d) => ({ year: d[0], numberOfIncidents: d[1].length }))
 
-	const datasetGroupedByYearSorted = datasetGroupedByYear.sort((a, b) => a.year - b.year)
-	return datasetGroupedByYearSorted
+	return datasetGroupedByYear.sort((a, b) => a.year - b.year)
 }
 
 export function groupByCity(dataset) {

--- a/client/charts/js/tests/utilities.test.js
+++ b/client/charts/js/tests/utilities.test.js
@@ -10,7 +10,7 @@ import {
 	groupByCity,
 	groupByState,
 	countIncidentsOutsideUS,
-	rangeInclusive,
+	rangeInclusive, groupByYearsSorted,
 } from '../lib/utilities'
 
 describe(filterDatasetByTag, () => {
@@ -455,6 +455,27 @@ describe(groupByMonthSorted, () => {
 			{ month: 11, monthName: 'Dec', numberOfIncidents: 0 },
 			{ month: 0, monthName: 'Jan', numberOfIncidents: 0 },
 			{ month: 1, monthName: 'Feb', numberOfIncidents: 0 },
+		])
+	})
+})
+
+describe(groupByYearsSorted, () => {
+	test('groupByYearsSorted test', () => {
+		expect(
+			groupByYearsSorted(
+				[
+					{ date: new Date(Date.UTC(2019, 0, 1)) },
+					{ date: new Date(Date.UTC(2023, 1, 1)) },
+					{ date: new Date(Date.UTC(2024, 2, 1)) },
+				],
+			)
+		).toEqual([
+			{ year: 2019, numberOfIncidents: 1 },
+			{ year: 2020, numberOfIncidents: 0 },
+			{ year: 2021, numberOfIncidents: 0 },
+			{ year: 2022, numberOfIncidents: 0 },
+			{ year: 2023, numberOfIncidents: 1 },
+			{ year: 2024, numberOfIncidents: 1 },
 		])
 	})
 })


### PR DESCRIPTION
## Description

Fixes #1567 

Changes proposed in this pull request:

Adds logic to explicitly add `numberOfIncidents = 0` on years where there are no incidents.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

To test, add an incident far into the past, say in 2017, and make sure that the page for that category has the chart visualization enabled. Then, on that category page you should see the year with no bar.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

![Screenshot 2023-10-11 at 3 18 11 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/ee9d923f-fcac-43f7-ac6c-cab2f1acfc30)

