### PR TITLE
fix: add browserslist config to package.json

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,9 +1,0 @@
-Chrome >= 35
-Firefox >= 31
-Edge >= 12
-Explorer >= 9
-iOS >= 8
-Safari >= 8
-Android 2.3
-Android >= 4
-Opera >= 12

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "stylelint": "stylelint client/**/*.sass"
   },
   "author": "Harris Lapiroff <harris@littleweaverweb.com>",
+  "browserslist": [
+    "baseline widely available"
+  ],
   "devDependencies": {
     "@babel/core": "^7.24.4",
     "@babel/plugin-transform-modules-commonjs": "^7.24.1",


### PR DESCRIPTION
## Description
Add browserslist config to package.json. Set the configuration to `baseline widely available`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field
