### PR TITLE
Add wagtail info to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -254,6 +254,20 @@ helpful to restore your snapshot from develop, so that the migrations
 for the new branch, which were presumably based off of develop, will
 have a clean starting point.
 
+
+Managing content
+=============
+
+Wagtail
+-------------
+The Wagtail interface can be accessed at the ``/admin`` route. By default, the credentials are:
+
+* username - ``test``
+* password - ``test``
+
+Note: these are the same django superuser credentials which can be used at ``/django-admin``.
+
+
 Deployment
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -255,11 +255,8 @@ for the new branch, which were presumably based off of develop, will
 have a clean starting point.
 
 
-Managing content
+Managing CMS Content
 =============
-
-Wagtail
--------------
 
 You can log in to the Wagtail interface at ``/admin`` with the following credentials:
 

--- a/README.rst
+++ b/README.rst
@@ -260,12 +260,11 @@ Managing content
 
 Wagtail
 -------------
-The Wagtail interface can be accessed at the ``/admin`` route. By default, the credentials are:
+
+You can log in to the Wagtail interface at ``/admin`` with the following credentials:
 
 * username - ``test``
 * password - ``test``
-
-Note: these are the same django superuser credentials which can be used at ``/django-admin``.
 
 
 Deployment


### PR DESCRIPTION
Add a small section to the readme with wagtail credentials. Otherwise I think the only way to get this is to look at the `auth_user` table and guess the password?

LMK if it fits better somewhere else, or you think any other details should be included.