### PR TITLE
fix: use dependabot to update pre-commit and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: 'pre-commit'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'sunday'
     cooldown:
       default-days: 7
 
@@ -16,5 +17,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'sunday'
     cooldown:
       default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.9.0
-    hooks:
-      - id: pre-commit-update
-
   - repo: https://github.com/adamchainz/django-upgrade
     rev: 1.30.0
     hooks:


### PR DESCRIPTION
## Description
- Use dependabot to update pre-commit and github-actions
- Disable pre-commit updates in .pre-commit-config.yaml
- Update ruff pre-commit hook

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field
