### PR TITLE
Viz mobile improvements

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -24,6 +24,7 @@ rules:
   declaration-block-semicolon-space-before: null
   declaration-block-trailing-semicolon: null
   declaration-block-no-redundant-longhand-properties: null
+  declaration-empty-line-before: never
   max-line-length: null
   max-nesting-depth: null
   selector-list-comma-newline-after: null

--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -82,6 +82,7 @@ export default function BarChart({
 	setSvgEl = () => {},
 	interactive = true,
 	disableAnimation = false,
+	showCategoryButtons = true,
 }) {
 	if (!data.length) return null
 	const dataset = data.map((d, i) => ({ ...d, index: i }))
@@ -119,7 +120,7 @@ export default function BarChart({
 	)
 
 	const categoryButtonsLabels = calculateCategoriesLabelsLegend(datasetStackedByCategory, paddings, width)
-	const buttonsHeight = isMobileView || !allCategories
+	const buttonsHeight = isMobileView || !allCategories || !showCategoryButtons
 		? 0
 		: calculateButtonsHeight(categoryButtonsLabels)
 
@@ -218,7 +219,7 @@ export default function BarChart({
 					viewBox={[0, 0, width, height]}
 				>
 					{description ? (<desc>{description}</desc>) : null}
-					{allCategories && (
+					{allCategories && showCategoryButtons && (
 						<CategoryButtons
 							interactive={interactive}
 							categoryButtonsLabels={categoryButtonsLabels}
@@ -391,15 +392,15 @@ export default function BarChart({
 				{
 					// If there are multiple categories, ie a stacked bar chart,
 					// we show the category buttons
-					allCategories && (
+					allCategories && showCategoryButtons && (
 						<CategoryButtons
 							interactive={interactive}
 							datasetStackedByCategory={datasetStackedByCategory}
+							categoryButtonsLabels={categoryButtonsLabels}
 							paddings={paddings}
 							width={width}
 							hoveredElement={!hoveredElement?.x && hoveredElement?.y}
 							setHoveredElement={(el) => setHoveredElement(el ? { y: el } : el)}
-							setButtonsHeight={setButtonsHeight}
 							findColor={findColor}
 							textStyle={textStyle}
 						/>

--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -30,6 +30,7 @@ const paddingsInternal = {
 }
 
 const borders = {
+	thin: 3,
 	normal: 5,
 	hover: 7,
 	grid: 1,
@@ -168,6 +169,7 @@ export default function BarChart({
 		const isHoveredByKey = !hoveredElement?.x && hoveredElement?.y === key
 		return isHoveredByDate || isHoveredByKey ? barColor : !hoveredElement ? barColor : defaultColor
 	}
+	const mobileThinBorderThreshold = 24
 
 	const selectedElement = dataset.find((d) => d[x] === sliderSelection)
 	const incidentsCount = selectedElement !== undefined ? selectedElement[y] : 0
@@ -394,10 +396,7 @@ export default function BarChart({
 					allCategories && (
 						<CategoryButtons
 							interactive={interactive}
-							datasetStackedByCategory={datasetStackedByCategory}
 							categoryButtonsLabels={categoryButtonsLabels}
-							paddings={paddings}
-							width={width}
 							hoveredElement={!hoveredElement?.x && hoveredElement?.y}
 							setHoveredElement={(el) => setHoveredElement(el ? { y: el } : el)}
 							findColor={findColor}
@@ -476,7 +475,7 @@ export default function BarChart({
 										: sliderSelection === null
 											? getBarColor(branchBars.key, d.data, 'white')
 											: 'white',
-								strokeWidth: borders.normal,
+								strokeWidth: dataset.length > mobileThinBorderThreshold ? borders.thin : borders.normal,
 								stroke: (d) => (sliderSelection === d[x] ? '#E07A5F' : 'black'),
 								cursor: searchPageURL ? 'pointer' : 'inherit',
 								shapeRendering: 'crispEdges',

--- a/client/charts/js/components/BarChart.jsx
+++ b/client/charts/js/components/BarChart.jsx
@@ -82,7 +82,6 @@ export default function BarChart({
 	setSvgEl = () => {},
 	interactive = true,
 	disableAnimation = false,
-	showCategoryButtons = true,
 }) {
 	if (!data.length) return null
 	const dataset = data.map((d, i) => ({ ...d, index: i }))
@@ -120,7 +119,7 @@ export default function BarChart({
 	)
 
 	const categoryButtonsLabels = calculateCategoriesLabelsLegend(datasetStackedByCategory, paddings, width)
-	const buttonsHeight = isMobileView || !allCategories || !showCategoryButtons
+	const buttonsHeight = !allCategories
 		? 0
 		: calculateButtonsHeight(categoryButtonsLabels)
 
@@ -219,7 +218,7 @@ export default function BarChart({
 					viewBox={[0, 0, width, height]}
 				>
 					{description ? (<desc>{description}</desc>) : null}
-					{allCategories && showCategoryButtons && (
+					{allCategories && (
 						<CategoryButtons
 							interactive={interactive}
 							categoryButtonsLabels={categoryButtonsLabels}
@@ -392,7 +391,7 @@ export default function BarChart({
 				{
 					// If there are multiple categories, ie a stacked bar chart,
 					// we show the category buttons
-					allCategories && showCategoryButtons && (
+					allCategories && (
 						<CategoryButtons
 							interactive={interactive}
 							datasetStackedByCategory={datasetStackedByCategory}

--- a/client/common/js/prepubPage.jsx
+++ b/client/common/js/prepubPage.jsx
@@ -1,15 +1,29 @@
 import React from 'react'
+import { ParentSize } from '@visx/responsive'
 import { createRoot } from 'react-dom/client'
 import CategoryIcon from './components/categoryIcon'
 import BarChart from '../../charts/js/components/BarChart'
 import Tooltip from '../../charts/js/components/Tooltip'
 
-function PrepubBarChart({
+function PrepubBarChart(props) {
+	return (
+		<ParentSize>
+			{(parent) => <PrepubBarChartWidth {...props} parentWidth={parent.width} />}
+		</ParentSize>
+	)
+}
+
+function PrepubBarChartWidth({
 	width,
 	dataset,
+	parentWidth
 }) {
+	const mobileBreakpoint = 670
+	const chartWidth = parentWidth < mobileBreakpoint ? parentWidth : width
+	const chartHeight = parentWidth < mobileBreakpoint ? 220 : 175
+	const isMobileView = parentWidth < mobileBreakpoint
 	return (
-		<div className={'prepubChartContainer'} style={{ width: width}}>
+		<div className={'prepubChartContainer'} style={{ maxWidth: width}}>
 			<div className={'prepubChart'}>
 				<BarChart
 					data={dataset}
@@ -17,12 +31,13 @@ function PrepubBarChart({
 					y={'count'}
 					titleLabel={'incidents'}
 					categoryColumn={'status'}
+					showCategoryButtons={false}
 					allCategories={["confirmed", "unconfirmed"]}
 					categoriesColors={{"unconfirmed": "#EEEEEE"}}
 					id={'prepub-page-bar-chart'}
-					width={width}
-					height={540}
-					isMobileView={false}
+					width={chartWidth}
+					height={chartHeight}
+					isMobileView={isMobileView}
 				/>
 			</div>
 		</div>
@@ -90,7 +105,7 @@ chartContainers.forEach((node) => {
 	const root = createRoot(node)
 	const chartDataset = JSON.parse(node.dataset.chartDataset)
 	root.render((
-		<PrepubBarChart width={1080} dataset={chartDataset} />
+		<PrepubBarChart width={670} dataset={chartDataset} />
 	))
 })
 

--- a/client/common/js/prepubPage.jsx
+++ b/client/common/js/prepubPage.jsx
@@ -32,7 +32,7 @@ function PrepubBarChartWidth({
 					titleLabel={'incidents'}
 					categoryColumn={'status'}
 					allCategories={["confirmed", "unconfirmed"]}
-					categoriesColors={{"unconfirmed": "#EEEEEE", "confirmed": "#E07A5F"}}
+					categoriesColors={{"unconfirmed": "#F4C280", "confirmed": "#E07A5F"}}
 					id={'prepub-page-bar-chart'}
 					width={chartWidth}
 					height={chartHeight}

--- a/client/common/js/prepubPage.jsx
+++ b/client/common/js/prepubPage.jsx
@@ -20,7 +20,7 @@ function PrepubBarChartWidth({
 }) {
 	const mobileBreakpoint = 670
 	const chartWidth = parentWidth < mobileBreakpoint ? parentWidth : width
-	const chartHeight = parentWidth < mobileBreakpoint ? 220 : 175
+	const chartHeight = parentWidth < mobileBreakpoint ? 280 : 250
 	const isMobileView = parentWidth < mobileBreakpoint
 	return (
 		<div className={'prepubChartContainer'} style={{ maxWidth: width}}>
@@ -31,9 +31,8 @@ function PrepubBarChartWidth({
 					y={'count'}
 					titleLabel={'incidents'}
 					categoryColumn={'status'}
-					showCategoryButtons={false}
 					allCategories={["confirmed", "unconfirmed"]}
-					categoriesColors={{"unconfirmed": "#EEEEEE"}}
+					categoriesColors={{"unconfirmed": "#EEEEEE", "confirmed": "#E07A5F"}}
 					id={'prepub-page-bar-chart'}
 					width={chartWidth}
 					height={chartHeight}
@@ -53,7 +52,29 @@ function PrepubIncidentCategoryCount({
 	const [tooltipPosition, setTooltipPosition] = React.useState({ x: 0, y: 0 })
 
 	const updateTooltipPosition = (MouseEvent) => {
-		setTooltipPosition({ x: MouseEvent.clientX, y: MouseEvent.clientY })
+		const tooltipWidth = 250 // approximate width of the tooltip in px
+		const tooltipHeight = 150 // approximate height of the tooltip in px
+		const padding = 10 // padding from the mouse pointer
+
+		let x = MouseEvent.clientX
+		let y = MouseEvent.clientY
+
+		// If tooltip would extend beyond the right edge of the window,
+		// position it to the left of the cursor instead
+		if (x + tooltipWidth + padding > window.innerWidth) {
+			x = x - tooltipWidth
+		}
+		// If tooltip would extend beyond the bottom edge of the window,
+		// center it vertically relative to the cursor
+		if (y + tooltipHeight + padding > window.innerHeight) {
+			y = y - tooltipHeight / 2
+		}
+		// If tooltip would extend beyond the top edge of the window,
+		// position it below the cursor instead
+		if (y < tooltipHeight) {
+			y = y + tooltipHeight + padding
+		}
+		setTooltipPosition({ x: x, y: y })
 	}
 	return (
 		<>

--- a/client/common/sass/components/_unconfirmed-incidents.sass
+++ b/client/common/sass/components/_unconfirmed-incidents.sass
@@ -1,8 +1,11 @@
 .unconfirmed-incidents
 	table-layout: fixed
 	border-collapse: collapse
-	width: 90%
-	margin: 10px auto
+	max-width: 670px
+	margin: 10px 8px
+
+	+desktop-up
+		margin: 10px 0
 
 	thead
 		border: solid 3px #000
@@ -15,12 +18,17 @@
 
 	th, td
 		padding: 0.6em
+		+mobile-down
+			padding: 0.4em 0.3em
 
 	tr > :nth-child(1)
-		width: 10%
+		width: 16%
 
 	tr > :nth-child(2)
-		width: 15%
+		width: 25%
+
+	tr:nth-child(even)
+		background-color: $section-background
 
 	caption
 		padding: 1em
@@ -28,6 +36,8 @@
 		caption-side: bottom
 		font-size: $font-size-small-ui
 		text-align: right
+		+mobile-down
+			padding: 0.6em
 
 	tfoot td
 		padding: 0
@@ -47,20 +57,25 @@
 				border-right-style: none
 
 	&--count
+		--count-unit-width: 1.6rem
 		box-sizing: border-box
-		display: inline-block
+		display: inline-flex
 		padding: 3px
 		background-color: $black
 		color: $white
 		border: 3px solid
 		border-color: $black
-		font-size: 1.125rem
+		font-size: 1.075rem
 		font-weight: 700
 		line-height: 1
 		// width of one cell * incident count
-		width: calc(var(--incident-count) * 1.6rem)
+		width: calc(var(--incident-count) * var(--count-unit-width))
 		height: 1.6rem
 		cursor: pointer
+
+		+mobile-down
+			--count-unit-width: 1rem
+			padding: 3px 0
 
 		&:hover,
 		&:focus-visible

--- a/client/common/sass/components/_unconfirmed-incidents.sass
+++ b/client/common/sass/components/_unconfirmed-incidents.sass
@@ -83,6 +83,10 @@
 			background-color: $white
 			color: $black
 
+.unconfirmed-incidents--page-title
+	+mobile-down
+		font-size: 3rem
+
 .category-count-tooltip
 	font-family: var(--font-base)
 	font-size: 0.75rem

--- a/client/common/sass/components/_unconfirmed-incidents.sass
+++ b/client/common/sass/components/_unconfirmed-incidents.sass
@@ -1,4 +1,5 @@
 .unconfirmed-incidents
+	--max-count: 1
 	table-layout: fixed
 	border-collapse: collapse
 	width: min(670px, 100%)
@@ -58,7 +59,8 @@
 				border-right-style: none
 
 	&--count
-		--count-unit-width: 1.6rem
+		--min-unit: 1.6rem
+		--max-unit: 25%
 		box-sizing: border-box
 		display: inline-flex
 		padding: 3px
@@ -70,12 +72,13 @@
 		font-weight: 700
 		line-height: 1
 		// width of one cell * incident count
-		width: calc(var(--incident-count) * var(--count-unit-width))
+		width: calc(var(--incident-count) * clamp(var(--min-unit), calc(100% / var(--max-count)), var(--max-unit)))
+		min-width: max-content
 		height: 1.6rem
 		cursor: pointer
 
 		+mobile-down
-			--count-unit-width: 1rem
+			--min-unit: 1rem
 			padding: 3px 0
 
 		&:hover,

--- a/client/common/sass/components/_unconfirmed-incidents.sass
+++ b/client/common/sass/components/_unconfirmed-incidents.sass
@@ -16,18 +16,18 @@
 
 	th, td
 		padding: 0.6em
-		+mobile-down
-			padding: 0.4em 0.3em
 
 	tr > :nth-child(1)
 		width: 16%
 		+mobile-down
-			width: 20%
+			width: 24%
+			padding-right: 0
 
 	tr > :nth-child(2)
 		width: 25%
 		+mobile-down
-			width: 33%
+			width: 36%
+			padding-right: 0
 
 	tr:nth-child(even)
 		background-color: $section-background
@@ -76,6 +76,8 @@
 		min-width: max-content
 		height: 1.6rem
 		cursor: pointer
+		-webkit-font-smoothing: antialiased
+		-moz-osx-font-smoothing: grayscale
 
 		+mobile-down
 			--min-unit: 1rem

--- a/client/common/sass/components/_unconfirmed-incidents.sass
+++ b/client/common/sass/components/_unconfirmed-incidents.sass
@@ -1,11 +1,8 @@
 .unconfirmed-incidents
 	table-layout: fixed
 	border-collapse: collapse
-	max-width: 670px
-	margin: 10px 8px
-
-	+desktop-up
-		margin: 10px 0
+	width: min(670px, 100%)
+	margin: 10px 0
 
 	thead
 		border: solid 3px #000
@@ -23,9 +20,13 @@
 
 	tr > :nth-child(1)
 		width: 16%
+		+mobile-down
+			width: 20%
 
 	tr > :nth-child(2)
 		width: 25%
+		+mobile-down
+			width: 33%
 
 	tr:nth-child(even)
 		background-color: $section-background

--- a/client/common/sass/components/_unconfirmed-incidents.sass
+++ b/client/common/sass/components/_unconfirmed-incidents.sass
@@ -63,7 +63,8 @@
 		--max-unit: 25%
 		box-sizing: border-box
 		display: inline-flex
-		padding: 3px
+		align-items:center
+		padding: 0 3px
 		background-color: $black
 		color: $white
 		border: 3px solid
@@ -81,7 +82,7 @@
 
 		+mobile-down
 			--min-unit: 1rem
-			padding: 3px 0
+			padding: 0
 
 		&:hover,
 		&:focus-visible

--- a/home/models.py
+++ b/home/models.py
@@ -231,7 +231,7 @@ class HomePage(MetadataPageMixin, MediaPageMixin, Page):
         sync = PrepublicationIncidentSync.objects.first()
         if prepub_settings.is_enabled and sync:
             lower_date = datetime.date.today() - prepub_settings.get_timespan()
-            context["prepubs"] = (
+            context["prepubs"], context["max_incident_count"] = (
                 PrepublicationIncident.objects.aggregate_with_category_counts(
                     lower_date_bound=lower_date,
                 )

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -35,7 +35,7 @@
 					<p class="homepage-unconfirmed-description">Unconfirmed incidents are possible press freedom aggressions that our team is working to verify for documentation.  Read more about the reporting process on our <a href="/frequently-asked-questions/">FAQ</a> page.</p>
 				</div>
 				<div>
-					{% include "incident/_prepub_table.html" with prepubs=prepubs updated_time=update_time row_limit=3 prepub_count=prepub_count only %}
+					{% include "incident/_prepub_table.html" with prepubs=prepubs max_incident_count=max_incident_count updated_time=update_time row_limit=3 prepub_count=prepub_count only %}
 				</div>
 			</div>
 		</div>

--- a/incident/models/prepub.py
+++ b/incident/models/prepub.py
@@ -47,18 +47,18 @@ class PrepublicationIncidentQuerySet(models.QuerySet):
             incident_count=Count("pk", distinct=True),
         ).order_by("-date")
 
+        max_count = 1
         for result in results:
+            count = Counter(result["categories"])
             result["category_counts"] = json.dumps(
                 sorted(
-                    [
-                        {"category": k, "count": v}
-                        for k, v in Counter(result["categories"]).items()
-                    ],
+                    [{"category": k, "count": v} for k, v in count.items()],
                     key=itemgetter("category"),
                 )
             )
-
-        return results
+            if (new_max_count := count.most_common(1)[0][1]) > max_count:
+                max_count = new_max_count
+        return results, max_count
 
     def fuzzy_date_filter(self, lower: date = None, upper: date = None):
         """Filter prepublication incidents by date range, accounting

--- a/incident/templates/incident/_prepub_table.html
+++ b/incident/templates/incident/_prepub_table.html
@@ -1,4 +1,4 @@
-<table class="unconfirmed-incidents">
+<table class="unconfirmed-incidents" style="--max-count: {{ max_incident_count }}">
 	<caption>
 		Updated {{ updated_time }}
 	</caption>

--- a/incident/templates/incident/prepub_list.html
+++ b/incident/templates/incident/prepub_list.html
@@ -3,7 +3,7 @@
 {% block title %}Unconfirmed Incidents{% endblock %}
 
 {% block main %}
-	<h1 class="page-title">Unconfirmed Incidents</h1>
+	<h1 class="unconfirmed-incidents--page-title page-title">Unconfirmed Incidents</h1>
 	<section class="simplepage-body">
 		<p>Unconfirmed incidents are possible press freedom aggressions that our team is working to verify for documentation. Read more about the reporting process on our FAQ page.</p>
 

--- a/incident/templates/incident/prepub_list.html
+++ b/incident/templates/incident/prepub_list.html
@@ -15,8 +15,6 @@
 		></div>
 
 		<h2>Ongoing Unconfirmed Incidents</h2>
-		{% include "incident/_prepub_table.html" with prepubs=prepubs updated_time=updated_time row_limit=None only %}
+		{% include "incident/_prepub_table.html" with prepubs=prepubs max_incident_count=max_incident_count updated_time=updated_time row_limit=None only %}
 	</section>
-
-
 {% endblock %}

--- a/incident/views.py
+++ b/incident/views.py
@@ -174,6 +174,15 @@ def prepub_list(request):
 
     sync = PrepublicationIncidentSync.objects.get()
 
+    max_count = 1
+    for p in prepubs:
+        count = Counter(p["categories"])
+        p["category_counts"] = json.dumps(
+            [{"category": k, "count": v} for k, v in count.items()]
+        )
+        if (new_max_count := count.most_common(1)[0][1]) > max_count:
+            max_count = new_max_count
+
     return TemplateResponse(
         request,
         "incident/prepub_list.html",
@@ -181,6 +190,7 @@ def prepub_list(request):
             "prepubs": PrepublicationIncident.objects.aggregate_with_category_counts(
                 lower_date_bound=lower_bound
             ),
+            "max_incident_count": max_count,
             "updated_time": sync.completed_at.strftime("%H:%M %p %Z"),
             "timespan_display": prepub_settings.get_timespan_display(),
             "bar_chart_dataset": json.dumps(bar_chart_dataset),

--- a/incident/views.py
+++ b/incident/views.py
@@ -173,24 +173,18 @@ def prepub_list(request):
         )
 
     sync = PrepublicationIncidentSync.objects.get()
-
-    max_count = 1
-    for p in prepubs:
-        count = Counter(p["categories"])
-        p["category_counts"] = json.dumps(
-            [{"category": k, "count": v} for k, v in count.items()]
+    prepubs, max_incident_count = (
+        PrepublicationIncident.objects.aggregate_with_category_counts(
+            lower_date_bound=lower_bound
         )
-        if (new_max_count := count.most_common(1)[0][1]) > max_count:
-            max_count = new_max_count
+    )
 
     return TemplateResponse(
         request,
         "incident/prepub_list.html",
         {
-            "prepubs": PrepublicationIncident.objects.aggregate_with_category_counts(
-                lower_date_bound=lower_bound
-            ),
-            "max_incident_count": max_count,
+            "prepubs": prepubs,
+            "max_incident_count": max_incident_count,
             "updated_time": sync.completed_at.strftime("%H:%M %p %Z"),
             "timespan_display": prepub_settings.get_timespan_display(),
             "bar_chart_dataset": json.dumps(bar_chart_dataset),


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #2077.
Fixes #2239 


### Changes proposed in this pull request:
Things needed to be done from https://github.com/freedomofpress/pressfreedomtracker.us/issues/2077#issuecomment-4732646067
#### Bar chart changes
- [x] Shrink height and width (max 670w) on page 
- [ ] ~~Add legend/key with corresponding colors [per initial design](https://www.figma.com/design/agOk78n9QpCcNCjqiZ6ObO/Press-Freedom-Tracker?node-id=309-10371&t=yKPnoCBz2uXAzDEj-4) (needed as we haven't used stacked bars previously)~~ (_To be addressed through https://github.com/freedomofpress/pressfreedomtracker.us/issues/2276_)
- [x] Remove filter buttons
- [x] Mobile: Switch to a slider and reduce bar width, padding, and margins as it shrinks to get to the _widths_ [seen in the prior comment](https://github.com/freedomofpress/pressfreedomtracker.us/issues/2077#issuecomment-4711246802)
- [ ] ~~Adjust tooltips per above guidance (one tooltip per entire bar, entire bar selectable)~~ (_To be addressed through https://github.com/freedomofpress/pressfreedomtracker.us/issues/2276_)
- [ ] ~~Remove <title> attributes as they compete with tooltips. (I believe they already have `aria-label` as I made a similar change in #2206)~~ (_To be addressed through https://github.com/freedomofpress/pressfreedomtracker.us/issues/2276_)
- [x] **TBD:** @ryanwhitney needs to provide guidance on visual hover states. Initial guidance is: since we have stacked bars, we don't want to white out all other bars when hovering on one as that obscures useful data. Instead we'll need to rely on something like a different color/width outline (or other type of indication) on the hovered bar while leaving others alone. 

#### Table changes
- [x] Shrink width on page: max 670 per other pft elements
- [x] Mobile: Reduce padding in (and around) unconfirmed incidents table per above guidance
- [x] Mobile: Have the bars adjust sizing at smaller sizes to ensure fit at 320px viewport
- [x] Number not vertically aligned in incident count bar
- [x] Table missing row coloring: In the design assets, even rows get a #F8F8F8 background. (`$section-background` in pft)
- [x] [Tooltips can go offscreen](https://github.com/user-attachments/assets/24cd7c44-1cb7-4cf6-88a7-378cdb63d315): We solved this elsewhere, should be able to reuse that

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

### Post-deployment actions

In case this PR needs any admin changes or run a management command after deployment, mention it here:

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

<img width="603" height="1500" alt="image" src="https://github.com/user-attachments/assets/dc3ac6d1-f4ff-4aec-a930-3fdd8dcf314b" />

