### PR TITLE
Renders pregenerated charts in lead graphic section of newsletter

### DIFF
--- a/blog/templates/blog/blog_page_newsletter.html
+++ b/blog/templates/blog/blog_page_newsletter.html
@@ -191,6 +191,22 @@
 								</figcaption>
 								{% endif %}
 							</figure>
+						{% elif lead_item.block_type == "vertical_bar_chart" or lead_item.block_type == "tree_map_chart" or lead_item.block_type == "bubble_map_chart" or lead_item.block_type == "hexbin_map_chart" %}
+							<mj-text>
+								{% if lead_item.value.title %}
+									<p><strong>{{ lead_item.value.title }}</strong></p>
+								{% endif %}
+								<img
+									style="max-width:100%"
+									alt="{{ lead_item.value.description }}"
+									src="{{ lead_item.value.png_snapshot_url }}"
+								>
+							</mj-text>
+							<mj-text>
+								<a href="{% fullpageurl page %}" class="link-external">
+									View interactive chart on the website &rarr;
+								</a>
+							</mj-text>
 						{% else %}
 							<mj-text>
 								<a href="{% fullpageurl page %}" class="link-external">


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

The lead graphic section of newsletters were not rendering the pregenerated charts. This PR adds pregenerated charts to the lead graphic section along with a link to view the interactive chart on the website.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
- Add a chart in the lead graphic section of a BlogPage
- Change the preview to newsletter mode
- Ensure that the chart is rendered correctly in the lead graphic section.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change

<img width="972" height="1680" alt="image" src="https://github.com/user-attachments/assets/0af13713-f465-4457-ae9d-7b1bf6a539a7" />

