### PR TITLE
fix: remove django 5.2 branch from publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish
 
 on:
   push:
-    branches: ['develop', 'prod', 'django-5.2.13']
+    branches: ['develop', 'prod']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
Remove django 5.2 branch from publish workflow. This was only needed for testing.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field