### PR TITLE
Displays organization even if author is not present

### DIFF
--- a/blog/templates/blog/_details_table.html
+++ b/blog/templates/blog/_details_table.html
@@ -13,16 +13,17 @@
 		</div>
 		{% endif %}
 
-		{% if blog.author %}
+		{% if blog.author or blog.organization %}
 		<div class="details-table__row">
 			<dt class="details-table__label details-table__label--bold">
 				Written by
 			</dt>
 			<dd class="details-table__value">
-				<a href="{% pageurl blog.get_parent %}?author={{ blog.author.pk }}" class="text-link">{{ blog.author.title }}</a>
-
+				{% if blog.author %}
+					<a href="{% pageurl blog.get_parent %}?author={{ blog.author.pk }}" class="text-link">{{ blog.author.title }}</a>
+				{% endif %}
+				{% if blog.author and blog.organization %}from{% endif %}
 				{% if blog.organization %}
-					from
 					<a href="{% pageurl blog.get_parent %}?organization={{ blog.organization.pk }}" class="text-link">{{ blog.organization.title }}</a>
 				{% endif %}
 			</dd>


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1981.

Changes proposed in this pull request:
Adds checks to ensure organization is shown event if author is not present

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
- Check that a Blog Page with both author and organization shows up details table as "Written by Author from Org"
- Check that a Blog Page with author and no organization shows up details table as "Written by Author"
- Check that a Blog Page with organization and no author shows up details table as "Written by Org"

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

![image](https://github.com/user-attachments/assets/70c8f4a9-cec9-4e4c-90aa-f0481f17f781)
