### PR TITLE
fix: update Debian Bookworm to Trixie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ compile-pip-dependencies: ## Uses pip-compile to update requirements.txt
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --output-file requirements.txt requirements.in && \
@@ -61,7 +61,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
@@ -71,7 +71,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 .PHONY: pip-upgrade
 pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 # in requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file requirements.txt requirements.in && \
@@ -80,7 +80,7 @@ pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 .PHONY: pip-dev-upgrade
 pip-dev-upgrade: ## Uses pip-compile to update all dev requirements that are not pinned
 # in dev-requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file dev-requirements.txt dev-requirements.in'
@@ -90,7 +90,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
@@ -98,7 +98,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 
 .PHONY: upgrade-pip-tools
 upgrade-pip-tools: ## Update the version of pip-tools used for other pip-related make commands
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-trixie \
 		bash -c 'pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package pip-tools --output-file pip-tools-requirements.txt pip-tools-requirements.in'
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ compile-pip-dependencies: ## Uses pip-compile to update requirements.txt
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-bookworm \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --output-file requirements.txt requirements.in && \
@@ -61,7 +61,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-bookworm \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in && \
@@ -71,7 +71,7 @@ pip-update: ## Uses pip-compile to update requirements.txt for upgrading a speci
 .PHONY: pip-upgrade
 pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 # in requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-bookworm \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file requirements.txt requirements.in && \
@@ -80,7 +80,7 @@ pip-upgrade: ## Uses pip-compile to update all requirements that are not pinned
 .PHONY: pip-dev-upgrade
 pip-dev-upgrade: ## Uses pip-compile to update all dev requirements that are not pinned
 # in dev-requirements.in
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-bookworm \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
     pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade --output-file dev-requirements.txt dev-requirements.in'
@@ -90,7 +90,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 # It is critical that we run pip-compile via the same Python version
 # that we're generating requirements for, otherwise the versions may
 # be resolved differently.
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-bookworm \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
 		bash -c 'apt-get update && apt-get install gcc libpq-dev -y && \
 	pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package $(PACKAGE) --output-file dev-requirements.txt dev-requirements.in'
@@ -98,7 +98,7 @@ pip-dev-update: ## Uses pip-compile to update dev-requirements.txt for upgrading
 
 .PHONY: upgrade-pip-tools
 upgrade-pip-tools: ## Update the version of pip-tools used for other pip-related make commands
-	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.5-slim-bookworm \
+	docker run --rm -v "$(DIR):/code" -w /code -it python:3.14.4-slim-trixie \
 		bash -c 'pip install pip-tools && \
 		pip-compile --generate-hashes --no-header --allow-unsafe --upgrade-package pip-tools --output-file pip-tools-requirements.txt pip-tools-requirements.in'
 
@@ -131,7 +131,7 @@ lint: ruff
 .PHONY: ruff
 ruff: ## Runs ruff linting in Python3 container.
 	@docker run --rm -v $(PWD):/code -w /code --name fpf_www_ruff --rm \
-			python:3.14.5-slim-bookworm \
+			python:3.14.5-slim-trixie \
 			bash -c "pip install -q ruff && ruff check && ruff format --check"
 
 .PHONY: check-migrations

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 for python:3.14.5-slim-bookworm on linux/amd64 as of 2026-05-20
-FROM python:3.14.5-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS python-base
+# sha256 for python:3.14.4-slim-trixie on linux/amd64 as of 2026-05-06
+FROM python:3.14.4-slim-trixie@sha256:c11aee3b3cae066f55d1e9318fc812673aa6557073b0db0d792b59491b262e0c AS python-base
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
 # sha256 for python:3.14.5-slim-trixie on linux/amd64 as of 2026-05-20
-FROM python:3.14.5-slim-trixie@sha256:sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
+FROM python:3.14.5-slim-trixie@sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/devops/docker/DevDjangoDockerfile
+++ b/devops/docker/DevDjangoDockerfile
@@ -1,5 +1,5 @@
-# sha256 for python:3.14.4-slim-trixie on linux/amd64 as of 2026-05-06
-FROM python:3.14.4-slim-trixie@sha256:c11aee3b3cae066f55d1e9318fc812673aa6557073b0db0d792b59491b262e0c AS python-base
+# sha256 for python:3.14.5-slim-trixie on linux/amd64 as of 2026-05-20
+FROM python:3.14.5-slim-trixie@sha256:sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -18,8 +18,8 @@ RUN npm install --global gulp-cli
 COPY ./ /src-files
 RUN cd /src-files && ( npm install && npm run build )
 
-# sha256 for python:3.14.4-slim-trixie on linux/amd64 as of 2026-05-06
-FROM python:3.14.4-slim-trixie@sha256:c11aee3b3cae066f55d1e9318fc812673aa6557073b0db0d792b59491b262e0c AS python-base
+# sha256 for python:3.14.5-slim-trixie on linux/amd64 as of 2026-05-20
+FROM python:3.14.5-slim-trixie@sha256:sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
 
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="pressfreedomtracker.us"

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -18,8 +18,8 @@ RUN npm install --global gulp-cli
 COPY ./ /src-files
 RUN cd /src-files && ( npm install && npm run build )
 
-# sha256 for python:3.14.5-slim-bookworm on linux/amd64 as of 2026-05-20
-FROM python:3.14.5-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS python-base
+# sha256 for python:3.14.4-slim-trixie on linux/amd64 as of 2026-05-06
+FROM python:3.14.4-slim-trixie@sha256:c11aee3b3cae066f55d1e9318fc812673aa6557073b0db0d792b59491b262e0c AS python-base
 
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="pressfreedomtracker.us"

--- a/devops/docker/ProdDjangoDockerfile
+++ b/devops/docker/ProdDjangoDockerfile
@@ -19,7 +19,7 @@ COPY ./ /src-files
 RUN cd /src-files && ( npm install && npm run build )
 
 # sha256 for python:3.14.5-slim-trixie on linux/amd64 as of 2026-05-20
-FROM python:3.14.5-slim-trixie@sha256:sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
+FROM python:3.14.5-slim-trixie@sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
 
 LABEL MAINTAINER="Freedom of the Press Foundation"
 LABEL APP="pressfreedomtracker.us"

--- a/devops/docker/ci-python-dockerfile
+++ b/devops/docker/ci-python-dockerfile
@@ -1,5 +1,5 @@
 # sha256 for python:3.14.5-slim-trixie on linux/amd64 as of 2026-05-20
-FROM python:3.14.5-slim-trixie@sha256:sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
+FROM python:3.14.5-slim-trixie@sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
 
 LABEL maintainer="Freedom of the Press Foundation"
 

--- a/devops/docker/ci-python-dockerfile
+++ b/devops/docker/ci-python-dockerfile
@@ -1,5 +1,5 @@
-# sha256 for python:3.14.4-slim-trixie on linux/amd64 as of 2026-05-06
-FROM python:3.14.4-slim-trixie@sha256:c11aee3b3cae066f55d1e9318fc812673aa6557073b0db0d792b59491b262e0c AS python-base
+# sha256 for python:3.14.5-slim-trixie on linux/amd64 as of 2026-05-20
+FROM python:3.14.5-slim-trixie@sha256:sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee460a404a13da9029fe41604 AS python-base
 
 LABEL maintainer="Freedom of the Press Foundation"
 

--- a/devops/docker/ci-python-dockerfile
+++ b/devops/docker/ci-python-dockerfile
@@ -1,10 +1,10 @@
-# sha256 for python:3.14.5-slim-bookworm on linux/amd64 as of 2026-05-20
-FROM python:3.14.5-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb AS python-base
+# sha256 for python:3.14.4-slim-trixie on linux/amd64 as of 2026-05-06
+FROM python:3.14.4-slim-trixie@sha256:c11aee3b3cae066f55d1e9318fc812673aa6557073b0db0d792b59491b262e0c AS python-base
 
 LABEL maintainer="Freedom of the Press Foundation"
 
 RUN apt-get update &&\
-    apt-get install --no-install-recommends git -y &&\
-    apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
-    rm -rf /usr/share/locale
+apt-get install --no-install-recommends git -y &&\
+apt-get clean && rm -rf /var/lib/apt/lists/* &&\
+rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
+rm -rf /usr/share/locale

--- a/devops/docker/ci-python-dockerfile
+++ b/devops/docker/ci-python-dockerfile
@@ -4,7 +4,7 @@ FROM python:3.14.5-slim-trixie@sha256:a7185a8e40af01bf891414a4df16ef10fc6000cee4
 LABEL maintainer="Freedom of the Press Foundation"
 
 RUN apt-get update &&\
-apt-get install --no-install-recommends git -y &&\
-apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
-rm -rf /usr/share/locale
+    apt-get install --no-install-recommends git -y &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/* &&\
+    rm -rf /usr/share/doc/ && rm -rf /usr/share/man &&\
+    rm -rf /usr/share/locale


### PR DESCRIPTION
## Description
Update Debian Bookworm to Trixie.
- Active support for Bookworm ends in June 2026.

Changes proposed in this pull request:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field
