### PR TITLE
Fix special blog lead attribution

### DIFF
--- a/blog/templates/blog/_special_blog.html
+++ b/blog/templates/blog/_special_blog.html
@@ -15,7 +15,7 @@
 {% else %}
 	{% image page.lead_graphic.0.value scale-100 preserve-svg as tmp_photo %}
 	<div class="special-blog__hero-bg" style="background-image: url('{{ tmp_photo.url }}')">
-		<span class="sr-only">Background hero image of {{ page.lead_graphic.0.title }}</span>
+		<span class="sr-only">Background hero image of {{ page.lead_graphic.0.value.title }}</span>
 	</div>
 {% endif %}
 

--- a/blog/templates/blog/_special_blog.html
+++ b/blog/templates/blog/_special_blog.html
@@ -31,11 +31,13 @@
 				{% endif %}
 			</p>
 		{% endif %}
-		{% if page.lead_graphic.0.attribution %}
-			<p class="special-blog__hero-citation">
-				{{ page.lead_graphic.0.attribution }}
-			</p>
-		{% endif %}
+		{% with attribution=page.lead_graphic.0.value.attribution %}
+			{% if attribution %}
+				<p class="special-blog__hero-citation">
+					{{ attribution }}
+				</p>
+			{% endif %}
+		{% endwith %}
 	</div>
 </div>
 


### PR DESCRIPTION
## Description

Fixes #1887 

Changes proposed in this pull request:

Restores missing image attribution in the header of the special blog template.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Verify that the image attribution now displays in the lead graphic for special blog pages.

### Post-deployment actions

No actions.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:
Not changed.
### If you made changes to incident model metadata

Not changed.
### If you made changes to blog

- [x] Verify that the blog index page renders correctly
- [x] Verify that the individual blogs show all the informations correctly

### If you made changes to shared templates (e.g. card design, lead media, etc.)
Not changed.
### If you made changes to email signup flow
Not changed.
### If you made changes to "Submit an Incident" form
Not changed.
### If it's a major change

Not major

### If you made any frontend change

See text in bottom right.

<img width="961" alt="image" src="https://github.com/user-attachments/assets/6362085c-e5e3-4ce0-8cd8-07855c00f710">