### PR TITLE
Augment production log data

### DIFF
--- a/tracker/settings/production.py
+++ b/tracker/settings/production.py
@@ -17,9 +17,7 @@ SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS').split(' ')
 
 
-MIDDLEWARE += [  # noqa: F405
-    'common.middleware.RequestLogMiddleware',
-]
+MIDDLEWARE.insert(3, 'common.middleware.RequestLogMiddleware')  # noqa: F405
 
 
 structlog.configure(

--- a/tracker/settings/production.py
+++ b/tracker/settings/production.py
@@ -43,8 +43,9 @@ structlog.configure(
 )
 
 pre_chain = [
-    # Add the log level and a timestamp to the event_dict if the log entry
-    # is not from structlog.
+    # Add the context vars, log level and a timestamp to the
+    # event_dict if the log entry is not from structlog.
+    structlog.contextvars.merge_contextvars,
     structlog.stdlib.add_log_level,
     structlog.stdlib.add_logger_name,
 ]


### PR DESCRIPTION
## Description

A part of https://github.com/freedomofpress/fpf-www-projects/issues/350

While doing research and testing some changes related to the above ticket, I noticed some places where our production log configuration could be improved to add more data to the entries that are already being made.

Changes proposed in this pull request:

1. Add structlog's processor `merge_contextvars` to the "foreign pre-chain" argument to the log formatter. This is processing that is applied to non-structlog loggers. This will make it so that data we add to structlogs context vars, such as the request/response data added by the `RequestLogMiddleware`, is included in log messages that we don't control, such as Django's internal log messages. 
2. Move the `RequestLogMiddleware` higher in the middleware chain. This will make it more likely that request and response data is as correct as possible, such as when the response is intercepted and changed by another middleware.  For example, the wagtail redirect middleware will dynamically update 404 reponses to 301 responses, and if the request logging occurs too late in the pipeline, it will not have the correct information.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

In production mode (i.e. with `docker compose -f prod-docker-compose.yaml` or by copying the production log settings into the development settings file), the following should be happen on this branch (but not on develop):

1. Wagtail redirects should correctly be logged as 301 status.
2. Django log messages, such as CSRF violations, should contain the complete request/response data (which is seen from our own loggers but not currently on django's loggers). This can be tested by, say, making a post request without a CSRF cookie.

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:

- [ ] Verify that API responses are correct
- [ ] Verify that visualizations using the API endpoints are functional

### If you made changes to incident model metadata

- [ ] Verify incident export works correctly
- [ ] Verify incident filters are rendered correctly
- [ ] Verify incident filters show correct incidents
- [ ] Verify categories work
- [ ] Verify incidents are discoverable by search

### If you made changes to blog

- [ ] Verify that the blog index page renders correctly
- [ ] Verify that the individual blogs show all the informations correctly

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [ ] Verify that it renders correctly in homepage, if applicable
- [ ] Verify that it renders correctly in incident index page, if applicable
- [ ] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [ ] Verify that it renders correctly in individual blog page, if applicable
- [ ] Verify that it renders correctly in individual special blog page, if applicable

### If you made changes to email signup flow

- [ ] Verify that the email signup form in the footer renders and works
- [ ] Verify that the individual email signup pages work

### If you made changes to "Submit an Incident" form

- [ ] Verify that the form renders correctly and submit correctly as well

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
