### PR TITLE
[PFT] Video embeds for newsletters

### DIFF
--- a/blog/templates/blog/blog_page_newsletter.html
+++ b/blog/templates/blog/blog_page_newsletter.html
@@ -1,7 +1,9 @@
 {% load newsletter_richtext mrml from wagtail_newsletter %}
-{% load wagtailsettings_tags wagtailcore_tags wagtailimages_tags %}
+{% load wagtailsettings_tags wagtailcore_tags wagtailimages_tags common_tags %}
 {% load static %}
+{% load get_embed %}
 {% get_settings use_default_site=True %}
+
 
 {% mrml %}
 <mjml>
@@ -306,13 +308,18 @@
 						</mj-text>
 
 					{% elif block.block_type == "video" %}
-						<mj-text>
-							<a href="{{ block.value.video.url }}" class="link-external">
-								Watch video &rarr;
+						{% get_embed block.value.video.url as embed_data %}
+						<mj-text align="center">
+							<a target="_blank" href="{{ block.value.video.url }}" style="display: inline-block; text-decoration: none; line-height: 0;">
+								<div style="display: inline-block; position: relative; width: 75%;">
+									{% if embed_data.thumbnail_url %}
+										<img src="{{ embed_data.thumbnail_url }}" alt="{% if embed_data.title %}{{ embed_data.title }}{% else %}Open video in a new tab{% endif %}" style="display: block; width: 100%; height: auto;" />
+									{% else %}
+										<div style="background-color: #23242C; width: 100%; padding-top: 56.25%;"></div>
+									{% endif %}
+									<span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 72px; height: 72px; background: rgba(0,0,0,0.65); border-radius: 50%; text-align: center; line-height: 72px; color: white; font-size: 28px;">&#9654;</span>
+								</div>
 							</a>
-							{% if block.value.caption %}
-								<p class="meta">{{ block.value.caption|richtext }}</p>
-							{% endif %}
 						</mj-text>
 
 					{% elif block.block_type == "statistics" %}

--- a/blog/templates/blog/blog_page_newsletter.html
+++ b/blog/templates/blog/blog_page_newsletter.html
@@ -63,6 +63,11 @@
 				padding: 20px 0;
 				display: block;
 			}
+			.video-link { display: inline-block; text-decoration: none; line-height: 0; }
+			.video-wrapper { display: inline-block; position: relative; width: 75%; }
+			.video-thumbnail { display: block; width: 100%; height: auto; }
+			.video-placeholder { background-color: #23242C; width: 100%; padding-top: 56.25%; }
+			.video-play { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 72px; height: 72px; background: rgba(0,0,0,0.65); border-radius: 50%; text-align: center; line-height: 72px; color: white; font-size: 28px; }
 			figure { margin: 0; padding: 0; }
 			.image-caption {
 				background-color: #000000;
@@ -310,14 +315,14 @@
 					{% elif block.block_type == "video" %}
 						{% get_embed block.value.video.url as embed_data %}
 						<mj-text align="center">
-							<a target="_blank" href="{{ block.value.video.url }}" style="display: inline-block; text-decoration: none; line-height: 0;">
-								<div style="display: inline-block; position: relative; width: 75%;">
+							<a target="_blank" href="{{ block.value.video.url }}" class="video-link">
+								<div class="video-wrapper">
 									{% if embed_data.thumbnail_url %}
-										<img src="{{ embed_data.thumbnail_url }}" alt="{% if embed_data.title %}{{ embed_data.title }}{% else %}Open video in a new tab{% endif %}" style="display: block; width: 100%; height: auto;" />
+										<img src="{{ embed_data.thumbnail_url }}" alt="{% if embed_data.title %}{{ embed_data.title }}{% else %}Open video in a new tab{% endif %}" class="video-thumbnail" />
 									{% else %}
-										<div style="background-color: #23242C; width: 100%; padding-top: 56.25%;"></div>
+										<div class="video-placeholder"></div>
 									{% endif %}
-									<span style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 72px; height: 72px; background: rgba(0,0,0,0.65); border-radius: 50%; text-align: center; line-height: 72px; color: white; font-size: 28px;">&#9654;</span>
+									<span class="video-play">&#9654;</span>
 								</div>
 							</a>
 						</mj-text>

--- a/blog/templates/blog/blog_page_newsletter.html
+++ b/blog/templates/blog/blog_page_newsletter.html
@@ -1,9 +1,8 @@
 {% load newsletter_richtext mrml from wagtail_newsletter %}
-{% load wagtailsettings_tags wagtailcore_tags wagtailimages_tags common_tags %}
+{% load wagtailsettings_tags wagtailcore_tags wagtailimages_tags %}
 {% load static %}
 {% load get_embed %}
 {% get_settings use_default_site=True %}
-
 
 {% mrml %}
 <mjml>
@@ -325,6 +324,9 @@
 									<span class="video-play">&#9654;</span>
 								</div>
 							</a>
+							{% if block.value.caption %}
+								<p class="meta">{{ block.value.caption|richtext }}</p>
+							{% endif %}
 						</mj-text>
 
 					{% elif block.block_type == "statistics" %}

--- a/common/templatetags/get_embed.py
+++ b/common/templatetags/get_embed.py
@@ -1,0 +1,14 @@
+from django import template
+from wagtail.embeds.embeds import get_embed as wagtail_get_embed
+from wagtail.embeds.exceptions import EmbedException
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_embed(url):
+    try:
+        return wagtail_get_embed(url)
+    except EmbedException:
+        return ""

--- a/common/tests/test_get_embed_tag.py
+++ b/common/tests/test_get_embed_tag.py
@@ -1,0 +1,27 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from common.templatetags.get_embed import get_embed
+
+
+class TestGetEmbedTag(TestCase):
+    @mock.patch("common.templatetags.get_embed.wagtail_get_embed")
+    def test_returns_embed_object_on_success(self, mock_get_embed):
+        fake_embed = mock.Mock()
+        mock_get_embed.return_value = fake_embed
+
+        result = get_embed("https://www.youtube.com/watch?v=abc123")
+
+        mock_get_embed.assert_called_once_with("https://www.youtube.com/watch?v=abc123")
+        self.assertEqual(result, fake_embed)
+
+    @mock.patch("common.templatetags.get_embed.wagtail_get_embed")
+    def test_returns_empty_string_on_embed_exception(self, mock_get_embed):
+        from wagtail.embeds.exceptions import EmbedException
+
+        mock_get_embed.side_effect = EmbedException()
+
+        result = get_embed("https://www.youtube.com/watch?v=notfound")
+
+        self.assertEqual(result, "")

--- a/common/tests/test_get_embed_tag.py
+++ b/common/tests/test_get_embed_tag.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.test import TestCase
-
+import wagtail.embeds.exceptions
 from common.templatetags.get_embed import get_embed
 
 
@@ -18,9 +18,8 @@ class TestGetEmbedTag(TestCase):
 
     @mock.patch("common.templatetags.get_embed.wagtail_get_embed")
     def test_returns_empty_string_on_embed_exception(self, mock_get_embed):
-        from wagtail.embeds.exceptions import EmbedException
 
-        mock_get_embed.side_effect = EmbedException()
+        mock_get_embed.side_effect = wagtail.embeds.exceptions.EmbedException()
 
         result = get_embed("https://www.youtube.com/watch?v=notfound")
 

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -402,6 +402,8 @@ CONTENT_SECURITY_POLICY = {
             "https://scontent.cdninstagram.com",
             "data:",
             "https://cdn.jsdelivr.net",
+            "https://i.ytimg.com",  # YouTube thumbnails
+            "https://i.vimeocdn.com",  # Vimeo thumbnails
         ],
         "media-src": [SELF],
         "object-src": [SELF],


### PR DESCRIPTION
## Description

Fixes #2172 

Changes proposed in this pull request:
- add a `get_embed` template tag similar to what we have on freedom.press 
- Allow YouTube and Vimeo thumbnail domains in CSP (covers ~95% of video content)
- Show thumbnail with play button overlay in newsletter embed block instead of simple text button

Corresponding PR for FPF (in progress): https://github.com/freedomofpress/freedom.press/pull/2810 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [ ] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [ ] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:

- [ ] Verify that API responses are correct
- [ ] Verify that visualizations using the API endpoints are functional

### If you made changes to incident model metadata

- [ ] Verify incident export works correctly
- [ ] Verify incident filters are rendered correctly
- [ ] Verify incident filters show correct incidents
- [ ] Verify categories work
- [ ] Verify incidents are discoverable by search

### If you made changes to blog

- [ ] Verify that the blog index page renders correctly
- [ ] Verify that the individual blogs show all the informations correctly

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [ ] Verify that it renders correctly in homepage, if applicable
- [ ] Verify that it renders correctly in incident index page, if applicable
- [ ] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [ ] Verify that it renders correctly in individual blog page, if applicable
- [ ] Verify that it renders correctly in individual special blog page, if applicable

### If you made changes to email signup flow

- [ ] Verify that the email signup form in the footer renders and works
- [ ] Verify that the individual email signup pages work

### If you made changes to "Submit an Incident" form

- [ ] Verify that the form renders correctly and submit correctly as well

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change


BLOG


<img width="1071" height="733" alt="image" src="https://github.com/user-attachments/assets/3ead1dab-48ab-45ee-be24-c3cd5edb5704" />


NEWSLETTER

<img width="466" height="542" alt="image" src="https://github.com/user-attachments/assets/38e35bcc-01cd-4f81-961e-2a03e7e258bf" />

