### PR TITLE
fix: add django-upgrade, HTML exception to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: end-of-file-fixer
         name: Enforce end of file format
-        exclude: '\.svg$'
+        exclude: '\.svg$|\.html$'
 
       - id: trailing-whitespace
         name: Enforce removal of trailing whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,12 @@ repos:
     hooks:
       - id: pre-commit-update
 
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.30.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, '5.2']
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:


### PR DESCRIPTION
## Description
Add django-upgrade to pre-commit config. Already present in FPF and SDO.

Except HTML files from end-of-file-fixer (don't require a trailing newline).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
