### PR TITLE
build: bump Pygments to 2.20.0

### DIFF
--- a/ci-requirements.in
+++ b/ci-requirements.in
@@ -1,3 +1,4 @@
 diff-cover>=8.0.3
 pytest
 pytest-testinfra
+pygments>=2.20.0

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -84,10 +84,12 @@ pluggy==0.13.1 \
     # via
     #   diff-cover
     #   pytest
-pygments==2.15.1 \
-    --hash=sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c \
-    --hash=sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1
-    # via diff-cover
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via
+    #   -r ci-requirements.in
+    #   diff-cover
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1135,9 +1135,9 @@ pyflakes==3.1.0 \
     --hash=sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774 \
     --hash=sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc
     # via flake8
-pygments==2.17.2 \
-    --hash=sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c \
-    --hash=sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via
     #   -r requirements.txt
     #   ipython

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ Jinja2>=3.1.6
 mailchimp_marketing>=3.0.66
 marshmallow>=3.26.2,<4
 psycopg2>=2.9.9
-Pygments
+Pygments>=2.20.0
 python-json-logger
 pillow>=10.2.0
 requests>=2.33.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -887,9 +887,9 @@ pycparser==2.21 \
     --hash=sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9 \
     --hash=sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
     # via cffi
-pygments==2.17.2 \
-    --hash=sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c \
-    --hash=sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via -r requirements.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \


### PR DESCRIPTION
## Description
This addresses a CVE in Pygments:
https://github.com/advisories/GHSA-5239-wwwm-4pmq: https://getsafety.com/vulnerabilities/SFTY-20260322-35073

I've pinned Pygments directly in ci-requiremwents.in, since it comes to us via the chain of dependencies.

This is a minor version upgrade for Pygments.

## Type of change
- [x] Vulnerabilities update

## Related issues
PFT https://github.com/freedomofpress/freedom.press/pull/2760
SDO https://github.com/freedomofpress/securedrop.org/pull/1247