### PR TITLE
Fix using localhost registry for chartgen image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -65,5 +65,5 @@ jobs:
         USERID=1001
         NPM_VER=10.9.2
       tags: ${{ needs.prepare.outputs.tags }}
-      registry: localhost/pressfreedomtracker-us-chartgen
+      registry: ghcr.io/freedomofpress/pressfreedomtracker-us-chartgen
 


### PR DESCRIPTION
## Description

Fixes publishing the chartgen container image to GHCR. Currently the image is only tagged for the `localhost` repository which is not pushed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field
- [x] CI/CD change
