### PR TITLE
Fix incident category ordering again

### DIFF
--- a/incident/devdata.py
+++ b/incident/devdata.py
@@ -615,8 +615,9 @@ class IncidentPageFactory(wagtail_factories.PageFactory):
             return
 
         if extracted:
-            for category in extracted:
+            for n, category in enumerate(extracted):
                 IncidentCategorizationFactory(
+                    sort_order=n,
                     incident_page=self,
                     category=category,
                 )

--- a/incident/templates/wagtailadmin/base.html
+++ b/incident/templates/wagtailadmin/base.html
@@ -1,0 +1,33 @@
+{% extends "wagtailadmin/base.html" %}
+{% load static %}
+
+{% comment %}
+
+This template exists to shim a JS function into the wagtail admin to
+correct for a bug in the wagtail admin where inline panels defined
+with a `min_num` are not correctly ordered during object creation.
+
+See https://github.com/wagtail/wagtail/issues/4010 for details.  If
+that issue is fixed, then this function can and should be removed.
+
+{% endcomment %}
+
+{% block extra_js %}
+	{{ block.super }}
+	<script>
+	 function fixOrderables() {
+		 // Find all inputs that contain -ORDER in their ID.
+		 $("input[id*='-ORDER").each(function(){
+			 if($(this).val() === ""){
+				 var inputId = $(this).attr("id");
+				 // Extract the "real" order from the ID and 1 to new order value.
+				 var inputVal = parseInt(inputId.substr(inputId.indexOf("-ORDER") - 1, 1))+1;
+				 if (parseInt($(this).val()) != inputVal){
+					 $(this).val(inputVal);
+				 }
+			 }
+		 });
+	 }
+	 document.addEventListener("DOMContentLoaded", fixOrderables);
+	</script>
+{% endblock %}


### PR DESCRIPTION
## Description

Fixes #1916 

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

1. Create an incident with multiple categories.
2. Click "save draft"
3. Ensure the order the categories appear is the same as the order you originally intended them.

### Post-deployment actions

None

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

