### PR TITLE
README fix: `npm test-update` -> `npm run test-update`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ If tests need to be updated, you can run the following command:
 
 .. code:: bash
 
-    docker compose exec node npm test-update
+    docker compose exec node npm run test-update
 
 Debugging
 ---------


### PR DESCRIPTION
## Description

`npm test` always runs the `test` script; other scripts have to be run with `npm run`.