### PR TITLE
fix: enable pip updates via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: 'github-actions'
@@ -20,3 +15,17 @@ updates:
       day: 'sunday'
     cooldown:
       default-days: 7
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: 'all'
+    commit-message:
+      prefix: 'build'
+      include: 'scope'


### PR DESCRIPTION
## Description
Enable pip updates via dependabot.

## Related
SecureDrop: https://github.com/freedomofpress/securedrop.org
FPF: https://github.com/freedomofpress/freedom.press/pull/2891

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
