### PR TITLE
Lint the chart pregenerator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,5 +55,19 @@ module.exports = {
 		"import/no-unresolved": 0,
 		"radix": ["error", "as-needed"],
 		"semi": ["error", "never"]
-	}
+	},
+
+	"overrides": [
+		{
+			// The chart pregenerator is a Node service (not browser code), so
+			// console logging is expected. It also imports shared chart
+			// components without file extensions (resolved by esbuild/babel/jest).
+			"files": ["chart_pregenerator/**/*.js", "chart_pregenerator/**/*.jsx"],
+			"env": { "node": true },
+			"rules": {
+				"no-console": "off",
+				"import/extensions": "off"
+			}
+		}
+	]
 };

--- a/chart_pregenerator/src/lib.jsx
+++ b/chart_pregenerator/src/lib.jsx
@@ -178,7 +178,6 @@ export const generateTreemapChartSVG = async (req) => {
 			options.dateRange,
 			filterStates,
 		)
-		console.dir(branches, {depth: null})
 		const categoriesColorMap = branches ? [...(new Set([...branches.map((d) => d.title)]))]
 			.reduce(
 				(acc, category, i) => ({
@@ -293,7 +292,6 @@ export const generateUSMapSVG = async (req) => {
 	}
 }
 
-
 export const generateHexbinUSMapSVG = async (req) => {
 	let options = {
 		filterTags: null,
@@ -330,7 +328,8 @@ export const generateHexbinUSMapSVG = async (req) => {
 			options.dateRange,
 			filterStates,
 		)
-		const datasetAggregatedByGeo = filteredDataset && groupByState(filteredDataset) // Hexbin maps are always state-level
+		// Hexbin maps are always state-level
+		const datasetAggregatedByGeo = filteredDataset && groupByState(filteredDataset)
 		const incidentsOutsideUS = countIncidentsOutsideUS(filteredDataset)
 
 		return ReactDOMServer.renderToString(
@@ -345,7 +344,7 @@ export const generateHexbinUSMapSVG = async (req) => {
 			>
 				<HexbinUSMap
 					data={datasetAggregatedByGeo}
-					aggregationLocality={d => d.state}
+					aggregationLocality={(d) => d.state}
 					incidentsOutsideUS={incidentsOutsideUS}
 					width={options.width}
 					height={options.height}

--- a/chart_pregenerator/src/server.jsx
+++ b/chart_pregenerator/src/server.jsx
@@ -2,7 +2,12 @@ import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import express from 'express'
 import { Resvg } from '@resvg/resvg-js'
-import { generateBarChartSVG, generateHexbinUSMapSVG, generateTreemapChartSVG, generateUSMapSVG } from './lib'
+import {
+	generateBarChartSVG,
+	generateHexbinUSMapSVG,
+	generateTreemapChartSVG,
+	generateUSMapSVG,
+} from './lib'
 
 const PORT = process.env.PORT || 3000
 const app = express()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "webpack watch --mode development --devtool eval-source-map",
     "test": "jest --passWithNoTests --coverage",
     "test-update": "jest -u --passWithNoTests --coverage",
-    "js-lint": "eslint client/**/*.js",
+    "js-lint": "eslint client/**/*.js chart_pregenerator/src/**/*.jsx",
     "stylelint": "stylelint client/**/*.sass"
   },
   "author": "Harris Lapiroff <harris@littleweaverweb.com>",


### PR DESCRIPTION
The `chart_pregenerator` service was excluded from eslint — `js-lint` only globbed `client/**/*.js` — so style issues and stray debug statements there went unnoticed (e.g. the `console.dir` cleaned up here, originally flagged in the #2299 review).

## Changes

**Add lint coverage**
- `package.json`: `js-lint` now also lints `chart_pregenerator/src/**/*.jsx`, so `make eslint` / CI cover it going forward.
- `.eslintrc.js`: an `overrides` block scopes `chart_pregenerator/**` as a **Node service** — `no-console` is off (console is the service's logging mechanism; stripping `console.error` from catch blocks would be wrong) and `import/extensions` is off (it imports shared chart components without extensions, resolved by esbuild/babel/jest). Test files remain ignored, consistent with the existing project-wide `*.test.js` ignore.

**Fix the violations this surfaced** (`lib.jsx`, `server.jsx`)
- Remove a leftover `console.dir(branches, …)` debug statement in `generateTreemapChartSVG`.
- Move an inline comment off an over-length line; parenthesize an arrow param; drop a duplicate blank line; break a long import onto multiple lines.

## Verification
- `npm run js-lint` → 0 errors (only 2 pre-existing `no-console` warnings in unrelated client files remain).
- `chart_pregenerator` jest suite: 6/6 pass, snapshots unchanged (the fixes are cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)