### PR TITLE
Adds robots.txt and sitemap.xml

### DIFF
--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -3,6 +3,7 @@ import hashlib
 from bs4 import BeautifulSoup
 from django import template
 from django.core.cache import cache
+from django.urls import reverse
 from django.utils.html import mark_safe
 from wagtail.templatetags.wagtailcore_tags import richtext
 
@@ -59,6 +60,13 @@ def richtext_aside(value):
     # Setting cache for 1 hour
     cache.set(cache_key, aside_html, 3600)
     return aside_html
+
+
+@register.simple_tag(takes_context=True)
+def get_absolute_url(context, view_name, *args, **kwargs):
+    return context['request'].build_absolute_uri(
+        reverse(view_name, args=args, kwargs=kwargs)
+    )
 
 
 @register.simple_tag

--- a/common/tests/test_frontend_cache_purge.py
+++ b/common/tests/test_frontend_cache_purge.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from django.test import TestCase, Client
 from unittest.mock import patch
 from wagtail.models import Site, Page
@@ -73,6 +74,15 @@ class TestCategoryPageCacheInvalidation(TestCase):
 
         list_of_arguments = purge_tags_from_cache.call_args[0][0]
         self.assertIn(self.categorypage.get_cache_tag(), list_of_arguments)
+
+    @patch('common.signals.purge_url_from_cache')
+    def test_cache_sitemap_purge_on_new_incident(self, purge_url_from_cache):
+        self.assertFalse(purge_url_from_cache.called)
+
+        # should trigger a cache purge on category page
+        IncidentPageFactory().save_revision().publish()
+
+        purge_url_from_cache.assert_called_with(reverse('sitemap'))
 
     def test_should_purge_all_cache_when_settings_changed(self):
         """Changing any Setting should purge the entire zone.

--- a/common/tests/test_template_tags.py
+++ b/common/tests/test_template_tags.py
@@ -9,6 +9,7 @@ from common.templatetags.common_tags import (
     add_as_string,
     richtext_aside,
     query_transform,
+    get_absolute_url,
 )
 
 
@@ -108,3 +109,11 @@ class TestTemplateTags(TestCase):
         qd = QueryDict(result)
         self.assertEqual(qd['page'], '1')
         self.assertEqual(qd['sort'], 'title')
+
+    def test_get_absolute_url(self):
+        request = RequestFactory().get('/')
+        context = {'request': request}
+
+        result = get_absolute_url(context, 'sitemap')
+
+        self.assertEqual(result, 'http://testserver/sitemap.xml')

--- a/common/tests/test_template_tags.py
+++ b/common/tests/test_template_tags.py
@@ -116,4 +116,4 @@ class TestTemplateTags(TestCase):
 
         result = get_absolute_url(context, 'sitemap')
 
-        self.assertEqual(result, 'http://testserver/sitemap.xml')
+        self.assertEqual(result, f'http://{request.get_host()}/sitemap.xml')

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -83,6 +83,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sitemaps',
     'rest_framework',
     'drf_spectacular',
     'drf_spectacular_sidecar',

--- a/tracker/templates/robots.txt
+++ b/tracker/templates/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Disallow: /all-incidents/?*
 Allow: /all-incidents/?page=*
+
+Sitemap: https://pressfreedomtracker.us/sitemap.xml

--- a/tracker/templates/robots.txt
+++ b/tracker/templates/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /all-incidents/?*
+Allow: /all-incidents/?page=*

--- a/tracker/templates/robots.txt
+++ b/tracker/templates/robots.txt
@@ -1,6 +1,7 @@
+{% load common_tags %}
 User-agent: *
 Disallow: /all-incidents/?*
 Allow: /all-incidents/?page=*
 Crawl-delay: 10
 
-Sitemap: https://pressfreedomtracker.us/sitemap.xml
+Sitemap: {% get_absolute_url 'sitemap' %}

--- a/tracker/templates/robots.txt
+++ b/tracker/templates/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /all-incidents/?*
 Allow: /all-incidents/?page=*
+Crawl-delay: 10
 
 Sitemap: https://pressfreedomtracker.us/sitemap.xml

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.conf import settings
 from django.urls import include, path, re_path
 from django.contrib import admin
+from django.views.generic import TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 from wagtailautocomplete.urls.admin import urlpatterns as autocomplete_admin_urls
 
@@ -29,6 +30,7 @@ urlpatterns = [
     path('health/ok/', common_views.health_ok),
     path('health/version/', common_views.health_version),
     path('csrf/', common_views.get_csrf_token, name='csrf_token'),
+    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     path(
         'subscribe_for_site/',
         common_views.SubscribeForSite.as_view(),

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -14,6 +14,7 @@ from emails import urls as emails_urls
 from incident.api.urls import urlpatterns as api_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail import urls as wagtail_urls
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
 
 
@@ -30,6 +31,7 @@ urlpatterns = [
     path('health/ok/', common_views.health_ok),
     path('health/version/', common_views.health_version),
     path('csrf/', common_views.get_csrf_token, name='csrf_token'),
+    path('sitemap.xml', sitemap),
     path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     path(
         'subscribe_for_site/',

--- a/tracker/urls.py
+++ b/tracker/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path('health/ok/', common_views.health_ok),
     path('health/version/', common_views.health_version),
     path('csrf/', common_views.get_csrf_token, name='csrf_token'),
-    path('sitemap.xml', sitemap),
+    path('sitemap.xml', sitemap, name='sitemap'),
     path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     path(
         'subscribe_for_site/',


### PR DESCRIPTION
## Description

Fixes #1761.

Changes proposed in this pull request:
Adds a robots.txt which disallows all bots access to `/all-incidents/?*` but allows `/all-incidents/?page=*`. Also adds a sitemap.xml and adds the sitemap link to robots.txt. A sitemap lets the crawlers know which pages to crawl (which helps search engines know about different pages) and also addresses [WCAG SC 2.4.5](https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways)

PS: Not all crawlers follow robots.txt fully, so this PR might not fully solve the issue of being crawled.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
- Check `/robots.txt` shows the content  that it should.
- Check `/sitemap.xml` shows the sitemap correctly.
