### PR TITLE
Replaces X/Twitter with just X for tweet embeds in newsletter

### DIFF
--- a/blog/templates/blog/blog_page_newsletter.html
+++ b/blog/templates/blog/blog_page_newsletter.html
@@ -293,7 +293,7 @@
 					{% elif block.block_type == "tweet" %}
 						<mj-text>
 							<a href="{{ block.value.tweet.url }}" class="link-external">
-								View post on X/Twitter &rarr;
+								View post on X &rarr;
 							</a>
 						</mj-text>
 


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #2201.

Changes proposed in this pull request:
Replaces "View post on X/Twitter" with "View post on X" for tweet embed in the newsletter templates.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Add a tweet embed in the Blog Page body, and check in newsletter mode it says "View post on X" instead of "View post on X/Twitter"

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
