### PR TITLE
Updates ordering for meta image and description for incidents

### DIFF
--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -1157,18 +1157,18 @@ class IncidentPage(MetadataPageMixin, Page):
 
     def get_meta_image(self):
         return (
-            self.teaser_image or
             self.search_image or
+            self.teaser_image or
             (self.get_main_category() and self.get_main_category().default_image) or
             self._get_ssssettings().default_image
         )
 
     def get_meta_description(self):
-        if self.teaser:
-            return self.teaser
-
         if self.search_description:
             return self.search_description
+
+        if self.teaser:
+            return self.teaser
 
         return truncatewords(
             strip_tags(self.body.render_as_block()),

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -1580,6 +1580,54 @@ class IncidentPageTests(TestCase):
             f'targeted_institutions={inst.title}'
         )
 
+    def test_get_meta_image(self):
+        search_image = CustomImageFactory.create(
+            file__width=333,
+            file__height=444,
+            file__color='orange',
+            collection__name='Photos',
+        )
+        tease_image = CustomImageFactory.create(
+            file__width=333,
+            file__height=444,
+            file__color='green',
+            collection__name='Photos',
+        )
+        inc1 = IncidentPageFactory(
+            parent=self.incident_index,
+            teaser_image=tease_image,
+        )
+        inc2 = IncidentPageFactory(
+            parent=self.incident_index,
+            search_image=search_image,
+        )
+        self.assertEqual(
+            inc1.get_meta_image(),
+            inc1.teaser_image
+        )
+        self.assertEqual(
+            inc2.get_meta_image(),
+            inc2.search_image
+        )
+
+    def test_get_meta_description(self):
+        inc1 = IncidentPageFactory(
+            parent=self.incident_index,
+            search_description='test description 1',
+        )
+        inc2 = IncidentPageFactory(
+            parent=self.incident_index,
+            teaser='test description 2',
+        )
+        self.assertEqual(
+            inc1.get_meta_description(),
+            inc1.search_description
+        )
+        self.assertEqual(
+            inc2.get_meta_description(),
+            inc2.teaser
+        )
+
 
 def create_prior_restraint_incident(
         *,


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1931.

Changes proposed in this pull request:
This PR just updates the order of preference for meta image and description in incdent page as mentioned in https://github.com/freedomofpress/pressfreedomtracker.us/issues/1931#issuecomment-2634413353 . Though the issue was just about image, I have updated the description also to follow the same preference order.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field