### PR TITLE
Charts cleanup, comments, and bugfixes

### DIFF
--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -43,6 +43,14 @@ const textStyle = {
 
 const textPadding = 10
 
+/**
+ * BarChart
+ *
+ * This component is in charge of rendering the bar chart components on the
+ * frontend. This component can be used to render normal bar charts and
+ * stacked bar charts in a variety of different combinations such as mobile
+ * devices, header images, preview images, etc.
+ */
 export default function BarChart({
 	data,
 	allCategories,
@@ -51,10 +59,14 @@ export default function BarChart({
 	categoryDivider = ',',
 	x,
 	y,
+	// A format function for the labels on the x-axis
 	xFormat = x => x,
+	// A format function for the labels on the y-axis
 	yFormat = y => y,
 	xDomain,
 	yDomain,
+	// An extra, optional format function for labels on the x-axis that show up
+	// in the tooltip
 	tooltipXFormat,
 	titleLabel,
 	isMobileView,
@@ -72,6 +84,7 @@ export default function BarChart({
 	if (!data.length) return null
 	const dataset = data.map((d, i) => ({ ...d, index: i }))
 
+	// State to keep track of the current hovered element
 	const [hoveredElement, setHoveredElement] = useState(null)
 	const [sliderSelection, setSliderSelection] = useState(dataset[0].index)
 	const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 })
@@ -92,6 +105,7 @@ export default function BarChart({
 		35
 	)
 
+	// Used when we have a stacked bar chart
 	const datasetStackedByCategory = stackDatasetByCategory(
 		dataset.map(d => ({ [categoryColumn]: Object.keys(d).join(', ') })),
 		[],
@@ -119,22 +133,26 @@ export default function BarChart({
 		.paddingInner(0.3)
 		.paddingOuter(0.2)
 
+	// xScaleOverLayer is for the bars that are only used for hover / click events,
+	// this is similar to xScale, except that it does not leave gaps between bars
+	// so that the closest bar is always hovered
 	const xScaleOverLayer = d3
 		.scaleBand()
 		.domain(xDomainItems)
 		.range([paddings.left + paddingsInternal.left, width - paddings.right - paddingsInternal.right])
 
+	// Used for the Slider component on mobile devices where we are unable to label all of the points
+	// due to space limitations
 	const xSlider = d3
 		.scalePoint()
 		.domain(xDomainItems)
-		.range([0, width])
+		.range([paddings.left, width - paddings.right])
 		.padding(0.3)
 
 	const computeBarheight = (y_) => {
 		return height - yScale(y_) - (isMobileView ? paddings.mobile : paddings.bottom)
 	}
 
-	const toggleSelectedCategory = () => {}
 	const findColor = (color) => categoriesColors[color] || 'white'
 	const getBarColor = (key, data, defaultColor) => {
 		const barColor = categoriesColors[key] || '#E07A5F'
@@ -148,6 +166,7 @@ export default function BarChart({
 
 	if (!width) return null
 
+	// Desktop
 	if (!isMobileView) {
 		return (
 			<>
@@ -191,19 +210,23 @@ export default function BarChart({
 					viewBox={[0, 0, width, height]}
 				>
 					{description ? (<desc>{description}</desc>) : null}
-					{allCategories && (
-						<CategoryButtons
-							interactive={interactive}
-							datasetStackedByCategory={datasetStackedByCategory}
-							paddings={paddings}
-							width={width}
-							hoveredElement={!hoveredElement?.x && hoveredElement?.y}
-							setHoveredElement={(el) => setHoveredElement(el ? { y: el } : el)}
-							setButtonsHeight={setButtonsHeight}
-							findColor={findColor}
-							textStyle={textStyle}
-						/>
-					)}
+					{
+						// If there are multiple categories, ie a stacked bar chart,
+						// we show the category buttons
+						allCategories && (
+							<CategoryButtons
+								interactive={interactive}
+								datasetStackedByCategory={datasetStackedByCategory}
+								paddings={paddings}
+								width={width}
+								hoveredElement={!hoveredElement?.x && hoveredElement?.y}
+								setHoveredElement={(el) => setHoveredElement(el ? { y: el } : el)}
+								setButtonsHeight={setButtonsHeight}
+								findColor={findColor}
+								textStyle={textStyle}
+							/>
+						)
+					}
 					<g>
 						<AnimatedDataset
 							dataset={gridLines}
@@ -247,7 +270,10 @@ export default function BarChart({
 							keyFn={(d) => d}
 						/>
 					</g>
-					{stackedData.map(branchBars => (
+					{
+						// These are the actual bars that are visibly displayed,
+						// using animatedDataset to allow for load-in animations
+						stackedData.map(branchBars => (
 							<AnimatedDataset
 								dataset={branchBars}
 								tag="rect"
@@ -273,46 +299,51 @@ export default function BarChart({
 								keyFn={(d) => branchBars.key + d.data.index}
 								key={branchBars.key}
 							/>
-						))}
-					{stackedData.map(branchBars => branchBars.map((branchEntry) => (
-						<g
-							key={branchBars.key + branchEntry.data.index}
-							style={{ pointerEvents: interactive ? "auto" : "none" }}
-						>
-							<DynamicWrapper
-								wrapperComponent={
-									<a
-										href={searchPageURL && searchPageURL(xFormat(branchEntry.data[x]))}
-										role="link"
-										aria-label={`${xFormat(branchEntry.data[x])}: ${yFormat(branchEntry.data[y])} ${titleLabel}`}
-									/>
-								}
-								wrap={interactive && searchPageURL}
+						))
+					}
+					{
+						// These elements are for the hover and link targets,
+						// they are not actually visibly displayed
+						stackedData.map(branchBars => branchBars.map((branchEntry) => (
+							<g
+								key={branchBars.key + branchEntry.data.index}
+								style={{ pointerEvents: interactive ? "auto" : "none" }}
 							>
-								<rect
-									x={xScaleOverLayer(branchEntry.data[x])}
-									y={yScale(branchEntry[1])}
-									height={computeBarheight(branchEntry[1] - branchEntry[0]) || 0}
-									width={xScaleOverLayer.bandwidth()}
-									style={{
-										opacity: 0,
-										cursor: (interactive && searchPageURL) ? 'pointer' : 'inherit',
-									}}
-									onMouseEnter={() => setHoveredElement({
-										x: (tooltipXFormat || xFormat)(branchEntry.data[x]),
-										y: branchBars.key
-									})}
-									onMouseMove={updateTooltipPosition}
-									onMouseLeave={() => setHoveredElement(null)}
-									shapeRendering="crispEdges"
+								<DynamicWrapper
+									wrapperComponent={
+										<a
+											href={searchPageURL && searchPageURL(xFormat(branchEntry.data[x]))}
+											role="link"
+											aria-label={`${xFormat(branchEntry.data[x])}: ${yFormat(branchEntry.data[y])} ${titleLabel}`}
+										/>
+									}
+									wrap={interactive && searchPageURL}
 								>
-									<title>
-										{xFormat(branchEntry.data[x])}: {yFormat(branchEntry.data[y])} {titleLabel}
-									</title>
-								</rect>
-							</DynamicWrapper>
-						</g>
-					)))}
+									<rect
+										x={xScaleOverLayer(branchEntry.data[x])}
+										y={yScale(branchEntry[1])}
+										height={computeBarheight(branchEntry[1] - branchEntry[0]) || 0}
+										width={xScaleOverLayer.bandwidth()}
+										style={{
+											opacity: 0,
+											cursor: (interactive && searchPageURL) ? 'pointer' : 'inherit',
+										}}
+										onMouseEnter={() => setHoveredElement({
+											x: (tooltipXFormat || xFormat)(branchEntry.data[x]),
+											y: branchBars.key
+										})}
+										onMouseMove={updateTooltipPosition}
+										onMouseLeave={() => setHoveredElement(null)}
+										shapeRendering="crispEdges"
+									>
+										<title>
+											{xFormat(branchEntry.data[x])}: {yFormat(branchEntry.data[y])} {titleLabel}
+										</title>
+									</rect>
+								</DynamicWrapper>
+							</g>
+						)))
+					}
 					<AnimatedDataset
 						dataset={dataset.filter((d, i) => i % xLabelDisplayInterval === 0)}
 						tag="text"
@@ -339,7 +370,9 @@ export default function BarChart({
 				</svg>
 			</>
 		)
-	} else {
+	}
+	// Mobile
+	else {
 		return (
 			<svg
 				ref={setSvgEl}
@@ -354,6 +387,23 @@ export default function BarChart({
 				id="barchart-svg"
 			>
 				{description ? (<desc>{description}</desc>) : null}
+				{
+					// If there are multiple categories, ie a stacked bar chart,
+					// we show the category buttons
+					allCategories && (
+						<CategoryButtons
+							interactive={interactive}
+							datasetStackedByCategory={datasetStackedByCategory}
+							paddings={paddings}
+							width={width}
+							hoveredElement={!hoveredElement?.x && hoveredElement?.y}
+							setHoveredElement={(el) => setHoveredElement(el ? { y: el } : el)}
+							setButtonsHeight={setButtonsHeight}
+							findColor={findColor}
+							textStyle={textStyle}
+						/>
+					)
+				}
 				<g>
 					<AnimatedDataset
 						dataset={gridLines}
@@ -393,35 +443,46 @@ export default function BarChart({
 						keyFn={(d) => d}
 					/>
 				</g>
-				{stackedData.map((branchBars) => branchBars.map((branchEntry, i) => (
+				{stackedData.map(branchBars => (
 					<DynamicWrapper
-						key={branchBars.key + i}
+						key={branchBars.key}
 						wrapperComponent={
 							<a
-								href={searchPageURL && searchPageURL(xFormat(branchEntry.data[x]))}
+								href={searchPageURL && searchPageURL(xFormat(branchBars[0].data[x]))}
 								role="link"
-								aria-label={`${xFormat(branchEntry.data[x])}: ${yFormat(branchEntry.data[y])} ${titleLabel}`}
+								aria-label={`${xFormat(branchBars[0].data[x])}: ${yFormat(branchBars[0].data[y])} ${titleLabel}`}
 							/>
 						}
 						wrap={searchPageURL}
 					>
 						<AnimatedDataset
-							dataset={[branchEntry.data]}
+							dataset={branchBars}
 							tag="rect"
+							init={{
+								x: (d) => xScale(d.data[x]),
+								y: height - paddings.mobile,
+								height: 0,
+								width: xScale.bandwidth(),
+							}}
 							attrs={{
-								x: (d) => xScale(d[x]),
-								y: (d) => yScale(d[y]),
-								height: (d) => computeBarheight(d[y]),
+								x: (d) => xScale(d.data[x]),
+								y: (d) => yScale(d[1]),
+								height: (d) => computeBarheight(d[1] - d[0]) || 0,
 								width: xScale.bandwidth(),
 								fill: (d) =>
-									sliderSelection === d[x] ? '#E07A5F' : sliderSelection === null ? '#E07A5F' : 'white',
+									(sliderSelection === d.data[x] || (!hoveredElement?.x && hoveredElement?.y === branchBars.key))
+										? getBarColor(branchBars.key, d.data, 'white')
+										: sliderSelection === null
+											? getBarColor(branchBars.key, d.data, 'white')
+											: 'white',
 								strokeWidth: borders.normal,
 								stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
 								cursor: searchPageURL ? 'pointer' : 'inherit',
 								shapeRendering: 'crispEdges',
 							}}
 							duration={250}
-							keyFn={() => branchBars.key + i}
+							durationByAttr={{ fill: 0, stroke: 0 }}
+							keyFn={(d) => branchBars.key + d.data.index}
 							key={branchBars.key}
 						/>
 						<text
@@ -435,15 +496,18 @@ export default function BarChart({
 								fontSize: '14px',
 							}}
 						>
-							{`${sliderSelection}: ${incidentsCount} ${titleLabel}`}
+							{`${(tooltipXFormat || xFormat)(sliderSelection)}: ${incidentsCount} ${titleLabel}`}
 						</text>
 					</DynamicWrapper>
-				)))}
+				))}
 				<Slider
 					elements={dataset.map((d) => d[x])}
 					xScale={xSlider}
 					y={height - paddings.bottom / 2}
-					setSliderSelection={setSliderSelection}
+					setSliderSelection={(d) => {
+						setSliderSelection(d);
+						setHoveredElement(null);
+					}}
 					sliderSelection={sliderSelection}
 					idContainer={'barchart-svg'}
 				/>

--- a/client/charts/js/components/CategoryButtons.jsx
+++ b/client/charts/js/components/CategoryButtons.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import * as d3 from 'd3'
 
+// Takes a best guess at the width of a letter to calculate the width of a button
 const averageLetterWidth = 8
 const labelHeight = 30
 
@@ -41,6 +42,7 @@ export default function CategoryButtons({
 	}, [])
 
 	useEffect(() => {
+		// Calls the function to set the height so the parent component can keep track of it
 		setButtonsHeight(
 			d3.max(datasetCategoriesLabelsLegend, d => d.labelStartingY) + labelHeight * 1.5
 		)
@@ -52,16 +54,17 @@ export default function CategoryButtons({
 		return "white"
 	}
 
-	return (<>
-		{datasetCategoriesLabelsLegend
-			.sort((a, b) => {
-				const isFirst = hoveredElement === a.category
-				const isSecond = hoveredElement === b.category
-				if (isFirst) return 1
-				else if (isSecond) return -1
-				return 0
-			})
-			.map(d => (
+	return (
+		<>
+			{datasetCategoriesLabelsLegend
+				.sort((a, b) => {
+					const isFirst = hoveredElement === a.category
+					const isSecond = hoveredElement === b.category
+					if (isFirst) return 1
+					else if (isSecond) return -1
+					return 0
+				})
+				.map(d => (
 					<g
 						key={d.category}
 						onMouseLeave={() => setHoveredElement(null)}
@@ -77,7 +80,7 @@ export default function CategoryButtons({
 							x={d.labelStartingX}
 							y={d.labelStartingY}
 							width={d.labelWidth}
-							height={30}
+							height={labelHeight}
 							strokeWidth={hoveredElement === d.category ? borderWidth.normal : borderWidth.mobile}
 							stroke={hoveredElement === d.category ? findColor(d.category) : 'black'}
 							fill={fillColor(d)}
@@ -95,5 +98,5 @@ export default function CategoryButtons({
 				)
 			)}
 		</>
-		)
+	)
 };

--- a/client/charts/js/components/IncidentsTimeBarChart.jsx
+++ b/client/charts/js/components/IncidentsTimeBarChart.jsx
@@ -4,7 +4,7 @@ import BarChart from './BarChart'
 import BarChartMini from './BarChartMini'
 import ChartDownloader from './ChartDownloader'
 import * as d3 from 'd3'
-import { categoriesColors, filterDatasets } from '../lib/utilities'
+import { categoriesColors, filterDatasets, tabletMinMainColumn } from '../lib/utilities'
 
 export default function IncidentsTimeBarChart({
 	dataset,
@@ -81,8 +81,10 @@ export default function IncidentsTimeBarChart({
 	const xFormat = (date) => {
 		if (showByYears) return timeFormat(date)
 		if (Object.keys(incidentsByYear).length === 1) return d3.utcFormat("%b")(date)
+		// If this is the first item in the list, format with the year
 		if (d3.utcFormat('%m-%Y')(date) === d3.utcFormat('%m-%Y')(allTime[0])
 			|| d3.utcFormat('%m')(date) === '01') return d3.utcFormat("%Y")(date)
+		// Format with the month abbreviation ie Jan, Feb, etc
 		return d3.utcFormat("%b")(date)
 	}
 
@@ -107,6 +109,7 @@ export default function IncidentsTimeBarChart({
 	return (
 		<ParentSize>
 			{(parent) => {
+				const isMobile = parent.width ? parent.width < tabletMinMainColumn : isMobileView
 				const barchart = fullSize ? (
 					<BarChart
 						description={description || generatedDescription}
@@ -120,8 +123,8 @@ export default function IncidentsTimeBarChart({
 						tooltipXFormat={d3.utcFormat(showByYears ? "%Y" : "%b %Y")}
 						titleLabel={'incidents'}
 						width={parent.width}
-						height={Math.min(parent.width * 0.75, 600)}
-						isMobileView={isMobileView}
+						height={Math.min(parent.width * (isMobile ? 1.2 : 0.75), 600) * (branchFieldName ? 1.1 : 1)}
+						isMobileView={isMobile}
 						interactive={interactive}
 					/>
 				) : (

--- a/client/charts/js/components/IncidentsTimeBarChart.jsx
+++ b/client/charts/js/components/IncidentsTimeBarChart.jsx
@@ -123,7 +123,7 @@ export default function IncidentsTimeBarChart({
 						tooltipXFormat={d3.utcFormat(showByYears ? "%Y" : "%b %Y")}
 						titleLabel={'incidents'}
 						width={parent.width}
-						height={Math.min(parent.width * (isMobile ? 1.2 : 0.75), 600) * (branchFieldName ? 1.1 : 1)}
+						height={Math.min(parent.width * (isMobile ? 1 : 0.75), 600) * (branchFieldName ? 1.2 : 1)}
 						isMobileView={isMobile}
 						interactive={interactive}
 					/>

--- a/client/charts/js/components/TreeMap.jsx
+++ b/client/charts/js/components/TreeMap.jsx
@@ -4,7 +4,7 @@ import { AnimatedDataset } from 'react-animated-dataset'
 import DynamicWrapper from './DynamicWrapper'
 import Tooltip from './Tooltip'
 import CategoryButtons from './CategoryButtons.jsx'
-import { colors } from '../lib/utilities.js'
+import { colors, tabletMinMainColumn } from '../lib/utilities.js'
 
 // React-animated-dataset uses an older version of
 // d3 selection and in order to access some of its
@@ -61,11 +61,9 @@ export function computeMinimumNumberOfIncidents(dataset, chartHeight, minimumBar
 		.range([0, chartHeight - borderWidth.normal - paddings.top - paddings.bottom])
 
 	// totalIncidents + 1 is needed in case there's only one incident (otherwise d3.range(1) => [0])
-	const minimumNumberOfIncidents = d3.min(
+	return d3.min(
 		d3.range(totalIncidents + 1).filter((d) => y(d) > minimumBarHeight)
 	)
-
-	return minimumNumberOfIncidents
 }
 
 export function stackDatasetByCategory(
@@ -113,7 +111,7 @@ export function stackDatasetByCategory(
 	const stack = d3.stack().keys(
 		Object.keys(incidentsGroupedByCategory).sort((a, b) => a.localeCompare(b))
 	)
-	const datasetStackedByCategory = stack([incidentsGroupedByCategoryAdjusted]).map((d) => ({
+	return stack([incidentsGroupedByCategoryAdjusted]).map((d) => ({
 		startingPoint: d[0][0],
 		endPoint: !isNaN(d[0][1]) ? d[0][1] : d[0][0],
 		numberOfIncidents: incidentsGroupedByCategory[d.key],
@@ -121,8 +119,6 @@ export function stackDatasetByCategory(
 	}))
 		// Only display non-empty groups in the chart.
 		.filter((d) => d.numberOfIncidents > 0 || (filterElements.length && allCategories.indexOf(d.category) >= 0))
-
-	return datasetStackedByCategory
 }
 
 export default function TreeMap({
@@ -149,7 +145,7 @@ export default function TreeMap({
 
 	// Because the chart can be rendered horizontally on desktop and vertically on
 	// mobile, we abstract the dimensions below
-	const isMobile = width < 500 || searchPageURL
+	const isMobile = width < tabletMinMainColumn || searchPageURL
 	const chartLength = isMobile ? height : width
 	const chartWidth = isMobile ? width : height
 	const chartLengthPaddingBefore = isMobile ? paddings.top : paddings.left
@@ -175,6 +171,7 @@ export default function TreeMap({
 		minimumBarHeight
 	)
 
+	// Groups the datasets by category, tag, etc
 	const datasetStackedByCategory = stackDatasetByCategory(
 		dataset,
 		selectedElements,
@@ -385,7 +382,7 @@ export default function TreeMap({
 								tag="text"
 								init={{
 									opacity: 0,
-									y: (d) => height - paddings.bottom,
+									y: () => height - paddings.bottom,
 									x: paddings.left + textPaddings.left,
 								}}
 								attrs={{
@@ -417,7 +414,7 @@ export default function TreeMap({
 								dataset={datasetStackedByCategory}
 								init={{
 									opacity: 0,
-									y: (d) => height - paddings.bottom,
+									y: () => height - paddings.bottom,
 									x: width - textPaddings.right - paddings.right,
 								}}
 								tag="text"

--- a/client/charts/js/lib/utilities.js
+++ b/client/charts/js/lib/utilities.js
@@ -32,6 +32,15 @@ export const monthIndexes = {
 	Dec: 12,
 }
 
+
+// These values are also set in sass at client/common/sass/_responsive.sass
+export const mobileMax = 768;
+export const tabletMax = 1152;
+export const desktopMax = 1440;
+export const tabletMin = mobileMax + 1;
+export const desktopMin = tabletMax + 1;
+export const tabletMinMainColumn = 500;
+
 export function getFilteredUrl(databasePath, filtersApplied, currentDate, categories) {
 	const categoriesSlugs = categories.reduce((acc, { title, slug }) => ({ ...acc, [title]: slug }), {})
 	const origin = window.location.origin

--- a/client/charts/js/tree-map-chart.js
+++ b/client/charts/js/tree-map-chart.js
@@ -27,12 +27,14 @@ function engageCharts() {
 		let dataUrl = [url]
 		let dataParser = [(data) => d3.csvParse(data, d3.autoType)]
 
+		// Specifies if the tree map needs to be grouped, and the method and key
+		// to group by
 		const branchFieldName = chartNode.dataset.branchFieldName
 		const branches = JSON.parse(chartNode.dataset.branches)
 		let additionalProps = {}
-		if (branches.type == 'list') {
+		if (branches.type === 'list') {
 			additionalProps.branches = branches.value
-		} else if (branches.type == 'url') {
+		} else if (branches.type === 'url') {
 			dataUrl.push(branches.value)
 			dataKey.push("branches")
 			dataParser.push(JSON.parse)

--- a/client/charts/js/vertical-bar-chart.js
+++ b/client/charts/js/vertical-bar-chart.js
@@ -28,13 +28,15 @@ function engageCharts() {
 		let dataUrl = [url || '/api/edge/incidents/homepage_csv/?']
 		let dataParser = [(data) => d3.csvParse(data, d3.autoType)]
 
+		// Specifies if the tree map needs to be grouped, and the method and key
+		// to group by
 		const branchFieldName = chartNode.dataset.branchFieldName
 		const branches = chartNode.dataset.branches && JSON.parse(chartNode.dataset.branches)
 		const groupByTag = chartNode.dataset?.groupByTag
 		let additionalProps = {}
-		if (chartNode.dataset.branches && branches.type == 'list') {
+		if (chartNode.dataset.branches && branches.type === 'list') {
 			additionalProps.branches = branches.value
-		} else if (chartNode.dataset.branches && branches.type == 'url') {
+		} else if (chartNode.dataset.branches && branches.type === 'url') {
 			dataUrl.push(branches.value)
 			dataKey.push("branches")
 			dataParser.push(JSON.parse)

--- a/client/common/sass/_responsive.sass
+++ b/client/common/sass/_responsive.sass
@@ -1,3 +1,4 @@
+// These values are also set in js at client/charts/js/lib/utilities.js
 $mobile-max: 768px
 $tablet-max: 1152px
 $desktop-max: 1440px


### PR DESCRIPTION
## Description
Did a final sweep of the charts that I've worked on in my time here at FPF, and here is a miscellaneous grab bag of comments, fixes, and some other things before I go.

Changes proposed in this pull request:
- Adds some comments to help better document some of the code I wrote in the charts
- Made some minor code formatting improvements and cleanup
- Uncovered a bug where the mobile version of the bar chart was actually never being shown (oops my bad)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
- Test the charts to make sure there are no regressions.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [x] Verify that it renders correctly in incident index page, if applicable
- [x] Verify that it renders correctly in individual incident page, if applicable
- [x] Verify that it renders correctly in blog index page, if applicable
- [x] Verify that it renders correctly in individual blog page, if applicable
- [x] Verify that it renders correctly in individual special blog page, if applicable

### If you made any frontend change

Mobile version of the bar chart with the slider works again:

<img width="432" alt="Screen Shot 2023-12-29 at 1 32 51 PM" src="https://github.com/freedomofpress/pressfreedomtracker.us/assets/3477162/f2be7a51-0243-4157-9d9c-b4aa92a3b4b6">
