### PR TITLE
If the unconfirmed incidents page has no data, return a 404 response

### DIFF
--- a/incident/tests/test_prepub_page.py
+++ b/incident/tests/test_prepub_page.py
@@ -82,12 +82,22 @@ class PrepubViewTestCase(TestCase):
             timespan_units=PrepublicationSettings.TimespanUnits.DAY,
         )
 
+    def test_not_found_if_sync_absent(self):
+        self.sync.delete()
+        response = self.client.get(reverse("prepub_list"))
+        self.assertEqual(response.status_code, 404)
+
+    def test_not_found_if_prepubs_absent(self):
+        response = self.client.get(reverse("prepub_list"))
+        self.assertEqual(response.status_code, 404)
+
     def test_gets_successfully(self):
         create_prepub(categories=[self.category_equipment])
         response = self.client.get(reverse("prepub_list"))
         self.assertEqual(response.status_code, 200)
 
     def test_includes_last_updated_time(self):
+        create_prepub()
         response = self.client.get(reverse("prepub_list"))
         time_representation = self.sync.completed_at.strftime("%H:%M %p %Z")
         self.assertContains(response, f"Updated {time_representation}")

--- a/incident/views.py
+++ b/incident/views.py
@@ -9,7 +9,7 @@ from django.db.models import (
     Count,
     F,
 )
-from django.http import HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
 from django.template.response import TemplateResponse
 from django.urls import reverse, reverse_lazy
@@ -135,6 +135,13 @@ def dates_between(lower, upper):
 
 
 def prepub_list(request):
+    try:
+        sync = PrepublicationIncidentSync.objects.get()
+    except PrepublicationIncidentSync.DoesNotExist:
+        raise Http404
+    if PrepublicationIncident.objects.count() < 1:
+        raise Http404
+
     prepub_settings = PrepublicationSettings.load(request_or_site=request)
     lower_bound = datetime.date.today() - prepub_settings.get_timespan()
     bar_chart_lower_bound = datetime.date.today() - datetime.timedelta(days=29)
@@ -178,8 +185,6 @@ def prepub_list(request):
         )
         .order_by("-date")
     )
-
-    sync = PrepublicationIncidentSync.objects.get()
 
     for p in prepubs:
         p["category_counts"] = json.dumps(


### PR DESCRIPTION
## Description
Fixes a problem where loading the page before data has been loaded results in a 500.

Changes proposed in this pull request:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

