### PR TITLE
Responsive embeds

### DIFF
--- a/client/common/sass/common.sass
+++ b/client/common/sass/common.sass
@@ -60,3 +60,4 @@
 @import components/category-checkbox
 @import components/anim-table
 @import components/topicpage
+@import components/responsive-object

--- a/client/common/sass/components/_media.sass
+++ b/client/common/sass/components/_media.sass
@@ -1,4 +1,7 @@
 .inline-media
+	&.full-width
+		margin-inline: 0
+
 	&.left
 		float: left
 		margin-bottom: 1em

--- a/client/common/sass/components/_responsive-object.sass
+++ b/client/common/sass/components/_responsive-object.sass
@@ -1,0 +1,11 @@
+.responsive-object
+	position: relative
+
+	iframe,
+	object,
+	embed
+		position: absolute
+		top: 0
+		left: 0
+		width: 100%
+		height: 100%

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -365,3 +365,5 @@ CHART_PREGENERATOR = {
     'HOST': os.environ.get('DJANGO_CHART_HOST', 'node-chart-pregenerator'),
     'PORT': int(os.environ.get('DJANGO_CHART_PORT', '3000')),
 }
+
+WAGTAILEMBEDS_RESPONSIVE_HTML = True


### PR DESCRIPTION
## Description

Fixes #1403

Changes proposed in this pull request:

* Makes it so embeds are (1) responsive, and (2) remove the default margin for full-width embeds. Point 1 is based on the [wagtail docs](https://docs.wagtail.org/en/v5.2.5/topics/writing_templates.html#responsive-embeds). Point 2 is so that embeds appear as large as possible on small screens, e.g. mobile.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?

Try embedding a full-width youtube video on an incident page. It should appear large and take up the full width of the column across all reasonable screen sizes.

### Post-deployment actions

None.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### Screenshot

![image](https://github.com/user-attachments/assets/bb8a5fff-7117-4fa1-8906-09c990842a16)
