### PR TITLE
Fix using development input that is not supported by oci-build workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,6 @@ jobs:
         NPM_VER=9.6.7
       registry: ghcr.io/freedomofpress/pressfreedomtracker-us
       requires-deep-history: true
-      default-branch: prod
       add-branch-tags: true
 
   build-chartgen:
@@ -42,6 +41,5 @@ jobs:
         USERID=1001
         NPM_VER=10.9.2
       registry: ghcr.io/freedomofpress/pressfreedomtracker-us-chartgen
-      default-branch: prod
       add-branch-tags: true
 


### PR DESCRIPTION
Fixes an error introduced in #2065 caused by leftover development parameters for freedomofpress/actionslib#34

See [here](https://github.com/freedomofpress/pressfreedomtracker.us/actions/runs/20350147333/workflow) for example failure