### PR TITLE
Set codeowners to different FPF teams instead of individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# The full web team are codeowners for all website changes
-*   @harrislapiroff @chigby @SaptakS @dkaoster
+# Web team developers are codeowners for all website changes
+*   @freedomofpress/fpf-web-developers
 
-# Harris should be in the loop on all ownership modifications
-.github/CODEOWNERS    @harrislapiroff
+# The web team manager(s) should be in the loop on all ownership modifications
+.github/CODEOWNERS    @freedomofpress/fpf-web-managers


### PR DESCRIPTION
## Description

Set codeowners to different FPF teams instead of individuals

Part of https://github.com/freedomofpress/fpf-www-projects/issues/485.
