### PR TITLE
Add a stub template for Person Pages to prevent errors on preview

### DIFF
--- a/common/templates/common/person_page.html
+++ b/common/templates/common/person_page.html
@@ -1,0 +1,1 @@
+{% if request.is_preview %}Person Pages cannot be previewed because they are not stand-alone pages.  The information entered here will only appear in the context of the Incident Pages and Blog Pages they are associated with.{% endif %}


### PR DESCRIPTION
## Description

PersonPages are technically subclasses of `Page` but they aren't used like pages. This meant they weren't given a template in the site redesign, but without a template the live preview feature will attempt to render it while editing.  This stub template will now prevent that error.

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

When editing a person page in the admin, if the preview panel is opened, the panel should display a message about the impossibility of previewing this page type. There should be no error in the console or displayed in the preview pane.

<img width="1712" height="693" alt="image" src="https://github.com/user-attachments/assets/0941df5f-f9ef-47fd-b490-cbe8f98394c3" />

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
