### PR TITLE
Sorts recent incidents by latest updates

### DIFF
--- a/common/models/pages.py
+++ b/common/models/pages.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.functions import Coalesce
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.defaultfilters import truncatewords
@@ -572,7 +573,14 @@ class CategoryPage(MetadataPageMixin, Page):
             request, incident_qs, page_key=DEFAULT_PAGE_KEY, per_page=8, orphans=5
         )
 
-        context["recent_incidents"] = incident_qs
+        context["recent_incidents"] = incident_qs.annotate(
+            # Incidents without any updates have a null latest_update, so
+            # fall back to the incident date to keep them in the ordering.
+            last_update_or_date=Coalesce(
+                "latest_update",
+                "date",
+            ),
+        ).order_by("-last_update_or_date")
         context["entries_page"] = entries
         context["paginator"] = paginator
 

--- a/common/tests/test_category_page.py
+++ b/common/tests/test_category_page.py
@@ -15,7 +15,7 @@ from common.models.settings import IncidentFilterSettings, GeneralIncidentFilter
 from common.tests.factories import CategoryPageFactory
 from common.models.choices import FILTER_CHOICES
 from incident.utils.incident_filter import IncidentFilter
-from incident.tests.factories import IncidentPageFactory
+from incident.tests.factories import IncidentPageFactory, IncidentUpdateFactory
 
 
 class ContextTest(TestCase):
@@ -45,6 +45,23 @@ class ContextTest(TestCase):
 
         self.assertEqual(
             list(context["recent_incidents"]), [incident1, incident2, incident3]
+        )
+
+    def test_unpaginated_recent_incidents_sort_by_updates(self):
+        category1 = CategoryPageFactory()
+        category2 = CategoryPageFactory()
+        incident3 = IncidentPageFactory(categories=[category1], date="2022-01-01")
+        incident1 = IncidentPageFactory(categories=[category1], date="2022-03-01")
+        incident2 = IncidentPageFactory(categories=[category1], date="2022-02-01")
+        IncidentUpdateFactory.create_batch(2, page=incident2, date="2022-04-01")
+        IncidentPageFactory(title="Not relevant", categories=[category2])
+
+        request = RequestFactory().get("/")
+
+        context = category1.get_context(request)
+
+        self.assertEqual(
+            list(context["recent_incidents"]), [incident2, incident1, incident3]
         )
 
     def test_incidents_filtered_by_category__and_choice(self):

--- a/incident/models/incident_index_page.py
+++ b/incident/models/incident_index_page.py
@@ -4,6 +4,7 @@ import json
 from typing import TYPE_CHECKING
 
 from django.db import models
+from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse, StreamingHttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_http_methods
@@ -171,11 +172,21 @@ class IncidentIndexPage(RoutablePageMixin, MetadataPageMixin, Page):
 
     def get_incidents(self):
         """Returns all published incident pages"""
-        return IncidentPage.objects.live().order_by(
-            # Incidents should be in reverse-chronological order by the
-            # incident date, not when they were published.
-            "-date",
-            "path",
+        return (
+            IncidentPage.objects.live()
+            .with_most_recent_update()
+            .annotate(
+                # Incidents without any updates have a null latest_update, so
+                # fall back to the incident date to keep them in the ordering.
+                last_update_or_date=Coalesce(
+                    "latest_update",
+                    "date",
+                ),
+            )
+            .order_by(
+                "-last_update_or_date",
+                "path",
+            )
         )
 
     def get_context(self, request, *args, **kwargs):


### PR DESCRIPTION
Sorts recent incidents in HomePage and Categorypage by latest updates if there are updates, else the incident date.

## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #2126.

Changes proposed in this pull request:
Updates the sort order for recent incidents in HomePage and CategoryPage to use latest_update date if incident updates exist, else fallback to incident date.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
- Add  updates to an incident shown in the recent incidents in homepage
- See that the incidents get sorted with the update date taken into consideration


## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader

### If you made any frontend change
Home page showing incidents sorted by update dates and falling back to incident date if update date doesn't exist.
<img width="1048" height="934" alt="image" src="https://github.com/user-attachments/assets/bba80ba1-1c25-4892-a114-ea407f37447b" />

