### PR TITLE
Ensure at least some incidents do not have tags in dev data

### DIFF
--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -1,4 +1,5 @@
 import json
+import math
 import random
 import requests
 import time
@@ -413,7 +414,7 @@ class Command(BaseCommand):
                     MultimediaIncidentPageFactory(
                         parent=incident_index_page,
                         categories=category_pages,
-                        tags=0,
+                        tags=None,
                         **kwargs,
                     )
                 number_created += 1
@@ -451,7 +452,11 @@ class Command(BaseCommand):
             ['tarsier', 'lemur', 'loris', 'baboon'],
         ]
         cat_map = {}
-        for incident in IncidentPage.objects.all():
+
+        # Ensure a certain percentage of incidents do not have any
+        # tags applied.
+        num_untagged = math.ceil(number_created / 5)
+        for incident in IncidentPage.objects.all()[num_untagged:]:
             incident.tags.clear()
             cat_ids = [x.category_id for x in incident.categories.all()]
             for cat_id in cat_ids:
@@ -469,10 +474,11 @@ class Command(BaseCommand):
             incident_tag__title='Important Animals',
         )
         tag = topic_page.incident_tag
+        all_tagged_incidents = IncidentPage.objects.exclude(tags=None)
         tag.tagged_items.add(
             *random.sample(
-                list(IncidentPage.objects.all()),
-                min(20, options['max_incidents']),
+                list(all_tagged_incidents),
+                min(20, len(all_tagged_incidents)),
             )
         )
 


### PR DESCRIPTION
## Description

With this change, around 20% of the incidents created with the command `createdevdata` will not have any tags. The reason for doing this is to have the dev data not lose this characteristic of the production dataset.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

To test this, you can reset your development database and re-run `createdevdata`. Around 20% of the created incidents should have no tags.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

