### PR TITLE
Fix newsletter render crashes for pages without a preamble

### DIFF
--- a/blog/templates/blog/blog_page_newsletter.html
+++ b/blog/templates/blog/blog_page_newsletter.html
@@ -164,7 +164,9 @@
 		{% if page.get_newsletter_preamble or page.lead_graphic %}
 			<mj-section background-color="#fffef0" css-class="intro">
 				<mj-column>
-					<mj-text padding-bottom="24px">{{ page.get_newsletter_preamble|newsletter_richtext }}</mj-text>
+					{% if page.get_newsletter_preamble %}
+						<mj-text padding-bottom="24px">{{ page.get_newsletter_preamble|newsletter_richtext }}</mj-text>
+					{% endif %}
 					{% for lead_item in page.lead_graphic %}
 						{% if lead_item.block_type == "image" %}
 							<figure>

--- a/blog/tests/test_page.py
+++ b/blog/tests/test_page.py
@@ -264,6 +264,29 @@ class TestPages(TestCase):
             "Preamble override",
         )
 
+    def test_newsletter_renders_without_preamble(self):
+        # Regression: a newsletter page with a lead graphic but no preamble
+        # set on either the page or its index page must still render. The
+        # intro section is emitted because of the lead graphic, and
+        # get_newsletter_preamble() returns None in that case -- passing None
+        # to the newsletter_richtext filter used to raise ValueError.
+        image = CustomImageFactory.create(
+            file__width=600,
+            file__height=400,
+            collection__name="Photos",
+        )
+        page = BlogPageFactory(parent=self.index, slug="no-preamble")
+        page.newsletter_preamble = None
+        page.body = []
+        page.lead_graphic = [("image", image)]
+        page.save()
+        self.index.newsletter_preamble = None
+        self.index.save()
+
+        self.assertIsNone(page.get_newsletter_preamble())
+        html = page.get_newsletter_html()
+        self.assertIn("Submit an incident", html)
+
     def test_get_blog_page_vertical_bar_chart_meta_image(self):
         self.assertEqual(
             self.blog_page2.get_meta_image(),

--- a/common/tests/utils.py
+++ b/common/tests/utils.py
@@ -134,7 +134,7 @@ def generate_raw_html():
 <dl><dt>Block type</dt><dd>Raw <abbr title="Hypertext Markup Language">HTML</abbr></dd><dt>Tags used</dt><dd><span style="font-family:monospace;">abbr, dd, div, dl, dt, meter, progress, span, table, td, tr</span></dd></dl>
 
 <table style="width: 66%; margin: 0 auto;">
-<tr><td><label for="completion">How close are we?</label></td><td><progress id="completion" max="100" value="{progress}"> {progress}% </progress></td>
+<tr><td><label for="completion">How close are we?</label></td><td><progress id="completion" max="100" value="{progress}"> {progress}% </progress></td></tr>
 <tr><td>Fuel remaining</td><td><meter id="fuel" min="0" max="100" low="33" high="66" optimum="80" value="{fuel}"></meter></td></tr></table></div>"""
     return generate_field(
         "raw_html", body.format(fuel=randrange(0, 101), progress=randrange(0, 101))


### PR DESCRIPTION
## Summary

Fixes two distinct bugs that caused newsletter rendering to 500. Both surfaced as "newsletter templates throwing an error."

### 1. Page with a lead graphic but no preamble (the staging crash)

A newsletter page with a `lead_graphic` but **no `newsletter_preamble`** (set on neither the page nor its blog index page) renders the intro section — because that section is shown whenever there's a preamble *or* a lead graphic — and then passed `get_newsletter_preamble()`'s `None` return value straight to the `newsletter_richtext` filter, which raises `ValueError: Expected string value`. A 500 before `mrml` even runs.

This affects any newsletter page in that configuration (the default `BlogPageFactory` is itself one). Fix: guard the preamble in the template so the filter is only called when a preamble exists (also avoids emitting an empty `<mj-text>`).

### 2. Unclosed `<tr>` in the dev-data raw-HTML fixture

`mrml` parses the newsletter MJML as **strict XML**. The `generate_raw_html` dev-data fixture produced a `<table>` with an unclosed `<tr>` — valid HTML5, invalid XML — so rendering a dev page with a raw-HTML block aborted with `unexpected end of stream in root template`. Fix: close the `<tr>`.

## Test plan

- Added `test_newsletter_renders_without_preamble`: renders a newsletter page with a lead graphic and no preamble. Fails with `ValueError: Expected string value` before the fix; passes after.
- Full `blog.tests.test_page` and `common.tests` suites pass (176 tests).
- ruff clean; no migrations.

## Follow-up

The broader, defensive hardening (normalize editor-supplied raw HTML / rich-text output to well-formed XML before `mrml`, so a malformed paste can never 500 a live newsletter) is tracked in #2300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)