### PR TITLE
fix: remove deprecated version attribute from docker compose file

### DIFF
--- a/prod-docker-compose.yaml
+++ b/prod-docker-compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: '3.4'
 networks:
   app:
 


### PR DESCRIPTION
## Description
remove deprecated version attribute from docker compose file
Avoids this warning:
> prod-docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
