### PR TITLE
build: update path-to-regexp to 0.1.13

### DIFF
--- a/chart_pregenerator/package-lock.json
+++ b/chart_pregenerator/package-lock.json
@@ -7965,9 +7965,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/performance-now": {
@@ -12450,7 +12450,7 @@
         "methods": "~1.1.2",
         "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
+        "path-to-regexp": "^0.1.13",
         "proxy-addr": "~2.0.7",
         "qs": "~6.14.0",
         "range-parser": "~1.2.1",
@@ -14553,9 +14553,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/chart_pregenerator/package.json
+++ b/chart_pregenerator/package.json
@@ -10,6 +10,9 @@
     "test": "jest --passWithNoTests --coverage",
     "test-update": "jest -u --passWithNoTests --coverage"
   },
+  "overrides": {
+    "path-to-regexp": "^0.1.13"
+  },
   "dependencies": {
     "@resvg/resvg-js": "^2.4.1",
     "@visx/responsive": "^3.0.0",


### PR DESCRIPTION
## Description
This addresses a CVE in path-to-regexp:

- CVE-2026-4867: https://github.com/advisories/GHSA-37ch-88jc-xwx2

I've used an override in `package.json`, since path-to-regexp comes to us via several other dependencies.

## Type of change

- [x] Vulnerabilities update
