### PR TITLE
Add line for special blog post to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,6 +59,7 @@ In case this PR needs any admin changes or run a management command after deploy
 - [ ] Verify that it renders correctly in individual incident page, if applicable
 - [ ] Verify that it renders correctly in blog index page, if applicable
 - [ ] Verify that it renders correctly in individual blog page, if applicable
+- [ ] Verify that it renders correctly in individual special blog page, if applicable
 
 ### If you made changes to email signup flow
 


### PR DESCRIPTION
## Description

Adds a line for special blog post in the pr template.

Changes proposed in this pull request:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

