### PR TITLE
build: update lodash to 4.18.0 (chart_pregenerator)

### DIFF
--- a/chart_pregenerator/package-lock.json
+++ b/chart_pregenerator/package-lock.json
@@ -15,7 +15,7 @@
         "d3": "^7.1.1",
         "esbuild": "^0.25.0",
         "express": "^4.18.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "node-fetch": "^3.3.1",
         "react": "^18.2.0",
         "react-animated-dataset": "^0.4.0",
@@ -7500,9 +7500,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -14235,9 +14235,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/chart_pregenerator/package.json
+++ b/chart_pregenerator/package.json
@@ -18,7 +18,7 @@
     "d3": "^7.1.1",
     "esbuild": "^0.25.0",
     "express": "^4.18.2",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "node-fetch": "^3.3.1",
     "react": "^18.2.0",
     "react-animated-dataset": "^0.4.0",


### PR DESCRIPTION
## Description
This addresses CVEs in lodash:

- CVE-2026-2950: https://github.com/advisories/GHSA-f23m-r3pf-42rh
- CVE-2026-4800: https://github.com/advisories/GHSA-r5fr-rjxr-66jc

I've used an override in `package.json`, since lodash comes to us via several other dependencies.

## Type of change

- [x] Vulnerabilities update
