### PR TITLE
Scale homepage bubble map bubbles by providing domain

### DIFF
--- a/client/charts/js/components/USMap.jsx
+++ b/client/charts/js/components/USMap.jsx
@@ -27,7 +27,7 @@ const defaultPaddings = {
 
 const markerSize = {
 	min: 5,
-	max: 30,
+	max: 60,
 }
 
 const markerBorder = {
@@ -52,16 +52,16 @@ export default function USMap({
 	searchPageURL,
 	aggregationLocality = d => d.state,
 	addBottomBorder,
-  	overridePaddings = {},
+	overridePaddings = {},
 	// function prop received from ChartDownloader that binds the svg element to allow
 	// it to be downloaded
-	setSvgEl = () => {},
+	setSvgEl = () => { },
 	interactive = true,
 }) {
 	const [hoveredElement, setHoveredElement] = useState(null)
 	const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 })
 
-  	const paddings = {...defaultPaddings, ...overridePaddings}
+	const paddings = { ...defaultPaddings, ...overridePaddings }
 
 	const updateTooltipPosition = (MouseEvent) => {
 		setTooltipPosition({ x: MouseEvent.clientX, y: MouseEvent.clientY })
@@ -72,8 +72,8 @@ export default function USMap({
 	const hasLatLon = ({ latitude, longitude }) => latitude && longitude
 
 	// Scale markers size depending on the number of incidents in a city
-	const markerScale = d3.scaleSqrt().domain([0, 30]).range([markerSize.min, markerSize.max])
-
+	const values = dataset.map((d) => d.numberOfIncidents);
+	const markerScale = d3.scaleSqrt().domain([0, d3.max(values)]).range([markerSize.min, markerSize.max])
 	if (!width) return null
 
 	return (
@@ -106,7 +106,7 @@ export default function USMap({
 				viewBox={`0 0 ${width} ${height}`}
 				aria-labelledby={id}
 				ref={setSvgEl}
-				style={{display: 'block'}}
+				style={{ display: 'block' }}
 			>
 				{description ? (<desc>{description}</desc>) : null}
 				<svg
@@ -148,8 +148,8 @@ export default function USMap({
 							fill={hoveredElement === null
 								? '#E07A5F'
 								: hoveredElement === `${aggregationLocality(d)}`
-								? '#E07A5F'
-								: 'white'
+									? '#E07A5F'
+									: 'white'
 							}
 							stroke={'black'}
 							strokeWidth={hoveredElement === `${aggregationLocality(d)}` ? markerBorder.hover : markerBorder.normal}
@@ -272,16 +272,14 @@ export default function USMap({
 								stroke: 'black',
 								fill: 'white',
 								strokeWidth: 1,
-								transform: `translate(${
-									hoveredElement === 'Abroad' ? width - paddings.arrow : width - paddings.arrow - 50
-								},${
-									height -
+								transform: `translate(${hoveredElement === 'Abroad' ? width - paddings.arrow : width - paddings.arrow - 50
+									},${height -
 									paddings.bottom -
 									markerBorder.grid -
 									paddings.text -
 									(width > 400 ? 14 : 12) +
 									1
-								})`,
+									})`,
 								opacity: hoveredElement === 'Abroad' ? 1 : 0,
 								pointerEvents: 'none',
 							}}
@@ -329,16 +327,14 @@ export default function USMap({
 								stroke: '#8F8F8F',
 								fill: 'white',
 								strokeWidth: 1,
-								transform: `translate(${
-									width - paddings.arrowSmall + 3 + (hoveredElement === 'Abroad' ? 150 : 0)
-								},${
-									height -
+								transform: `translate(${width - paddings.arrowSmall + 3 + (hoveredElement === 'Abroad' ? 150 : 0)
+									},${height -
 									paddings.bottom -
 									markerBorder.grid -
 									paddings.text -
 									(width > 400 ? 14 : 12) +
 									3
-								})`,
+									})`,
 								opacity: hoveredElement === 'Abroad' ? 0 : 1,
 								pointerEvents: 'none',
 							}}
@@ -415,15 +411,15 @@ export default function USMap({
 					</g>
 				)}
 
-			  	{addBottomBorder ? (
-				  <line
-					x1={0}
-					x2={width}
-					y1={height - paddings.bottom}
-					y2={height - paddings.bottom}
-					style={{ stroke: 'black', strokeWidth: markerBorder.grid }}
-					shapeRendering="crispEdges"
-				  />
+				{addBottomBorder ? (
+					<line
+						x1={0}
+						x2={width}
+						y1={height - paddings.bottom}
+						y2={height - paddings.bottom}
+						style={{ stroke: 'black', strokeWidth: markerBorder.grid }}
+						shapeRendering="crispEdges"
+					/>
 				) : null}
 			</svg>
 		</>


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1924 

Changes proposed in this pull request:
- Fetch the max city size to calculate the domain before scaling
- Bound the range at radius 60 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


### If you made any frontend change
Before & after this change, where the largest bubble is for a state with 500 incidents and the smallest is for 1

<img width="496" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/6d0f0f42-492f-4e9a-84c8-387300871f41" />
<img width="466" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/810e7d3a-acbe-46ff-a29d-fa5f315d424c" />


