### PR TITLE
Adds a check to see the type of content_warning block

### DIFF
--- a/common/blocks.py
+++ b/common/blocks.py
@@ -14,7 +14,7 @@ import bleach
 from common.choices import BACKGROUND_COLOR_CHOICES
 from common.models.charts import (
     BubbleMapChartOptionsSchema,
-    HexbinMapChartOptionsSchema
+    HexbinMapChartOptionsSchema,
 )
 from common.models.helpers import get_categories, get_states, get_tags
 from common.search import get_searchable_content_for_fields
@@ -107,7 +107,7 @@ class AlignedCaptionedImageBlock(blocks.StructBlock):
 
     def get_context(self, value, **kwargs):
         context = super(AlignedCaptionedImageBlock, self).get_context(value, **kwargs)
-        if value['content_warning'] and type(value['content_warning']) == blocks.list_block.ListValue:
+        if value['content_warning'] and isinstance(value['content_warning'], blocks.list_block.ListValue):
             value['content_warning'] = value['content_warning'][0]
         return context
 

--- a/common/blocks.py
+++ b/common/blocks.py
@@ -107,7 +107,7 @@ class AlignedCaptionedImageBlock(blocks.StructBlock):
 
     def get_context(self, value, **kwargs):
         context = super(AlignedCaptionedImageBlock, self).get_context(value, **kwargs)
-        if value['content_warning']:
+        if value['content_warning'] and type(value['content_warning']) == blocks.list_block.ListValue:
             value['content_warning'] = value['content_warning'][0]
         return context
 

--- a/common/tests/test_blocks.py
+++ b/common/tests/test_blocks.py
@@ -1,24 +1,23 @@
 from django.test import TestCase
 
 from common.blocks import AlignedCaptionedImageBlock
-from common.tests.factories import AlignedCaptionedImageBlockFactory
 
 
 class AlignedCaptionedImageBlockGetContextTest(TestCase):
     def test_get_context_with_content_warning_unwraps_first_item(self):
+        warning_text = 'This image may be disturbing.'
         block = AlignedCaptionedImageBlock()
-        value = AlignedCaptionedImageBlockFactory()
-        value['content_warning'] = ['This image may be disturbing.']
-
+        value = block.to_python({
+            'content_warning': [warning_text],
+        })
         block.get_context(value)
-
-        self.assertEqual(value['content_warning'], 'This image may be disturbing.')
+        self.assertEqual(value['content_warning'], warning_text)
 
     def test_get_context_without_content_warning_leaves_value_unchanged(self):
         block = AlignedCaptionedImageBlock()
-        value = AlignedCaptionedImageBlockFactory()
-        value['content_warning'] = []
+        value = block.to_python({
+            'content_warning': [],
+        })
 
         block.get_context(value)
-
-        self.assertEqual(value['content_warning'], [])
+        self.assertEqual(list(value['content_warning']), [])


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes issue with content warning text where only the first character is shown. I was actually not able to reproduce it locally, but seems like it is happening in staging: https://staging.pressfreedomtracker.us/all-incidents/alaska-state-senator-slaps-journalist/

My theory for adding that was because locally that block always returns a ListValue list of strings, but I am guessing in some cases it just returns a string, in which case maybe it just takes the first character. I added a check that it only tries to take the first element if the value is of type ListValue. This should ensure that if it is a string, it won't take the 0th element. I was not able to test it since I can't reproduce the error locally.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader