### PR TITLE
fix: avoid exceptions on 403 errors

### DIFF
--- a/common/middleware/request_logger.py
+++ b/common/middleware/request_logger.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 import structlog
 
@@ -26,7 +27,7 @@ class RequestLogMiddleware(object):
         self.response_keys = ("charset", "reason_phrase", "status_code")
 
     def process_exception(self, request, exception):
-        if isinstance(exception, (Http404, PermissionDenied)):
+        if not isinstance(exception, (Http404, PermissionDenied)):
             logger.exception("request_failed")
 
     def __call__(self, request):

--- a/common/middleware/request_logger.py
+++ b/common/middleware/request_logger.py
@@ -26,7 +26,7 @@ class RequestLogMiddleware(object):
         self.response_keys = ("charset", "reason_phrase", "status_code")
 
     def process_exception(self, request, exception):
-        if not isinstance(exception, Http404):
+        if isinstance(exception, (Http404, PermissionDenied)):
             logger.exception("request_failed")
 
     def __call__(self, request):

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -4,6 +4,8 @@ from unittest import mock
 import structlog
 from django.conf import settings
 from django.test import TestCase, RequestFactory
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
 from django.contrib.auth import get_user_model
 from wagtail.models import Page
 
@@ -57,6 +59,40 @@ class RequestLogTestCase(TestCase):
         log_entry = cap_logs[0]
         self.assertEqual(log_entry["event"], "request_failed")
         self.assertEqual(log_entry["log_level"], "error")
+
+    @mock.patch.object(Page, "serve")
+    def test_request_log_404(self, serve):
+        serve.side_effect = Http404()
+
+        with capture_logs_with_contextvars() as cap_logs:
+            with self.modify_settings(
+                MIDDLEWARE={
+                    "append": "common.middleware.request_logger.RequestLogMiddleware",
+                }
+            ):
+                self.client.get("/")
+
+        log_entry = cap_logs[0]
+        self.assertEqual(log_entry["event"], "request_finished")
+        self.assertEqual(log_entry["log_level"], "info")
+        self.assertEqual(log_entry["response"]["status_code"], 404)
+
+    @mock.patch.object(Page, "serve")
+    def test_request_log_permission_denied(self, serve):
+        serve.side_effect = PermissionDenied()
+
+        with capture_logs_with_contextvars() as cap_logs:
+            with self.modify_settings(
+                MIDDLEWARE={
+                    "append": "common.middleware.request_logger.RequestLogMiddleware",
+                }
+            ):
+                self.client.get("/")
+
+        log_entry = cap_logs[0]
+        self.assertEqual(log_entry["event"], "request_finished")
+        self.assertEqual(log_entry["log_level"], "info")
+        self.assertEqual(log_entry["response"]["status_code"], 403)
 
     def test_request_log_finished(self):
         response = mock.Mock(


### PR DESCRIPTION
## Description
Avoid exceptions on 403s

Fixes https://github.com/freedomofpress/pressfreedomtracker.us/issues/2326

Changes proposed in this pull request:

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field