### PR TITLE
fix: update GitHub actions to current versions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -110,19 +110,19 @@ jobs:
         fetch-depth: 0
 
     - name: Download dev django image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-dev-django.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
 
     - name: Download dev node image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-dev-node.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
 
     - name: Download dev chartgen image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-dev-chartgen.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
@@ -225,7 +225,7 @@ jobs:
         python -m pip install --requirement=ci-requirements.txt --require-hashes --disable-pip-version-check --no-color --no-input
 
     - name: Download coverage artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.test.outputs.artifact-pytestcov }}
         path: ${{ runner.temp }}/coverage
@@ -252,13 +252,13 @@ jobs:
         persist-credentials: false
 
     - name: Download django image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-prod-django.outputs.artifact-name }}
         path: ${{ runner.temp }}/images
 
     - name: Download chartgen image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ${{ needs.build-prod-chartgen.outputs.artifact-name }}
         path: ${{ runner.temp }}/images

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -214,7 +214,7 @@ jobs:
         python-version: ${{ env.VERSION_PYTHON }}
 
     - name: Configure Job Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/pip

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -99,7 +99,7 @@ jobs:
         - stylelint
     steps:
     - name: Install Docker
-      uses: docker/setup-docker-action@v4
+      uses: docker/setup-docker-action@v5
       with:
         version: ${{ env.VERSION_DOCKER }}
 
@@ -242,7 +242,7 @@ jobs:
     - build-prod-chartgen
     steps:
     - name: Install Docker
-      uses: docker/setup-docker-action@v4
+      uses: docker/setup-docker-action@v5
       with:
         version: ${{ env.VERSION_DOCKER }}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -104,7 +104,7 @@ jobs:
         version: ${{ env.VERSION_DOCKER }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: true
         fetch-depth: 0
@@ -203,7 +203,7 @@ jobs:
       actions: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: true
         fetch-depth: 0
@@ -247,7 +247,7 @@ jobs:
         version: ${{ env.VERSION_DOCKER }}
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: false
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -209,7 +209,7 @@ jobs:
         fetch-depth: 0
     
     - name: Install Python ${{ env.VERSION_PYTHON }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.VERSION_PYTHON }}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -171,7 +171,7 @@ jobs:
         docker compose --file="$COMPOSE_FILE_DEV" logs node
 
     - name: Save HTML coverage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ matrix.target == 'dev-tests' }}
       with:
         name: test-${{ matrix.target }}-${{ github.run_id }}-htmlcov
@@ -181,7 +181,7 @@ jobs:
         retention-days: 5
 
     - name: Save PyTest coverage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ matrix.target == 'dev-tests'}}
       with:
         name: test-${{ matrix.target }}-${{ github.run_id }}-pytestcov


### PR DESCRIPTION
## Description
Update GitHub actions to current versions:
- update actions/download-artifact from v4 to v6
- update actions/upload-artifact from v4 to v7
- update docker/setup-docker-action from v4 to v5
- update actions/setup-python from v4 to v6
- update actions/checkout from v4 to v6
- update actions/cache from v4 to v5

Resolves deprecation warnings about Node v20.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field


## Testing
Ensure CI passes.