### PR TITLE
fix: update docker compose command in shell script

### DIFF
--- a/devops/scripts/browser-open.sh
+++ b/devops/scripts/browser-open.sh
@@ -24,7 +24,7 @@ else
     export PORT=8000
 fi
 
-export DJANGO_URL="http://$(docker-compose -f ${DOCKER_COMPOSE_FILE} port ${CONTAINER} ${PORT})"
+export DJANGO_URL="http://$(docker compose -f ${DOCKER_COMPOSE_FILE} port ${CONTAINER} ${PORT})"
 
 # Are we on Linux?
 if [[ "${PLATFORM}" == *"linux"* ]]; then


### PR DESCRIPTION
## Description
Update docker compose command in shell script. (`docker-compose` is old, `docker compose` is new.) Matches FPF behavior, which already fixed this.

Fixes
```
zsh: docker-compose not found
```

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field
