### PR TITLE
Smart search phase two

### DIFF
--- a/client/charts/js/components/FilterSummary.jsx
+++ b/client/charts/js/components/FilterSummary.jsx
@@ -1,19 +1,5 @@
 import React from 'react'
-import classNames from 'classnames'
-
-const symbolMap = {
-	"Arrest / Criminal Charge": "arrest",
-	"Border Stop": "border_stop",
-	"Denial of Access": "denial_of_access",
-	"Equipment Search or Seizure": "equipment_search",
-	"Assault": "assault",
-	"Leak Case": "leak_case",
-	"Subpoena / Legal Order": "subpoena",
-	"Equipment Damage": "equipment_damage",
-	"Prior Restraint": "prior_restraint",
-	"Chilling Statement": "chilling_statement",
-	"Other Incident": "other_incident",
-}
+import CategoryIcon, { categorySymbolMap } from '../../../common/js/components/categoryIcon'
 
 export default function FilterSummary({ serializedFilters }) {
 	const categoryFilters = JSON.parse(serializedFilters)
@@ -44,7 +30,7 @@ export default function FilterSummary({ serializedFilters }) {
 	const categories = [...new Set(
 		(categoriesStr ? categoriesStr.split(',').map(d => d.trim()) : [])
 			.map(category => {
-				if (symbolMap[category]) return category;
+				if (categorySymbolMap[category]) return category;
 				if (idMap[category]) return idMap[category];
 				return null;
 			})
@@ -75,7 +61,7 @@ export default function FilterSummary({ serializedFilters }) {
 						className="btn btn-tag"
 						aria-label={`Removes filter: ${category.toLowerCase()}`}
 					>
-						{symbolMap[category] && <div className={classNames("category", `category-${symbolMap[category]}`)}></div>}
+						<CategoryIcon category={category} />
 						<span>{category.toLowerCase()}</span>
 						<span className="close-icon" />
 					</button>

--- a/client/common/js/components/Search.jsx
+++ b/client/common/js/components/Search.jsx
@@ -96,10 +96,11 @@ export default function Search({ data = [], selectedTags = [] }) {
 		}
 	}
 
+	let unselectable = (selectedTag != null || selectedCategory != null)
 	// The base markup is the same as incidents/templates/incident/_search_bar.html
 	return (
 		<form
-			className="search-form"
+			className={classNames("search-form", {'smart-search--unselectable': unselectable})}
 			onSubmit={handleSubmit}
 			onFocus={() => setSearchActive(true)}
 			onBlur={(e) => {
@@ -142,10 +143,11 @@ export default function Search({ data = [], selectedTags = [] }) {
 					<button
 						type="button"
 						className="search-category-pill--close"
-						aria-label="Close"
+						aria-label="Clear"
 						onClick={updateSelectedTag(null)}
 					>
 						<i className="search-tag-pill--close--icon" aria-hidden />
+						Clear
 					</button>
 				</div>
 			)}
@@ -157,10 +159,11 @@ export default function Search({ data = [], selectedTags = [] }) {
 					<button
 						type="button"
 						className="search-tag-pill--close"
-						aria-label="Close"
+						aria-label="Clear"
 						onClick={updateSelectedTag(null)}
 					>
 						<i className="search-tag-pill--close--icon" aria-hidden />
+						Clear
 					</button>
 				</div>
 			)}

--- a/client/common/js/components/Search.jsx
+++ b/client/common/js/components/Search.jsx
@@ -37,11 +37,12 @@ export default function Search({ data = [], selectedTags = [] }) {
 		inputRef?.current.focus()
 	}
 
-	const updateSelectedCategory = (category) => () => {
-		setSearchText('')
-		setSelectedCategory(category)
-		setSelectedTag(null)
-		inputRef?.current.focus()
+	const performCategorySearch = (category) => {
+		window.location.href = `/all-incidents/?categories=${category}`
+	}
+
+	const performTagSearch = (tag) => {
+		window.location.href = `/all-incidents/?tags=${tag}`
 	}
 
 	const updateSearchText = (text) => {
@@ -211,12 +212,13 @@ export default function Search({ data = [], selectedTags = [] }) {
 												<button
 													className="search-dropdown--category--button"
 													type="button"
-													onClick={updateSelectedCategory(category)}
+													onClick={() => performCategorySearch(category)}
 													onKeyDown={handleArrowKeys}
 												>
 													<span className="search-dropdown--tag--button--category-label">category:</span>
 													<CategoryIcon category={category} />
 													{category}
+													<span className="search-dropdown__go">Go &#8594;</span>
 												</button>
 											</li>
 										))}
@@ -241,11 +243,12 @@ export default function Search({ data = [], selectedTags = [] }) {
 										<button
 											className="search-dropdown--tag--button"
 											type="button"
-											onClick={updateSelectedTag(tag)}
+											onClick={() => performTagSearch(tag)}
 											onKeyDown={handleArrowKeys}
 										>
 											<span className="search-dropdown--tag--button--hash">#</span>
 											{tag}
+											<span className="search-dropdown__go">Go &#8594;</span>
 										</button>
 									</li>
 								))}

--- a/client/common/js/components/categoryIcon.jsx
+++ b/client/common/js/components/categoryIcon.jsx
@@ -1,0 +1,29 @@
+import classNames from 'classnames'
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export const categorySymbolMap = {
+	'Arrest / Criminal Charge': 'arrest',
+	'Border Stop': 'border_stop',
+	'Denial of Access': 'denial_of_access',
+	'Equipment Search or Seizure': 'equipment_search',
+	Assault: 'assault',
+	'Leak Case': 'leak_case',
+	'Subpoena / Legal Order': 'subpoena',
+	'Equipment Damage': 'equipment_damage',
+	'Prior Restraint': 'prior_restraint',
+	'Chilling Statement': 'chilling_statement',
+	'Other Incident': 'other_incident',
+}
+
+export default function CategoryIcon({ category }) {
+	return (<div className={classNames('category', `category-${categorySymbolMap[category] || category}`)} />)
+}
+
+CategoryIcon.propTypes = {
+	category: PropTypes.string,
+}
+
+CategoryIcon.defaultProps = {
+	category: '',
+}

--- a/client/common/sass/_colors.sass
+++ b/client/common/sass/_colors.sass
@@ -4,6 +4,7 @@ $white: #FFF
 $section-background: #F8F8F8
 $tag-inactive-bg: #F2F2F2
 $tag-inactive: #C1C1C1
+$gray-light: #C1C1C1
 $gray-text: #757575
 $gray-dark: #6b6b6b
 $gray-border: #C1C1C1

--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -1,8 +1,16 @@
 .search-form
 	position: relative
 
+	input[type="search"]
+		cursor: var(--bar-cursor)
+		background-color: var(--bar-background-color)
+
 .text-field--search-bar.smart-search-active
 	outline: none
+
+.smart-search--unselectable
+	--bar-background-color: #{$tag-inactive-bg}
+	--bar-cursor: default
 
 .search-button
 	position: absolute
@@ -12,7 +20,7 @@
 	border: 0
 	margin: 0
 	font-weight: 500
-	background-color: $white
+	background-color: var(--bar-background-color, $white)
 
 .search-dropdown
 	position: absolute
@@ -82,8 +90,9 @@
 	left: 20px
 	display: flex
 	align-items: center
-	background-color: $white
+	background-color: var(--bar-background-color, $white)
 	font-weight: bold
+	cursor: text
 
 	&--tag-hash, &--category-label
 		color: $gray-text
@@ -98,6 +107,12 @@
 		border: 0
 		background-color: transparent
 		cursor: pointer
+		display: grid
+		grid-template-columns: auto auto
+		gap: 3px
+		place-items: center
+		text-transform: uppercase
+		margin-left: 4px
 
 		&--icon
 			display: block

--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -33,6 +33,9 @@
 	padding: 12px 0
 	z-index: 20000
 
+	&__go
+		margin-left: auto
+
 	&--wrap
 		padding: 0
 		margin: 0
@@ -52,7 +55,7 @@
 
 		&--button
 			padding: 4px 23px
-			display: block
+			display: flex
 			width: 100%
 			text-align: left
 			background: none

--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -25,15 +25,22 @@
 	padding: 12px 0
 	z-index: 20000
 
+	&--wrap
+		padding: 0
+		margin: 0
+
 	&--header
 		padding: 0 23px
 		color: $gray-text
 		font-size: 12px
-		margin-bottom: 6px
+		margin: 6px 0
 
-	&--tag
+	&--tag, &--category
 		width: 100%
 		list-style: none
+
+		&--custom-search
+			font-weight: bold
 
 		&--button
 			padding: 4px 23px
@@ -49,14 +56,26 @@
 				background-color: $accent-color
 				outline: none
 
-			&--hash
+			&--hash, &--category-label
 				display: inline-block
 				padding: 4px
 				margin-right: 8px
 				background-color: $black
-				color: $tag-inactive
+				color: $gray-light
 
-.search-tag-pill
+			&--category-label
+				padding: 4px 8px
+
+			& .category
+				display: inline-block
+	hr
+		background-color: $gray-light
+		height: 2px
+		border: none
+		margin: 24px
+
+
+.search-tag-pill, .search-category-pill
 	position: absolute
 	top: 3px
 	bottom: 3px
@@ -66,11 +85,14 @@
 	background-color: $white
 	font-weight: bold
 
-	&--tag-hash
+	&--tag-hash, &--category-label
 		color: $gray-text
 		font-weight: normal
 		margin-right: 4px
 		display: inline-block
+
+	&--category-label
+		color: $gray-light
 
 	&--close
 		border: 0

--- a/client/common/sass/components/_search-bar.sass
+++ b/client/common/sass/components/_search-bar.sass
@@ -66,12 +66,12 @@
 			&--category-label
 				padding: 4px 8px
 
-			& .category
+			.category
 				display: inline-block
 	hr
 		background-color: $gray-light
 		height: 2px
-		border: none
+		border: 0
 		margin: 24px
 
 


### PR DESCRIPTION
## Description

Fixes #1804

Adds smart search phase two by editing the dropdown to include categories when the search bar is active.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
Run the app locally, and in the homepage or the incident page, use the search bar by clicking it and expanding the options. Ensure that the search bar works as described in the mocks and satisfies accessibility requirements.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [x] Verify that it renders correctly in incident index page, if applicable


### If you made any frontend change
![Screenshot 2023-12-06 at 6 18 27 PM](https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/fc4e4d39-9822-4abb-9f0d-1c2d54fa79e3)


