### PR TITLE
Replace images from the deprecated Unsplash URL with Lorem Picsum

### DIFF
--- a/common/management/commands/createdevdata.py
+++ b/common/management/commands/createdevdata.py
@@ -159,7 +159,7 @@ class Command(BaseCommand):
         )
 
     def fetch_image(self, width, height, collection):
-        url = f'https://source.unsplash.com/{width}x{height}?animal'
+        url = f'https://picsum.photos/{width}/{height}'
         response = requests.get(url, timeout=5)
         if response and response.content:
             CustomImageFactory(


### PR DESCRIPTION
see: https://picsum.photos/

## Description

Does what it says on the tin. I was getting failures from `./manage.py createdevdata` locally before this change.

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

1. Delete your dev database with `docker compose rm -v postgres`
2. Run `docker compose run ./manage.py createdevdata` and confirm that it succeeds
3. Run `docker compose up` and confirm that you see a website at locahost:8000 which has images.

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader