### PR TITLE
Add image build trigger for django-5.2.13 branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 
 on:
   push:
-    branches: ['develop', 'prod']
+    branches: ['develop', 'prod', 'django-5.2.13']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Adds a build trigger for the `django-5.2.13` branch to publish images built from it

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [x] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

N/a

### Post-deployment actions

N/a

## Checklist

### General checks

N/a

### If you made changes to API flow:

N/a

### If you made changes to incident model metadata

N/a

### If you made changes to blog

N/a

### If you made changes to shared templates (e.g. card design, lead media, etc.)

N/a

### If you made changes to email signup flow

N/a

### If you made changes to "Submit an Incident" form

N/a

### If it's a major change

N/a

### If you made any frontend change

N/a
