### PR TITLE
Adjust frequent tags

### DIFF
--- a/client/charts/js/components/HomepageSelection.jsx
+++ b/client/charts/js/components/HomepageSelection.jsx
@@ -9,8 +9,13 @@ import {
 	filterDatasetByFiltersApplied,
 } from '../lib/utilities.js'
 
-export function chooseMostFrequentTags(dataset, numberOfTags) {
-	const tags = dataset.map((d) => d.tags).filter((d) => d !== null)
+export function chooseTrendingTags(dataset, numberOfTags) {
+	const currentDate = new Date();
+	const filterStartDate = (new Date()).setFullYear(currentDate.getFullYear() - 1);
+	const tags = dataset
+		.filter(({ date }) => date >= filterStartDate)
+		.map((d) => d.tags)
+		.filter((d) => d !== null)
 
 	// Any incident having multiple tags is counted once per category
 	const tagsSimplified = tags.flatMap((d) => d.split(',').map((e) => e.trim()))
@@ -32,7 +37,7 @@ export function chooseMostFrequentTags(dataset, numberOfTags) {
 export default function HomepageSelection({
 	data: originalDataset,
 	numberOfTags = 5,
-	selectedTags = chooseMostFrequentTags(originalDataset, numberOfTags),
+	selectedTags = chooseTrendingTags(originalDataset, numberOfTags),
 	currentDate = new Date(),
 	filtersApplied,
 	setFiltersApplied,

--- a/client/common/js/components/Search.jsx
+++ b/client/common/js/components/Search.jsx
@@ -2,7 +2,7 @@
 import React, { useState, createRef } from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import { chooseMostFrequentTags } from '../../../charts/js/components/HomepageSelection'
+import { chooseTrendingTags } from '../../../charts/js/components/HomepageSelection'
 
 const numberOfTags = 4
 
@@ -12,7 +12,7 @@ export default function Search({ data = [], selectedTags = [] }) {
 	const [searchText, setSearchText] = useState('')
 
 	const frequentTags = (selectedTags && selectedTags.length)
-		? selectedTags : chooseMostFrequentTags(data, numberOfTags)
+		? selectedTags : chooseTrendingTags(data, numberOfTags)
 	const inputRef = createRef()
 
 	const updateSelectedTag = (tag) => () => {

--- a/client/common/js/components/Search.jsx
+++ b/client/common/js/components/Search.jsx
@@ -6,12 +6,13 @@ import { chooseMostFrequentTags } from '../../../charts/js/components/HomepageSe
 
 const numberOfTags = 4
 
-export default function Search({ data = [] }) {
+export default function Search({ data = [], selectedTags = [] }) {
 	const [searchActive, setSearchActive] = useState(false)
 	const [selectedTag, setSelectedTag] = useState()
 	const [searchText, setSearchText] = useState('')
 
-	const frequentTags = chooseMostFrequentTags(data, numberOfTags)
+	const frequentTags = (selectedTags && selectedTags.length)
+		? selectedTags : chooseMostFrequentTags(data, numberOfTags)
 	const inputRef = createRef()
 
 	const updateSelectedTag = (tag) => () => {
@@ -110,7 +111,7 @@ export default function Search({ data = [] }) {
 
 			{searchActive && !selectedTag && !searchText && !!frequentTags.length && (
 				<div className="search-dropdown" id="search-dropdown" role="listbox">
-					<ul className="search-dropdown--header">Trending Topics</ul>
+					<ul className="search-dropdown--header">{(selectedTags && selectedTags.length) ? 'Trending Topics' : 'Frequently Used Tags'}</ul>
 					{frequentTags.map((tag, i) => (
 						<li
 							id={`smart-search-form-${i}`}
@@ -139,8 +140,11 @@ export default function Search({ data = [] }) {
 Search.propTypes = {
 	// eslint-disable-next-line react/forbid-prop-types
 	data: PropTypes.array,
+	// eslint-disable-next-line react/forbid-prop-types
+	selectedTags: PropTypes.array,
 }
 
 Search.defaultProps = {
 	data: [],
+	selectedTags: [],
 }

--- a/client/common/js/search-bar.js
+++ b/client/common/js/search-bar.js
@@ -24,6 +24,8 @@ function engageSearchBars() {
 	const searchBars = document.querySelectorAll('.search-bar')
 
 	searchBars.forEach((searchBarNode) => {
+		const selectedTags = searchBarNode.dataset.tags ? JSON.parse(searchBarNode.dataset.tags) : []
+
 		const root = createRoot(searchBarNode)
 		root.render((
 			<DataLoader
@@ -31,7 +33,7 @@ function engageSearchBars() {
 				dataKey={['data']}
 				loadingComponent={false}
 			>
-				<Search />
+				<Search selectedTags={selectedTags} />
 			</DataLoader>
 		))
 	})

--- a/incident/templates/incident/_search_bar.html
+++ b/incident/templates/incident/_search_bar.html
@@ -1,4 +1,7 @@
-<div class="search-bar">
+<div
+	class="search-bar"
+	data-tags="{{ data_viz_tags_json|escape }}"
+>
 	<form class="search-form" method="GET" action="{{ action }}">
 		<label for="primary-search-bar" class="sr-only">
 			Search incidents by text


### PR DESCRIPTION
## Description

Fixes #1801

Sets the homepage to the tags specified in the admin, and the search page to be the tags that are most frequently used.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

## Testing

Run the app locally, and double check http://localhost:8000/ and http://localhost:8000/all-incidents/ to make sure that the suggested tags in the search bars are correct.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [x] Verify that it renders correctly in incident index page, if applicable
- [x] Verify that it renders correctly in individual incident page, if applicable
- [x] Verify that it renders correctly in blog index page, if applicable
- [x] Verify that it renders correctly in individual blog page, if applicable
- [x] Verify that it renders correctly in individual special blog page, if applicable


### If you made any frontend change
![Screenshot 2023-11-28 at 7 15 14 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/ef139305-7e07-48d4-a84f-d1c980fe7be9)


![Screenshot 2023-11-28 at 7 15 03 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/f42fe6de-7356-4e48-a417-041ea4bece52)
