### PR TITLE
Fix vertical bar charts when incident has no tags

### DIFF
--- a/client/charts/js/components/IncidentsTimeBarChart.jsx
+++ b/client/charts/js/components/IncidentsTimeBarChart.jsx
@@ -38,7 +38,7 @@ export default function IncidentsTimeBarChart({
 
 		if (groupByTag) {
 			// if groupByTag is set, that means we are filtering a tag
-			if (d.tags.indexOf(groupByTag) >= 0) {
+			if (d.tags?.indexOf(groupByTag) >= 0) {
 				dateData[groupByTag] = dateData[groupByTag] ? dateData[groupByTag] + 1 : 1
 			} else {
 				const notBranchFieldName = `not ${groupByTag}`;


### PR DESCRIPTION
## Description

Fixes https://freedomofpress.slack.com/archives/C05DGNV886R/p1698088793401849 for when there are incidents with no tags, `tags = null` which causes problems with the group by tag logic.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

- To test, check out this branch and edit an incident by removing all of the tags.
- Go to a blog page and create a vertical bar chart that is grouped by tag.
- Ensure that the vertical bar chart still shows up.
