### PR TITLE
Fix issue with updated table row not rendering

### DIFF
--- a/incident/templates/incident/_incident_card.html
+++ b/incident/templates/incident/_incident_card.html
@@ -54,15 +54,17 @@
 			</ol>
 
 			<dl class="database-card-table__incident-details">
-				{% if incident.latest_update and incident.updates.all.exists %}
-					<div class="database-card-table__row table-{{ details }}">
-						<dt class="database-card-table__label database-card-table__label--bold">Updated on</dt>
-						<dd class="database-card-table__value">
-							<time datetime="{{ incident.latest_update|date:"c" }}">
-								{{ incident.latest_update|date:"F j, Y" }}
-							</time>
-						</dd>
-					</div>
+				{% if incident.updates.all.exists %}
+					{% with latest_update=incident.get_updates_by_desc_date|first %}
+						<div class="database-card-table__row table-{{ details }}">
+							<dt class="database-card-table__label database-card-table__label--bold">Updated on</dt>
+							<dd class="database-card-table__value">
+								<time datetime="{{ latest_update.date|date:"c" }}">
+									{{ latest_update.date|date:"F j, Y" }}
+								</time>
+							</dd>
+						</div>
+					{% endwith %}
 				{% endif %}
 
 				<div class="database-card-table__row table-{{ details }}">


### PR DESCRIPTION
## Description

Restore a table row for "Updated On" to incident teasers. We had the code in place for this but were erroneously using the nonexistent `.latest_update` attribute to render it.

<img width="499" alt="image" src="https://github.com/user-attachments/assets/45a5e32d-2b4c-4a20-b2b1-1ea23b77d4a0" />

Fixes #1911

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

Run the site locally and:

- [ ] verify that incident teasers are showing accurate last updated dates next to "Updated On"
- [ ] verify incidents with multiple updates show the date of the _most recent_ one.
- [ ] verify incidents without updates show no row.

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [x] Verify that it renders correctly in homepage, if applicable
- [ ] Verify that it renders correctly in incident index page, if applicable
- [ ] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [ ] Verify that it renders correctly in individual blog page, if applicable
- [ ] Verify that it renders correctly in individual special blog page, if applicable