### PR TITLE
Fix category page bar chart tooltip label

### DIFF
--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -156,7 +156,7 @@ export default function BarChart({
 						content={
 							<div style={{ fontFamily: 'var(--font-base)', fontSize: 12, fontWeight: 500 }}>
 								<div>Number of{
-									(hoveredElement?.y && hoveredElement?.y !== 'count') ? ` ${hoveredElement.y.replace('Incident', '')}` : ''
+									(hoveredElement?.y && hoveredElement?.y !== 'count' && hoveredElement?.y !== 'numberOfIncidents') ? ` ${hoveredElement.y.replace('Incident', '')}` : ''
 								} Incidents</div>
 								<div
 									style={{


### PR DESCRIPTION
## Description

Fixes #1798 

Fixes the incorrect label in bar charts on the category page.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

- Run this branch locally
- In a category page, make sure the `Viz type` is set to bar chart
- Go to the bar chart page and hover over the bars, make sure that the tooltip says "Number of Incidents"

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

![Screenshot 2023-11-22 at 11 21 47 AM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/eac71b8f-2f2b-4982-b07c-2f92c82b0d46)

