### PR TITLE
Format dates that appear in details table rows in AP style

### DIFF
--- a/common/tests/test_date_utils.py
+++ b/common/tests/test_date_utils.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from django.test import TestCase
+
+from common.utils import format_date
+
+
+class APStyleDatesTestCase(TestCase):
+    def test_abbreviates_months_in_ap_style(self):
+        self.assertEqual(format_date(date(2024, 9, 5)), "Sept. 5, 2024")
+        self.assertEqual(format_date(date(2024, 5, 25)), "May 25, 2024")

--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -3,3 +3,4 @@ from common.utils.echo import *  # noqa: F403, F401
 from common.utils.unescape import *  # noqa: F403, F401
 from common.utils.mailchimp import *  # noqa: F403, F401
 from common.utils.pages import *  # noqa: F403, F401
+from common.utils.date import *  # noqa: F403, F401

--- a/common/utils/date.py
+++ b/common/utils/date.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+
+__all__ = ['format_date']
+
+
+def format_date(instance: date) -> str:
+    """Formats a date instance into a string that uses AP style."""
+    months = [
+        'Jan.',
+        'Feb.',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'Aug.',
+        'Sept.',
+        'Oct.',
+        'Nov.',
+        'Dec.'
+    ]
+    formatted_month = months[instance.month - 1]
+    formatted_year = instance.year
+    formatted_day = instance.day
+    return f'{formatted_month} {formatted_day}, {formatted_year}'

--- a/incident/models/inlines.py
+++ b/incident/models/inlines.py
@@ -16,6 +16,7 @@ from common.blocks import (
     RichTextBlockQuoteBlock,
     RichTextTemplateBlock,
 )
+from common.utils import format_date
 from incident import choices
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 from statistics.blocks import StatisticsBlock
@@ -40,7 +41,6 @@ class IncidentCharge(ClusterableModel):
     ]
 
     def entries_display(self):
-        date_format = '%b. %-d, %Y'
         entries = [
             (self.date, self.get_status_display())
         ] + [
@@ -48,7 +48,7 @@ class IncidentCharge(ClusterableModel):
         ]
 
         return [
-            (date.strftime(date_format), status) for date, status in
+            (format_date(date), status) for date, status in
             sorted(entries, key=lambda item: item[0])
         ]
 
@@ -111,17 +111,15 @@ class LegalOrder(ClusterableModel):
     ]
 
     def entries_display(self):
-        date_format = '%b. %-d, %Y'
-
         update_entries = [
             (
-                update.date.strftime(date_format) if update.date else 'Unknown date',
+                format_date(update.date) if update.date else 'Unknown date',
                 update.get_status_display(),
             )
             for update in self.updates.all()
         ]
         entries = [
-            (self.date.strftime(date_format), self.get_status_display())
+            (format_date(self.date), self.get_status_display())
         ] + update_entries
         return entries
 


### PR DESCRIPTION
This affects how charges and legal order updates are shown on incident pages and cards.

## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1858 

Changes proposed in this pull request:

Updates date formatting to use the [AP style](https://writingexplained.org/ap-style/ap-style-months) for abbreviation (or non-abbreviation) of months when showing dates within incident details table rows. Could potentially be applied to more places in the future, if we wish.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Check if the months abbreviations are correct and that the dates still format correctly for incidents with legal order and/or charge status updates.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:
None.
### If you made changes to incident model metadata

- [x] Verify incident export works correctly
- [x] Verify incident filters are rendered correctly
- [x] Verify incident filters show correct incidents
- [x] Verify categories work
- [x] Verify incidents are discoverable by search

### If you made changes to blog

None.

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [x] Verify that it renders correctly in incident index page, if applicable
- [x] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [ ] Verify that it renders correctly in individual blog page, if applicable
- [ ] Verify that it renders correctly in individual special blog page, if applicable

### If you made changes to email signup flow
None
### If you made changes to "Submit an Incident" form
None
### If it's a major change
Not major.
### If you made any frontend change

#### Charges
![image](https://github.com/freedomofpress/pressfreedomtracker.us/assets/561931/dbf3524c-2849-4100-ac1a-0f01e2049e4c)
#### Legal orders (mobile view)
![image](https://github.com/freedomofpress/pressfreedomtracker.us/assets/561931/bee159f7-eb51-47a6-8211-45b5e924d199)
