### PR TITLE
Fix link text size in image captions

### DIFF
--- a/client/common/sass/components/_primary-banner-media.sass
+++ b/client/common/sass/components/_primary-banner-media.sass
@@ -23,7 +23,7 @@
 		> .rich-text
 			display: inline-block
 
-			p
+			p, a
 				font-size: 0.875rem
 				margin: 0
 


### PR DESCRIPTION
## Description

The styling for image captions inside of `.primary-banner-media` were previously applied to only `<p>`, this adds `<a>` 

Fixes #1847 

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [ ] Verify that it renders correctly in homepage, if applicable
- [ ] Verify that it renders correctly in incident index page, if applicable
- [ ] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [ ] Verify that it renders correctly in individual blog page, if applicable
- [ ] Verify that it renders correctly in individual special blog page, if applicable

### If you made any frontend change

Before:
![Finish history people](https://github.com/freedomofpress/pressfreedomtracker.us/assets/8910065/e82aa5af-cbfc-4bae-b304-95bb9f8b962e)
 
After:
![Pasted Graphic 1](https://github.com/freedomofpress/pressfreedomtracker.us/assets/8910065/88ae9071-5b75-4889-ada5-7746cdd44a1e)