### PR TITLE
fix: update fast-uri to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6605,9 +6605,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "brace-expansion@<1.1.13": "^1.1.13",
     "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3",
+    "fast-uri": "^3.1.2",
     "lodash": "^4.18.0"
   },
   "author": "Harris Lapiroff <harris@littleweaverweb.com>",


### PR DESCRIPTION
## Description
Update fast-uri to 3.1.2.

Addresses CVEs:
- [CVE-2026-6322](https://github.com/advisories/GHSA-v39h-62p7-jpjc) fast-uri vulnerable to host confusion via percent-encoded authority delimiters
- [CVE-2026-6321](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) fast-uri vulnerable to path traversal via percent-encoded dot segments

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field