### PR TITLE
Adds full_clean step in autocomplete object creation

### DIFF
--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -700,7 +700,10 @@ class CommonTag(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_comma(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(
         max_length=255,

--- a/common/tests/test_common_tag.py
+++ b/common/tests/test_common_tag.py
@@ -26,3 +26,7 @@ class TestUnusedTags(TestCase):
     def test_validation_autocomplete_tag_creation(self):
         with self.assertRaises(ValidationError):
             CommonTag.autocomplete_create('hello,world')
+
+        CommonTag.autocomplete_create('tag')
+        with self.assertRaises(ValidationError):
+            CommonTag.autocomplete_create('tag')

--- a/incident/models/items.py
+++ b/incident/models/items.py
@@ -11,7 +11,10 @@ class Journalist(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(max_length=255, validators=[validate_disallow_AND])
 
@@ -26,7 +29,10 @@ class Institution(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(max_length=255, unique=True, validators=[validate_disallow_AND])
 
@@ -41,7 +47,10 @@ class GovernmentWorker(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(max_length=255, unique=True, validators=[validate_disallow_AND])
 
@@ -57,7 +66,10 @@ class GovernmentWorker(ClusterableModel):
 class LawEnforcementOrganization(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(max_length=255, unique=True)
 
@@ -96,7 +108,10 @@ class Charge(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(
         max_length=255,
@@ -115,7 +130,10 @@ class Nationality(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(
         max_length=255,
@@ -135,7 +153,10 @@ class PoliticianOrPublic(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(
         max_length=255,
@@ -155,7 +176,10 @@ class PoliticianOrPublic(ClusterableModel):
 class Venue(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
-        return kls.objects.create(title=value)
+        instance = kls(title=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     title = models.CharField(
         max_length=255,

--- a/incident/models/snippets.py
+++ b/incident/models/snippets.py
@@ -10,7 +10,10 @@ class Equipment(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
         validate_disallow_AND(value)
-        return kls.objects.create(name=value)
+        instance = kls(name=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     autocomplete_search_field = 'name'
 
@@ -37,7 +40,10 @@ class Equipment(ClusterableModel):
 class State(ClusterableModel):
     @classmethod
     def autocomplete_create(kls, value):
-        return kls.objects.create(name=value)
+        instance = kls(name=value)
+        instance.full_clean()
+        instance.save()
+        return instance
 
     autocomplete_search_field = 'name'
 

--- a/incident/tests/test_category_field_values.py
+++ b/incident/tests/test_category_field_values.py
@@ -19,8 +19,11 @@ from incident.models import (
     IncidentPage,
     Institution,
     Journalist,
+    LawEnforcementOrganization,
     Nationality,
     PoliticianOrPublic,
+    State,
+    Venue,
     choices,
 )
 from incident.tests.factories import (
@@ -190,18 +193,37 @@ class TestCategoryFieldValuesByField(TestCase):
             {field_name: '0'},
         )
 
-    def assert_validation(self, model_name):
+    def assert_and_validation(self, model_name):
         with self.assertRaises(ValidationError):
             model_name.autocomplete_create('hello AND world')
 
+    def assert_duplicate_validation(self, model_name):
+        model_name.autocomplete_create('title')
+        with self.assertRaises(ValidationError):
+            model_name.autocomplete_create('title')
+
     def test_validation_autocomplete_field_creation(self):
-        self.assert_validation(Equipment)
-        self.assert_validation(Journalist)
-        self.assert_validation(Institution)
-        self.assert_validation(GovernmentWorker)
-        self.assert_validation(Charge)
-        self.assert_validation(Nationality)
-        self.assert_validation(PoliticianOrPublic)
+        self.assert_and_validation(Equipment)
+        self.assert_and_validation(Journalist)
+        self.assert_and_validation(Institution)
+        self.assert_and_validation(GovernmentWorker)
+        self.assert_and_validation(Charge)
+        self.assert_and_validation(Nationality)
+        self.assert_and_validation(PoliticianOrPublic)
+
+        self.assert_duplicate_validation(Equipment)
+        self.assert_duplicate_validation(State)
+        self.assert_duplicate_validation(Institution)
+        self.assert_duplicate_validation(GovernmentWorker)
+        self.assert_duplicate_validation(LawEnforcementOrganization)
+        self.assert_duplicate_validation(Charge)
+        self.assert_duplicate_validation(Nationality)
+        self.assert_duplicate_validation(PoliticianOrPublic)
+        self.assert_duplicate_validation(Venue)
+
+        # Journalist is not unique, so calling same thing should not raise any error
+        Journalist.autocomplete_create('title')
+        self.assertEqual(Journalist.autocomplete_create('title').title, 'title')
 
     def test_arrest_status(self):
         self.assert_choices(


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1483.

Changes proposed in this pull request:
Adds the `full_clean` method in the `autocomplete_create` method to raise `ValidationError` instead of giving 500 error.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing

How should the reviewer test this PR?
Try creating a duplicate autocomplete object and it should raise a ValidationError instead of throwing 500.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
