### PR TITLE
Fix possible image attribution variables

### DIFF
--- a/blog/tests/test_page.py
+++ b/blog/tests/test_page.py
@@ -1,3 +1,4 @@
+import wagtail.blocks
 from wagtail.models import Site, Page
 from django.test import TestCase, Client
 
@@ -95,6 +96,21 @@ class TestPages(TestCase):
         org = OrganizationPageFactory()
         response = self.client.get(f'/all-blogs/?organization={org.pk}')
         self.assertNotContains(response, 'Featured')
+
+    def test_get_blog_page_contains_lead_graphic_image_attribution(self):
+        image = CustomImageFactory()
+        self.blog_page.lead_graphic = wagtail.blocks.StreamValue(
+            stream_block=self.blog_page.lead_graphic.stream_block,
+            stream_data=[('image', image)],
+        )
+        self.blog_page.save()
+        expected_attribution = image.attribution
+        response = self.client.get(self.blog_page.url)
+        self.assertContains(
+            response,
+            f'<span class="media-attribution"> — {expected_attribution}</span>',
+            html=True,
+        )
 
     def test_get_blog_page_vertical_bar_chart_additional_js_media(self):
         response = self.client.get(self.blog_page.url)

--- a/common/templates/common/_video_or_image.html
+++ b/common/templates/common/_video_or_image.html
@@ -20,14 +20,14 @@
 					{% image image width-910 alt=image.attribution|default:image.title %}
 				{% endif %}
 				{% if caption or image.attribution %}
-						<figcaption class="media-caption">
-				<div class="rich-text">{{ caption|richtext }}</div>
-				{% if image.attribution %}
-					<span
-						class="media-attribution"
-					> — {{ image.attribution }}</span>
-				{% endif %}
-			</figcaption>
+					<figcaption class="media-caption">
+						<div class="rich-text">{{ caption|richtext }}</div>
+						{% if image.attribution %}
+							<span
+								class="media-attribution"
+							> — {{ image.attribution }}</span>
+						{% endif %}
+					</figcaption>
 				{% endif %}
 		</figure>
 {% endif %}

--- a/common/templates/common/_video_or_image.html
+++ b/common/templates/common/_video_or_image.html
@@ -19,13 +19,14 @@
 				{% elif image %}
 					{% image image width-910 alt=image.attribution|default:image.title %}
 				{% endif %}
-				{% if caption or image.attribution %}
+				{% firstof image.attribution image.0.value.attribution as attribution %}
+				{% if caption or attribution %}
 					<figcaption class="media-caption">
 						<div class="rich-text">{{ caption|richtext }}</div>
-						{% if image.attribution %}
+						{% if attribution %}
 							<span
 								class="media-attribution"
-							> — {{ image.attribution }}</span>
+							> — {{ attribution }}</span>
 						{% endif %}
 					</figcaption>
 				{% endif %}

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -1370,6 +1370,21 @@ class TestTopicPage(WagtailPageTestCase):
             [incident2, incident1]
         )
 
+    def test_topic_page_photo_attribution(self):
+        topic_page = TopicPageFactory(
+            parent=self.home_page,
+            incident_index_page=self.index_page,
+        )
+
+        topic_page.photo = CustomImageFactory()
+        topic_page.save()
+        response = self.client.get(topic_page.url)
+        self.assertContains(
+            response,
+            f'<span class="media-attribution"> — {topic_page.photo.attribution}</span>',
+            html=True,
+        )
+
 
 class IncidentPageQueriesTest(TestCase):
     @classmethod


### PR DESCRIPTION
## Description

This PR updates the "video or image" template to check for the attribution field on both possible data types that might be passed into this template: an Image object and a StreamField object (with an image as its first element).

I've added some tests for both uses of this template using Topic Page and Blog Page as examples.

Fixes #1768

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
Image attributions should render on:
1. Blog pages with an image as their lead graphic
2. Topic pages using the `photo` field
3. Incident pages using the `teaser_image` field.

### Post-deployment actions
None 

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:
No changes
### If you made changes to incident model metadata
No changes.
### If you made changes to blog

- [x] Verify that the blog index page renders correctly
- [x] Verify that the individual blogs show all the informations correctly

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [ ] Verify that it renders correctly in homepage, if applicable
- [ ] Verify that it renders correctly in incident index page, if applicable
- [x] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [x] Verify that it renders correctly in individual blog page, if applicable
- [x] Verify that it renders correctly in topic page, if applicable

Not applicable to unchecked pages.

### If you made changes to email signup flow
No changes.
### If you made changes to "Submit an Incident" form
No changes.
### If it's a major change
No changes.
### If you made any frontend change

Example of this bug being fixed:

![image](https://github.com/freedomofpress/pressfreedomtracker.us/assets/561931/b7cab709-1977-42f8-a196-4eb0b75d55c0)

Not much to see, actually, this change is not primarily visual.