### PR TITLE
fix: add experimental branch to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,10 @@ name: Publish
 
 on:
   push:
-    branches: ['develop', 'prod']
+    branches:
+      - develop
+      - prod
+      - experimental
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
Add experimental branch to publish workflow. Pushes branch to GHCR.

Part of work for https://github.com/freedomofpress/infrastructure/issues/6984

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing  or renaming a field