### PR TITLE
Rename of fpf-misc-resources to fpf-security-allowlists

### DIFF
--- a/scripts/safety_check.py
+++ b/scripts/safety_check.py
@@ -7,7 +7,7 @@ import sys
 import pathlib
 
 
-CENTRALIZATION_REPO_NAME = "fpf-misc-resources"
+CENTRALIZATION_REPO_NAME = "fpf-security-allowlists"
 
 
 def check_full_report(ids_to_ignore=[]):


### PR DESCRIPTION
Should be reviewed ahead of time, and merged together with rename.

See https://github.com/freedomofpress/infrastructure/issues/5925 (FPF-internal)