### PR TITLE
Adds label for tag checkboxes and tag search

### DIFF
--- a/client/charts/js/components/Autocomplete.jsx
+++ b/client/charts/js/components/Autocomplete.jsx
@@ -151,6 +151,7 @@ const AutoComplete = ({
 
 	return (
 		<>
+			<label htmlFor={id} className="sr-only">{placeholder}</label>
 			<input
 				type="text"
 				name={name}

--- a/client/charts/js/components/CheckBoxBar.jsx
+++ b/client/charts/js/components/CheckBoxBar.jsx
@@ -22,7 +22,7 @@ export default function CheckBoxBar({ label, count, i, onClick, isSelected, barW
 				<input
 					type="checkbox"
 					name="drone"
-					id={"drone" + label}
+					id={`drone-${label}`}
 					checked={isSelected}
 					onChange={onClick}
 					style={{ width: 24, height: 24 }}
@@ -52,7 +52,7 @@ export default function CheckBoxBar({ label, count, i, onClick, isSelected, barW
 							lineHeight: '20px',
 							fontFamily: 'var(--font-base)',
 						}}
-						htmlFor={"drone" + label}
+						htmlFor={`drone-${label}`}
 					>
 						{label}
 					</label>

--- a/client/charts/js/components/CheckBoxBar.jsx
+++ b/client/charts/js/components/CheckBoxBar.jsx
@@ -22,6 +22,7 @@ export default function CheckBoxBar({ label, count, i, onClick, isSelected, barW
 				<input
 					type="checkbox"
 					name="drone"
+					id={"drone" + label}
 					checked={isSelected}
 					onChange={onClick}
 					style={{ width: 24, height: 24 }}
@@ -44,16 +45,17 @@ export default function CheckBoxBar({ label, count, i, onClick, isSelected, barW
 						marginBottom: 0,
 					}}
 				>
-					<div
+					<label
 						style={{
 							color: 'black',
 							fontSize: 14,
 							lineHeight: '20px',
 							fontFamily: 'var(--font-base)',
 						}}
+						htmlFor={"drone" + label}
 					>
 						{label}
-					</div>
+					</label>
 					<div
 						style={{
 							fontFamily: 'var(--font-mono)',

--- a/client/charts/js/components/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`renders Autocomplete with mocked data 1`] = `
 <React.Fragment>
+  <label
+    className="sr-only"
+    htmlFor="id_test autocomplete"
+  >
+    test
+  </label>
   <input
     autoComplete="off"
     className="text-field--single"

--- a/client/charts/js/components/__tests__/__snapshots__/CheckBoxBar.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/CheckBoxBar.test.js.snap
@@ -23,6 +23,7 @@ exports[`renders CheckBoxBar with mocked data 1`] = `
     <input
       checked={false}
       disabled={false}
+      id="dronetest"
       name="drone"
       onChange={[Function]}
       style={
@@ -53,7 +54,8 @@ exports[`renders CheckBoxBar with mocked data 1`] = `
         }
       }
     >
-      <div
+      <label
+        htmlFor="dronetest"
         style={
           {
             "color": "black",
@@ -64,7 +66,7 @@ exports[`renders CheckBoxBar with mocked data 1`] = `
         }
       >
         test
-      </div>
+      </label>
       <div
         style={
           {

--- a/client/charts/js/components/__tests__/__snapshots__/CheckBoxBar.test.js.snap
+++ b/client/charts/js/components/__tests__/__snapshots__/CheckBoxBar.test.js.snap
@@ -23,7 +23,7 @@ exports[`renders CheckBoxBar with mocked data 1`] = `
     <input
       checked={false}
       disabled={false}
-      id="dronetest"
+      id="drone-test"
       name="drone"
       onChange={[Function]}
       style={
@@ -55,7 +55,7 @@ exports[`renders CheckBoxBar with mocked data 1`] = `
       }
     >
       <label
-        htmlFor="dronetest"
+        htmlFor="drone-test"
         style={
           {
             "color": "black",


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #2633.

Changes proposed in this pull request:
- Converts the label to actual label tag for checkbox tags
- Adds a sr-only label for the tags search input

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
- Visually the tags sidebar should look and operate exactly same as before this change
- The accessibility tree should show labels for the tag checkboxes and search input.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
