### PR TITLE
Use consistent text for "Search incidents" to avoid flicker

### DIFF
--- a/incident/templates/incident/_search_bar.html
+++ b/incident/templates/incident/_search_bar.html
@@ -8,7 +8,7 @@
 		</label>
 		<input
 			id="primary-search-bar"
-			placeholder="{{ placeholder_text|default:"Search incidents by text" }}"
+			placeholder="{{ placeholder_text|default:"Search incidents" }}"
 			spellcheck="false"
 			autocomplete="off"
 			type="search"

--- a/incident/templates/incident/incident_index_page.html
+++ b/incident/templates/incident/incident_index_page.html
@@ -17,7 +17,7 @@
 
 	<section class="incident-index__search-area">
 		<div class="incident-index__search-bar">
-			{% include 'incident/_search_bar.html' with placeholder_text="Search incidents by text" action=current_page_url value=search_value %}
+			{% include 'incident/_search_bar.html' with placeholder_text="Search incidents" action=current_page_url value=search_value %}
 		</div>
 		<div class="incident-index__download">
 			<details class="incident-index__download-details">


### PR DESCRIPTION
## Description

Fixes #1806

Changes proposed in this pull request:

## Type of change

- [x] Bug fix

## Testing

Confirm that text no longer flashes on https://pressfreedomtracker.us/ or https://pressfreedomtracker.us/all-incidents/

### Post-deployment actions

Same.

## Checklist

### General checks

- [ ] Linting and tests pass locally

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [x] Verify that it renders correctly in incident index page, if applicable