### PR TITLE
fix: remove duplicate ruff Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,6 @@ ruff: ## Runs ruff linting in Python3 container.
 			python:3.12.2-slim-bookworm \
 			bash -c "pip install -q ruff && ruff check"
 
-.PHONY: ruff
-ruff: ## Runs ruff linter/formatter.
-	@docker compose run --rm django ruff check .
-
 .PHONY: check-migrations
 check-migrations: ## Check for ungenerated migrations
 	docker compose exec -T django /bin/bash -c "./manage.py makemigrations --dry-run --check"


### PR DESCRIPTION
## Description
Remove duplicate ruff Makefile rule.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field