### PR TITLE
Update wagtail autocomplete to version 0.12.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1456,9 +1456,9 @@ wagtail==6.3.2 \
     #   wagtail-factories
     #   wagtail-inventory
     #   wagtail-metadata
-wagtail-autocomplete==0.11.0 \
-    --hash=sha256:11479000aae7532376048d0ff75585d9bebc8fdd09bad88b28f770032a362d11 \
-    --hash=sha256:b2ba0f5c8a0e43cdc124a9503d91e9815fb0251a1431d52db5868306ab935059
+wagtail-autocomplete==0.12.0 \
+    --hash=sha256:17be82c7e2ab2714b01a2a3edbf29f56ba37ad72f2bebcded560c5ead9b482df \
+    --hash=sha256:d1cd315475e8c776c85a75ba5eb76ceb2eb680c18334e7e9424040d7faa9b538
     # via -r requirements.txt
 wagtail-django-recaptcha==1.0 \
     --hash=sha256:fc177e75da966e9db1dfd9a566c40d30567518d9280b5db4fec4d50a8c853154

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ structlog
 typing
 typogrify
 wagtail>=6.3.2,<6.4
-wagtail-autocomplete>=0.11.0
+wagtail-autocomplete>=0.12.0
 wagtail-factories>=4.1.0
 wagtail-django-recaptcha
 wagtail-metadata>=5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1068,9 +1068,9 @@ wagtail==6.3.2 \
     #   wagtail-factories
     #   wagtail-inventory
     #   wagtail-metadata
-wagtail-autocomplete==0.11.0 \
-    --hash=sha256:11479000aae7532376048d0ff75585d9bebc8fdd09bad88b28f770032a362d11 \
-    --hash=sha256:b2ba0f5c8a0e43cdc124a9503d91e9815fb0251a1431d52db5868306ab935059
+wagtail-autocomplete==0.12.0 \
+    --hash=sha256:17be82c7e2ab2714b01a2a3edbf29f56ba37ad72f2bebcded560c5ead9b482df \
+    --hash=sha256:d1cd315475e8c776c85a75ba5eb76ceb2eb680c18334e7e9424040d7faa9b538
     # via -r requirements.in
 wagtail-django-recaptcha==1.0 \
     --hash=sha256:fc177e75da966e9db1dfd9a566c40d30567518d9280b5db4fec4d50a8c853154


### PR DESCRIPTION
## Description

Updates wagtail autocomplete to version 0.12.0 (latest).

Changes proposed in this pull request:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Ensure wagtail-autocomplete installs cleanly and still works on the site.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

