### PR TITLE
Shows organization in blog cards if author is not present

### DIFF
--- a/blog/templates/blog/_blog_card.html
+++ b/blog/templates/blog/_blog_card.html
@@ -34,12 +34,16 @@
 						{{ post.publication_datetime|date:"F j, Y" }}
 					</time>
 				</dd>
-				{% if post.authors.count %}
+				{% if post.authors.count or post.organization %}
 					<dt>Written by</dt>
 					<dd>
-						{% for author in post.authors.all %}
-							{{ author.summary }}{% if not forloop.last %}, {% endif %}
-						{% endfor %}
+						{% if post.authors.count %}
+							{% for author in post.authors.all %}
+								{{ author.summary }}{% if not forloop.last %}, {% endif %}
+							{% endfor %}
+						{% else %}
+							{{ post.organization.title }}
+						{% endif %}
 					</dd>
 				{% endif %}
 			</dl>


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1987 .

Changes proposed in this pull request:
Adds a check in article cards, to show organization if author is not present for a blog.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
Find a blog in the admin without an athor, but which has an organization. Add that to the featured blogs in the blog index page. The "Written By" should show the organization.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader