### PR TITLE
Ensure that pages can be rendered before validation

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -141,7 +141,9 @@ class BlogIndexPage(RoutablePageMixin, MetadataPageMixin, MediaPageMixin, Page):
 
         if not request.GET.get("author") and not request.GET.get("organization"):
             context["featured_blogs"] = [
-                f.page for f in self.featured_blogs.select_related("page").all()
+                f.page
+                for f in self.featured_blogs.select_related("page").all()
+                if f.page_id
             ]
 
         context["incident_listing_heading"] = "Latest"

--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -508,7 +508,7 @@ class CategoryPage(MetadataPageMixin, Page):
         context["incident_qs"] = urlencode(data)
 
         context["featured_blog_posts"] = [
-            f.page for f in self.featured_blogs.select_related("page")
+            f.page for f in self.featured_blogs.select_related("page") if f.page_id
         ]
         context["featured_incident_pages"] = [
             f.page
@@ -516,6 +516,7 @@ class CategoryPage(MetadataPageMixin, Page):
                 "page",
                 "page__teaser_image",
             )
+            if f.page_id
         ]
 
         # Hard code the date and month. The state

--- a/home/models.py
+++ b/home/models.py
@@ -197,7 +197,7 @@ class HomePage(MetadataPageMixin, MediaPageMixin, Page):
         context["serialized_filters"] = json.dumps(get_serialized_filters())
 
         context["featured_blog_posts"] = [
-            f.page for f in self.featured_blog_posts.select_related("page")
+            f.page for f in self.featured_blog_posts.select_related("page") if f.page_id
         ]
 
         context["featured_incident_pages"] = [
@@ -206,10 +206,11 @@ class HomePage(MetadataPageMixin, MediaPageMixin, Page):
                 "page",
                 "page__teaser_image",
             )
+            if f.page_id
         ]
 
         context["data_viz_tags_json"] = json.dumps(
-            [t.tag.title for t in self.data_viz_tags.all()]
+            [t.tag.title for t in self.data_viz_tags.all() if t.tag_id]
         )
 
         search_settings = SearchSettings.for_site(Site.find_for_request(request))

--- a/incident/models/incident_page.py
+++ b/incident/models/incident_page.py
@@ -1108,7 +1108,7 @@ class IncidentPage(MetadataPageMixin, Page):
             return self.updated_days_ago < 30
         else:
             latest_update = self.updates.order_by("-date").first()
-            if latest_update:
+            if latest_update and latest_update.date:
                 delta = (
                     datetime.datetime.now(datetime.timezone.utc) - latest_update.date
                 )
@@ -1132,7 +1132,7 @@ class IncidentPage(MetadataPageMixin, Page):
         Returns the first category in the list of categories
         """
         first_category = self.categories.all().first()
-        if first_category:
+        if first_category and first_category.category_id:
             return first_category.category
         return None
 
@@ -1143,6 +1143,8 @@ class IncidentPage(MetadataPageMixin, Page):
         category_details = {}
         categories_without_metadata = {}
         for category in self.categories.all():
+            if not category.category_id:
+                continue
             category_fields = CATEGORY_FIELD_MAP.get(category.category.slug, [])
 
             if not category_fields:

--- a/incident/models/topic_page.py
+++ b/incident/models/topic_page.py
@@ -20,7 +20,7 @@ from common.utils import (
     DEFAULT_PAGE_KEY,
     paginate,
 )
-from incident.models import IncidentCategorization
+from incident.models import IncidentCategorization, IncidentPage
 from incident.forms import TopicPageForm
 
 
@@ -266,11 +266,14 @@ class TopicPage(RoutablePageMixin, MetadataPageMixin, Page):
                 exact_date_unknown=True,
                 date__fuzzy_date__overlap=target_range,
             )
-        incident_qs = (
-            self.incident_index_page.get_incidents()
-            .filter(incident_lookups)
-            .order_by("-date")
-        )
+        if self.incident_index_page_id is None:
+            incident_qs = IncidentPage.objects.none()
+        else:
+            incident_qs = (
+                self.incident_index_page.get_incidents()
+                .filter(incident_lookups)
+                .order_by("-date")
+            )
 
         paginator, entries = paginate(
             request, incident_qs, page_key=DEFAULT_PAGE_KEY, per_page=8, orphans=5

--- a/incident/templates/incident/topic_page.html
+++ b/incident/templates/incident/topic_page.html
@@ -21,11 +21,13 @@
 				<div class="topicpage__block">{% include_block block %}</div>
 			{% endfor %}
 
+			{% if page.incident_index_page %}
 			<div class="topicpage__block">
 				<a class="btn btn-secondary" href="{% pageurl page.incident_index_page %}?tags={{ page.incident_tag.title }}">
 					View incidents in database
 				</a>
 			</div>
+			{% endif %}
 		</section>
 
 		<section class="topicpage-body__sidebar">

--- a/incident/tests/test_pages.py
+++ b/incident/tests/test_pages.py
@@ -32,6 +32,7 @@ from incident.models.incident_page import IncidentPage
 from incident.models.topic_page import TopicPage
 from incident.models.export import is_exportable, to_row
 from incident.models import IncidentCategorization
+from incident.models.inlines import IncidentPageUpdates
 from .factories import (
     IncidentIndexPageFactory,
     IncidentPageFactory,
@@ -913,6 +914,11 @@ class RecentlyUpdatedMethod(TestCase):
         self.assertTrue(self.inc2.recently_updated())
         self.assertTrue(self.inc3.recently_updated())
 
+    def test_handles_update_with_no_date(self):
+        incident = IncidentPage(title="Update with no date")
+        incident.updates.add(IncidentPageUpdates(title="Update", date=None))
+        self.assertFalse(incident.recently_updated())
+
     def test_runs_no_queries_if_information_cached(self):
         incidents = IncidentPage.objects.with_most_recent_update().all()
         for incident in incidents:
@@ -1452,6 +1458,12 @@ class TestTopicPage(WagtailPageTestCase):
             [incident2, incident1, incident3],
         )
 
+    def test_renders_with_no_incident_index_page(self):
+        topic_page = TopicPageFactory.build(incident_index_page=None)
+        request = RequestFactory().get("/")
+
+        self.assertEqual(list(topic_page.get_context(request)["entries_page"]), [])
+
     def test_filters_incidents_by_date_range(self):
         topic_page = TopicPageFactory(
             parent=self.home_page,
@@ -1579,6 +1591,16 @@ class IncidentPageTests(TestCase):
         self.assertRegex(incident2.unique_date, UNIQUE_DATE_FORMAT)
 
         self.assertNotEqual(incident1.unique_date, incident2.unique_date)
+
+    def test_get_main_category_handles_categorization_without_category(self):
+        incident = IncidentPage(title="No category")
+        incident.categories.add(IncidentCategorization())
+        self.assertIsNone(incident.get_main_category())
+
+    def test_get_category_details_skips_categorization_without_category(self):
+        incident = IncidentPage(title="No category")
+        incident.categories.add(IncidentCategorization())
+        self.assertEqual(incident.get_category_details(index=incident), {})
 
     def test_looks_up_latitude_longitude_from_city_and_state(self):
         incident_index = IncidentIndexPageFactory.build(title="A title")


### PR DESCRIPTION
This is a collection of fixes to issues that prevent page drafts from being rendered by the preview pane in the Wagtail admin (because they raise exceptions/generate 500 errors) since Wagtail 7.0's deferred validation. Deferred validation means that fields and blocks can be saved with blank values but are still expected to be previewable.

The majority of these are fixes in either templates to `if`-gate access to variables in templates that might be `None`, or in `get_context` and other `get_` accessors on models to gracefully handle when a value trying to be accessed might be `None`.

There are only one `pageurl` guard needed here in the TopicPage template (that I've found, there's always the possibility I'm wrong), because most of them are either guarded already or the page they're trying to fetch the URL of is required.

I've added a few unit tests around the Python guards in accessors where possible. 

I have not added tests for the additional `if f.page_id` in the featured post list comprehensions, since these appear to already tested in the affirmative with, for example, [`test_preview_home_should_succeed`](https://github.com/freedomofpress/pressfreedomtracker.us/blob/de53f59fe0a4cbd7084ac358c6e9571b0546e494/home/tests/test_homepage.py#L94-L151). But ultimately, this is just constructing a list of pages for the templates to handle. The negative, where `f.page_id` is falsey, gets caught at render time in the templates, which check [`{% if featured_blog_posts %}`](https://github.com/freedomofpress/pressfreedomtracker.us/blob/de53f59fe0a4cbd7084ac358c6e9571b0546e494/home/templates/home/home_page.html#L56-L62).

This addresses https://github.com/freedomofpress/fpf-www-projects/issues/552 for pressfreedomtracker.us.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

With this change, creating a new page type, with all available fields blank, and with all block options added and blank, should still successfully preview in the preview pane in the Wagtail admin. The specific pages and blocks that are fixed in this PR are:

Unsaved page/related pages in page types:

- BlogIndexPage guards getting featured blog posts
- CategoryPage guards getting featured blog posts
- HomePage guards getting featured blog posts
- IncidentPage places guards its date field in `recently_updated()` and around category pages in `get_main_category()` and `get_category_details()`
- TopicPage places guards around IncidentPage lookups in `get_context()` and around its incident index page in templates.

But, as in https://github.com/freedomofpress/freedom.press/pull/2955, any page and combination of page blocks and fields may be blank and the preview pane will still render without error, so manually testing other possibilities is recommended.


## Checklist

### General checks

- [x] Linting and tests pass locally
- [ ] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [ ] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [ ] The changes are accessible using keyboard and screenreader

### If you made changes to API flow:

- [ ] Verify that API responses are correct
- [ ] Verify that visualizations using the API endpoints are functional

### If you made changes to incident model metadata

- [ ] Verify incident export works correctly
- [ ] Verify incident filters are rendered correctly
- [ ] Verify incident filters show correct incidents
- [ ] Verify categories work
- [ ] Verify incidents are discoverable by search

### If you made changes to blog

- [ ] Verify that the blog index page renders correctly
- [ ] Verify that the individual blogs show all the informations correctly

### If you made changes to shared templates (e.g. card design, lead media, etc.)

- [ ] Verify that it renders correctly in homepage, if applicable
- [ ] Verify that it renders correctly in incident index page, if applicable
- [ ] Verify that it renders correctly in individual incident page, if applicable
- [ ] Verify that it renders correctly in blog index page, if applicable
- [ ] Verify that it renders correctly in individual blog page, if applicable
- [ ] Verify that it renders correctly in individual special blog page, if applicable

### If you made changes to email signup flow

- [ ] Verify that the email signup form in the footer renders and works
- [ ] Verify that the individual email signup pages work

### If you made changes to "Submit an Incident" form

- [ ] Verify that the form renders correctly and submit correctly as well

### If it's a major change

- [ ] Do the changes need to be tested in a separate staging instance?

### If you made any frontend change

If the PR involves some visual changes in the frontend, it is recommended to add a screenshot of the new visual.
