### PR TITLE
Add env var for `WAGTAIL_AUTOSAVE_INTERVAL`

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -228,10 +228,13 @@ WAGTAILIMAGES_MAX_IMAGE_PIXELS = int(
     os.environ.get("WAGTAILIMAGES_MAX_IMAGE_PIXELS", 128000000)
 )
 
-
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = "https://pressfreedomtracker.us"
+
+# Wagtail autosave interval in ms. Sets how often to wait after the last attempt
+# to autosave before autosaving again. Wagtail default is 500.
+WAGTAIL_AUTOSAVE_INTERVAL = int(os.environ.get("WAGTAIL_AUTOSAVE_INTERVAL", 500))
 
 # Named group of wagtail rich text features
 WAGTAILADMIN_RICH_TEXT_EDITORS = {


### PR DESCRIPTION
This adds an env var for `WAGTAIL_AUTOSAVE_INTERVAL`, defaulting to 500ms, the [Wagtail default](https://docs.wagtail.org/en/v7.4.1/reference/settings.html#wagtail-autosave-interval). This gives us a knob to tweak in deployment to adjust autosave or turn it off (by setting it to `0`).

Part of https://github.com/freedomofpress/fpf-www-projects/issues/544

@enpaul and @conorsch for awareness.

## Type of change


- [x] Config changes


## Checklist

### General checks

- [x] Linting and tests pass locally