### PR TITLE
Adds platform.x.com to CSP

### DIFF
--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -390,6 +390,7 @@ CONTENT_SECURITY_POLICY = {
             SELF,
             # For Social Widgets
             "https://platform.twitter.com",
+            "https://platform.x.com",
             "https://www.instagram.com",
             "https://embed.bsky.app",
             # For recaptcha
@@ -402,6 +403,7 @@ CONTENT_SECURITY_POLICY = {
             "https://analytics.freedom.press",
             # For Social Widgets
             "https://platform.twitter.com",
+            "https://platform.x.com",
             "https://syndication.twitter.com",
             "https://pbs.twimg.com",
             "https://ton.twimg.com",
@@ -429,6 +431,7 @@ CONTENT_SECURITY_POLICY = {
             # For Social Widgets
             UNSAFE_EVAL,
             "https://platform.twitter.com",
+            "https://platform.x.com",
             "https://www.instagram.com",
             "https://embed.bsky.app",
             # Observable Notebooks


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Changes proposed in this pull request:
Fixes twitter embed related issue reported by editors. Twitter embed are [not getting rendered properly](https://pressfreedomtracker.us/all-incidents/independent-reporter-arrested-punched-by-police-at-new-jersey-protest/) because the source of the script to render ember by twitter has been changed from platform.twitter.com to platform.x.com. In this PR, I have updated CSP to include platform.x.com. I have not removed platform.twitter.com just to be safe because I am not sure if they ever revert back or if part of the embed might still keep using that.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Check an incident page with twitter embed which has image/video and see it is getting rendered correctly. Disable any privacy blocker extension you might have (this got me stuck for few minutes :P).

### Post-deployment actions

After deployment, we need to update the CSP tests in Infra side. Attn @freedomofpress/fpf-infra 

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
