### PR TITLE
Aligns images and embeds correctly

### DIFF
--- a/client/common/sass/components/_media.sass
+++ b/client/common/sass/components/_media.sass
@@ -1,16 +1,19 @@
 .inline-media
-	&.full-width
-		margin-inline: 0
+	width: 100%
+	margin-inline: 0
 
-	&.left
-		float: left
-		margin-bottom: 1em
-		margin-right: 1em
+	+tablet-up
+		&.left
+			margin-bottom: 1em
+			margin-right: 1em
+			float: left
+			max-width: 60%
 
-	&.right
-		float: right
-		margin-bottom: 1em
-		margin-left: 1em
+		&.right
+			margin-bottom: 1em
+			margin-left: 1em
+			float: right
+			max-width: 60%
 
 	&__caption
 		line-height: 1


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1912.

Changes proposed in this pull request:
- Makes left and right aligned media only take up a maximum of 60% width. Without this constraint, depending on the size of the media and the caption, it was trying to take up 100% space and hence the text was not wrapping around it
- Makes the width of the media independent of the caption size. Before this change, the width of embed media was dependent on the width of the caption size.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
- Add an image or youtube embed
- Apply left or right alignment
- See that the text actually wraps around

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made changes to blog

- [ ] Verify that the blog index page renders correctly
- [ ] Verify that the individual blogs show all the informations correctly

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.

![image](https://github.com/user-attachments/assets/aa6e457f-1e71-42df-a581-ad7c7a9bab67)

