### PR TITLE
fix: remove django-autocomplete-light

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -409,7 +409,6 @@ django==5.2.16 \
     # via
     #   -r requirements.txt
     #   django-anymail
-    #   django-autocomplete-light
     #   django-csp
     #   django-debug-toolbar
     #   django-filter
@@ -434,10 +433,6 @@ django==5.2.16 \
 django-anymail==15.0 \
     --hash=sha256:23d8ab6589afe8cc1ae7665c26879814ad192f4c3ed837a2a1868b0a056869e0 \
     --hash=sha256:64d33dd1084bfc8e4e12245f56629be40aa0b0498fc7fc7544d87b9b2048be1e
-    # via -r requirements.txt
-django-autocomplete-light==4.0.0 \
-    --hash=sha256:2d4438320eefe1248ad0543e1d1673449f571afcc5c603fb487e5ed2fe4849cf \
-    --hash=sha256:60ecf1bbc00f8a633c3967443ab745d9945b73cd6b4f7f64f236280c956b7ba4
     # via -r requirements.txt
 django-cprofile-middleware==1.0.5 \
     --hash=sha256:b942185a38f3b582935a55c768f126ce9a6f0cefceee3b5d19e6b307ad129889

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@ beautifulsoup4
 Django>=5.2.13,<6.0
 djangorestframework>=3.14
 django-anymail
-django-autocomplete-light
 django-csp>=3.7
 django-modelcluster>=6.2.1
 django-settings-export

--- a/requirements.txt
+++ b/requirements.txt
@@ -279,7 +279,6 @@ django==5.2.16 \
     # via
     #   -r requirements.in
     #   django-anymail
-    #   django-autocomplete-light
     #   django-csp
     #   django-filter
     #   django-modelcluster
@@ -302,10 +301,6 @@ django==5.2.16 \
 django-anymail==15.0 \
     --hash=sha256:23d8ab6589afe8cc1ae7665c26879814ad192f4c3ed837a2a1868b0a056869e0 \
     --hash=sha256:64d33dd1084bfc8e4e12245f56629be40aa0b0498fc7fc7544d87b9b2048be1e
-    # via -r requirements.in
-django-autocomplete-light==4.0.0 \
-    --hash=sha256:2d4438320eefe1248ad0543e1d1673449f571afcc5c603fb487e5ed2fe4849cf \
-    --hash=sha256:60ecf1bbc00f8a633c3967443ab745d9945b73cd6b4f7f64f236280c956b7ba4
     # via -r requirements.in
 django-csp==4.0 \
     --hash=sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833 \

--- a/tracker/settings/base.py
+++ b/tracker/settings/base.py
@@ -70,8 +70,6 @@ INSTALLED_APPS = [
     "webpack_loader",
     "wagtailautocomplete",
     "widget_tweaks",
-    "dal",
-    "dal_select2",
     "wagtailinventory",
     "wagtail_honeypot",
     "wagtail_newsletter",


### PR DESCRIPTION
## Description
Remove django-autocomplete-light, which is not used by our code.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [X] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field
