### PR TITLE
Updates name for actor field in equipment damage

### DIFF
--- a/incident/models/category_fields.py
+++ b/incident/models/category_fields.py
@@ -49,7 +49,7 @@ CATEGORY_FIELD_MAP = {
     ],
     'equipment-damage': [
         ('equipment_broken', 'Equipment Broken'),
-        ('actor', 'Actor who seized equipment'),
+        ('actor', 'Actor'),
     ],
     'equipment-search-seizure-or-damage': [
         ('equipment_seized', 'Equipment Seized'),


### PR DESCRIPTION
## Description

Request from @stephaniesugars on slack:
> the "actor" field on equipment damage currently displays as "actor who seized equipment" (which is why we stopped using it for the ED category in the first place). Can you change it to just read "Actor"?

This PR addresses the above request.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
- Update an incident to have `equipment-damage` category
- Add an actor field
- Check that the metadata table shows "Actor" instead of "Actor who seized equipment"

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
