### PR TITLE
Update `tqdm` package to 4.66.4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1404,9 +1404,9 @@ telepath==0.3.1 \
     # via
     #   -r requirements.txt
     #   wagtail
-tqdm==4.66.1 \
-    --hash=sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386 \
-    --hash=sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7
+tqdm==4.66.4 \
+    --hash=sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644 \
+    --hash=sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb
     # via
     #   -r requirements.txt
     #   wagtail-inventory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1037,9 +1037,9 @@ telepath==0.3.1 \
     --hash=sha256:925c0609e0a8a6488ec4a55b19d485882cf72223b2b19fe2359a50fddd813c9c \
     --hash=sha256:c280aa8e77ad71ce80e96500a4e4d4a32f35b7e0b52e896bb5fde9a5bcf0699a
     # via wagtail
-tqdm==4.66.1 \
-    --hash=sha256:d302b3c5b53d47bce91fea46679d9c3c6508cf6332229aa1e7d8653723793386 \
-    --hash=sha256:d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7
+tqdm==4.66.4 \
+    --hash=sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644 \
+    --hash=sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb
     # via wagtail-inventory
 typing==3.7.4.3 \
     --hash=sha256:1187fb9c82fd670d10aa07bbb6cfcfe4bdda42d6fab8d5134f04e8c4d0b71cc9 \


### PR DESCRIPTION
## Description

Fixes GHSA-g7vv-2v7x-gj9p

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

