### PR TITLE
Always default homepage charts to smallest available timespan

### DIFF
--- a/client/charts/js/lib/utilities.js
+++ b/client/charts/js/lib/utilities.js
@@ -171,10 +171,14 @@ export function resolveDefaultTimePreset(dataset, currentDate, sevenDayEnabled) 
 	if (sevenDayEnabled && filterDatasetByLastNDays(dataset, currentDate, 7).length > 0) {
 		return TIME_PRESETS.SEVEN_DAYS
 	}
-	if (dataset.length > 0 && filterDatasetByLastNWeeks(dataset, currentDate, 4).length === 0) {
-		return TIME_PRESETS.SIX_MONTHS
+	// Otherwise widen to the narrowest window that has data (empty/loading stays 4 weeks).
+	if (dataset.length === 0 || filterDatasetByLastNWeeks(dataset, currentDate, 4).length > 0) {
+		return TIME_PRESETS.FOUR_WEEKS
 	}
-	return TIME_PRESETS.FOUR_WEEKS
+	if (filterDatasetByLastNWeeks(dataset, currentDate, 12).length > 0) {
+		return TIME_PRESETS.TWELVE_WEEKS
+	}
+	return TIME_PRESETS.SIX_MONTHS
 }
 
 export function filterDatasetByFiltersApplied(originalDataset, filtersApplied, currentDate) {

--- a/client/charts/js/tests/utilities.test.js
+++ b/client/charts/js/tests/utilities.test.js
@@ -345,7 +345,8 @@ describe(resolveDefaultTimePreset, () => {
 	const currentDate = new Date(Date.UTC(2024, 4, 15))
 	const withinSevenDays = { date: new Date(Date.UTC(2024, 4, 14)) }   // Tue May 14
 	const withinFourWeeks = { date: new Date(Date.UTC(2024, 4, 1)) }    // Wed May 1 (not in last 7 days)
-	const olderThanFourWeeks = { date: new Date(Date.UTC(2024, 2, 1)) } // Mar 1
+	const olderThanFourWeeks = { date: new Date(Date.UTC(2024, 2, 1)) }    // Mar 1 (in last 12 weeks)
+	const olderThanTwelveWeeks = { date: new Date(Date.UTC(2024, 0, 1)) }  // Jan 1 (beyond 12 weeks)
 
 	test('returns SEVEN_DAYS when enabled and there is data in the last 7 days', () => {
 		expect(resolveDefaultTimePreset([withinSevenDays], currentDate, true))
@@ -362,8 +363,13 @@ describe(resolveDefaultTimePreset, () => {
 			.toBe(TIME_PRESETS.FOUR_WEEKS)
 	})
 
-	test('widens to SIX_MONTHS when there is data but none in the last 4 weeks', () => {
+	test('widens to TWELVE_WEEKS when data is in the last 12 weeks but not the last 4', () => {
 		expect(resolveDefaultTimePreset([olderThanFourWeeks], currentDate, true))
+			.toBe(TIME_PRESETS.TWELVE_WEEKS)
+	})
+
+	test('widens to SIX_MONTHS when data is older than the last 12 weeks', () => {
+		expect(resolveDefaultTimePreset([olderThanTwelveWeeks], currentDate, true))
 			.toBe(TIME_PRESETS.SIX_MONTHS)
 	})
 


### PR DESCRIPTION
One small tweak on top of #2206

For homepage charts, the prior PR had the default timespan cascade like so: 7d (if enabled + data) -> 4w (if data) -> 6mo

This updates it to also include 12w, so it always chooses the smallest available bucket. (7d -> 4w -> 12w -> 6mo)

This likely won't be needed for prod, but staging has no data within 4w and this is preferable and more expected behavior. 