### PR TITLE
fix: prevent dependabot from updating to a major django or wagtail version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,8 @@ updates:
       - dependency-name: 'django'
         update-types:
           - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      - dependency-name: 'wagtail'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,7 @@ updates:
     commit-message:
       prefix: 'build'
       include: 'scope'
+    ignore:
+      - dependency-name: 'django'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
## Description
Prevent dependabot from updating to a major Django version. Allow minor and patch versions.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field