### PR TITLE
fix: replace bleach with nh3 for HTML sanitization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,7 @@ lint: ruff
 
 .PHONY: ruff
 ruff: ## Runs ruff linting in Python3 container.
-	@docker run --rm -v $(PWD):/code -w /code --name fpf_www_ruff --rm \
-			python:3.14.6-slim-trixie \
-			bash -c "pip install -q ruff && ruff check && ruff format --check"
+	@docker compose run --rm -T django /bin/bash -c "ruff check && ruff format --check"
 
 .PHONY: dev-init
 dev-init: ## Initialize docker environment for developer workflow

--- a/common/blocks.py
+++ b/common/blocks.py
@@ -9,7 +9,7 @@ from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.rich_text import RichText
 
-import bleach
+import nh3
 
 from common.choices import BACKGROUND_COLOR_CHOICES
 from common.models.charts import (
@@ -194,7 +194,7 @@ class TweetEmbedBlock(blocks.StructBlock):
     def get_searchable_content(self, value):
         tweet_content = value.get("tweet", None)
         if tweet_content and tweet_content.html:
-            return [bleach.clean(tweet_content.html, strip=True, tags={})]
+            return [nh3.clean(tweet_content.html, tags=set())]
         else:
             return []
 

--- a/common/templatetags/common_tags.py
+++ b/common/templatetags/common_tags.py
@@ -8,7 +8,7 @@ from django.utils.html import mark_safe
 
 from wagtail.templatetags.wagtailcore_tags import richtext
 
-import bleach
+import nh3
 from bs4 import BeautifulSoup
 
 
@@ -27,10 +27,15 @@ def richtext_inline(value):
     "Returns HTML-formatted rich text stripped of block level elements"
     text = richtext(value)
     return mark_safe(
-        bleach.clean(
+        nh3.clean(
             text,
-            strip=True,
             tags={"a", "abbr", "acronym", "b", "code", "em", "i", "strong", "span"},
+            attributes={
+                "a": {"href", "title"},
+                "abbr": {"title"},
+                "acronym": {"title"},
+            },
+            link_rel=None,
         )
     )
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -34,10 +34,6 @@ beautifulsoup4==4.15.0 \
     #   -r dev-requirements.in
     #   -r requirements.txt
     #   wagtail
-bleach==6.4.0 \
-    --hash=sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452 \
-    --hash=sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081
-    # via -r requirements.txt
 certifi==2026.6.17 \
     --hash=sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432 \
     --hash=sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
@@ -1009,6 +1005,41 @@ mrml==0.2.3 \
     # via
     #   -r requirements.txt
     #   wagtail-newsletter
+nh3==0.3.6 \
+    --hash=sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56 \
+    --hash=sha256:2411e8c3cee81a1ddd62c2a5d50585c28aa5566d373ad1db92536b95ddb24ef2 \
+    --hash=sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec \
+    --hash=sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0 \
+    --hash=sha256:34d2b0d934156b87ee114f599a3ba9b8b9e17b5d79652ba3a13fa50903de965e \
+    --hash=sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f \
+    --hash=sha256:43bc1ed3fa0716295fabee29ba42b2667e4a51d140b0a68e092170a765474fa6 \
+    --hash=sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae \
+    --hash=sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf \
+    --hash=sha256:4713502748f564fee0633b37b3403783ce0a3af3a3d148ad91025a5bdadb7bc6 \
+    --hash=sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da \
+    --hash=sha256:597a8e843bea00b2eb5520658dc24a9bb032e7fc9e7c2c0c4cd29420220c9796 \
+    --hash=sha256:69bbb92865a693d909db3a700d3c01537533844d0948c1e9323561ce06ecda41 \
+    --hash=sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21 \
+    --hash=sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78 \
+    --hash=sha256:889932a97fb4abb6f95fef1914c0d269ebfb60011e67121c1163059b9449dbb4 \
+    --hash=sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e \
+    --hash=sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25 \
+    --hash=sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e \
+    --hash=sha256:e196fa70c2ff2eb4de7d3df3108f8f358c1d69dff20d45b11f20a5aa227ffb6d \
+    --hash=sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69 \
+    --hash=sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d \
+    --hash=sha256:edb2b4a1a27523e6cc7c417f8d21ce3d005243548b93e56b762b66b0c7f589f9 \
+    --hash=sha256:f2f14b7ae1fca99c4a66c981aac3974e7fbc1ca30a12673d223ae1df76680917 \
+    --hash=sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10 \
+    --hash=sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7 \
+    --hash=sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438
+    # via -r requirements.txt
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via
+    #   -r requirements.txt
+    #   requests-oauthlib
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \
     --hash=sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050
@@ -1788,12 +1819,6 @@ wcwidth==0.8.2 \
     --hash=sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda \
     --hash=sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85
     # via prompt-toolkit
-webencodings==0.5.1 \
-    --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
-    --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-    # via
-    #   -r requirements.txt
-    #   bleach
 whitenoise==6.12.0 \
     --hash=sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad \
     --hash=sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,4 @@
 beautifulsoup4
-bleach>=6.4.0
 Django>=5.2.13,<6.0
 djangorestframework>=3.14
 django-anymail
@@ -20,6 +19,7 @@ Jinja2>=3.1.6
 lxml>=6.1.1
 mailchimp_marketing>=3.0.66
 marshmallow>=3.26.2,<4
+nh3>=0.3
 pillow>=12.3.0
 psycopg[binary]
 Pygments>=2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,6 @@ beautifulsoup4==4.15.0 \
     # via
     #   -r requirements.in
     #   wagtail
-bleach==6.4.0 \
-    --hash=sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452 \
-    --hash=sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081
-    # via -r requirements.in
 certifi==2026.6.17 \
     --hash=sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432 \
     --hash=sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
@@ -812,6 +808,39 @@ mrml==0.2.3 \
     --hash=sha256:ef0adc1afcc7413fa66f5f6881863f002c143bb1a6b43f5f826341d352cb65b0 \
     --hash=sha256:fefcf949f426d8887c995504cbe17c9072ad74430fb4c549eebe0dc7f00770d1
     # via wagtail-newsletter
+nh3==0.3.6 \
+    --hash=sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56 \
+    --hash=sha256:2411e8c3cee81a1ddd62c2a5d50585c28aa5566d373ad1db92536b95ddb24ef2 \
+    --hash=sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec \
+    --hash=sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0 \
+    --hash=sha256:34d2b0d934156b87ee114f599a3ba9b8b9e17b5d79652ba3a13fa50903de965e \
+    --hash=sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f \
+    --hash=sha256:43bc1ed3fa0716295fabee29ba42b2667e4a51d140b0a68e092170a765474fa6 \
+    --hash=sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae \
+    --hash=sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf \
+    --hash=sha256:4713502748f564fee0633b37b3403783ce0a3af3a3d148ad91025a5bdadb7bc6 \
+    --hash=sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da \
+    --hash=sha256:597a8e843bea00b2eb5520658dc24a9bb032e7fc9e7c2c0c4cd29420220c9796 \
+    --hash=sha256:69bbb92865a693d909db3a700d3c01537533844d0948c1e9323561ce06ecda41 \
+    --hash=sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21 \
+    --hash=sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78 \
+    --hash=sha256:889932a97fb4abb6f95fef1914c0d269ebfb60011e67121c1163059b9449dbb4 \
+    --hash=sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e \
+    --hash=sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25 \
+    --hash=sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e \
+    --hash=sha256:e196fa70c2ff2eb4de7d3df3108f8f358c1d69dff20d45b11f20a5aa227ffb6d \
+    --hash=sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69 \
+    --hash=sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d \
+    --hash=sha256:edb2b4a1a27523e6cc7c417f8d21ce3d005243548b93e56b762b66b0c7f589f9 \
+    --hash=sha256:f2f14b7ae1fca99c4a66c981aac3974e7fbc1ca30a12673d223ae1df76680917 \
+    --hash=sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10 \
+    --hash=sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7 \
+    --hash=sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438
+    # via -r requirements.in
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via requests-oauthlib
 openpyxl==3.1.5 \
     --hash=sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2 \
     --hash=sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050
@@ -1361,10 +1390,6 @@ wagtail-newsletter[mailchimp,mrml]==0.2.4 \
     --hash=sha256:a19789be23bb1d5dcf9ade798dde1a36b598751d9f31ba6e4e94bf50488f0aa4 \
     --hash=sha256:cacf44ff81c2429134e6615914fb8c8a3ff3d5220e43f567fb63df2083762b03
     # via -r requirements.in
-webencodings==0.5.1 \
-    --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
-    --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-    # via bleach
 whitenoise==6.12.0 \
     --hash=sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad \
     --hash=sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2


### PR DESCRIPTION
## Description
Bleach is effectively unmaintained upstream, which recommends nh3 (Rust-based ammonia bindings) as the replacement HTML sanitizer.

Same as https://github.com/freedomofpress/freedom.press/pull/3113

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
