### PR TITLE
Fixes duplicate IDs in HTML tags

### DIFF
--- a/incident/templates/incident/_category_table.html
+++ b/incident/templates/incident/_category_table.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
-<dl class="details-table__category-fields" aria-labelledby="incident-details-title">
+<dl class="details-table__category-fields" aria-labelledby="{{ category.slug }}-details-title">
 	<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">
 		<a class="text-link text-link--card" href="{% pageurl category %}">
 			{{ category.title }}

--- a/incident/templates/incident/_database_card_details.html
+++ b/incident/templates/incident/_database_card_details.html
@@ -9,7 +9,7 @@
 </button>
 <div class="incident-database-card__details-container database-card-table__container" id="incident-details-{{ incident.pk }}" data-visible="false">
 	<div class="incident-database-card__main-details">
-		<h3 class="heading-table incident-database-card__details-title" id="incident-details-title">Incident Details</h3>
+		<h3 class="heading-table incident-database-card__details-title" id="incident-details-title-{{ incident.pk }}">Incident Details</h3>
 
 		{% include "incident/_database_card_table.html" with incident=incident index=index only %}
 	</div>
@@ -18,8 +18,8 @@
 <div id="category-details-{{ incident.pk }}" class="incident-database-card__category-details database-card-table__container" data-visible="false">
 	{% get_category_details incident index as all_details %}
 	{% for category, category_detail in all_details.items %}
-		<dl class="database-card-table__category-details" aria-labelledby="{{ category.slug }}-details-title">
-			<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title">
+		<dl class="database-card-table__category-details" aria-labelledby="{{ category.slug }}-details-title-{{ incident.pk }}">
+			<h3 class="heading-table category category-{{ category.page_symbol }}" id="{{ category.slug }}-details-title-{{ incident.pk }}">
 				<a class="text-link text-link--card" href="{% pageurl category %}">{{ category.title }}</a>
 			</h3>
 

--- a/incident/templates/incident/_database_card_table.html
+++ b/incident/templates/incident/_database_card_table.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags case_tags %}
 
-<dl class="database-card-table__incident-details" aria-labelledby="incident-details-title">
+<dl class="database-card-table__incident-details" aria-labelledby="incident-details-title-{{ incident.pk }}">
 	{% with incident.latest_update as last_updated %}
 		{% if last_updated and incident.updates.all.exists %}
 			<div class="database-card-table__row database-card-table__row--inline">

--- a/incident/templates/incident/_details_table.html
+++ b/incident/templates/incident/_details_table.html
@@ -1,5 +1,5 @@
 <section class="details-table">
-	<h3 class="heading-table" id="incident-details-title">Incident details</h3>
+	<h3 class="heading-table" id="incident-details-title-{{ incident.pk }}">Incident details</h3>
 	<button class="disclose-summary details-toggle-btn" aria-expanded="true" aria-controls="incident-details" id="details-toggle-btn">
 		Show More
 	</button>

--- a/incident/templates/incident/_incident_details_table.html
+++ b/incident/templates/incident/_incident_details_table.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags case_tags %}
 
-<dl class="details-table__incident-details" aria-labelledby="incident-details-title">
+<dl class="details-table__incident-details" aria-labelledby="incident-details-title-{{ incident.pk }}">
 	{% if incident.updates.all.exists %}
 		{% with latest_update=incident.get_updates_by_desc_date|first %}
 			<div class="details-table__row">


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #1327.

Changes proposed in this pull request:
Adds incident.pk to update the id attributes to not be duplicate.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Check in the all-incidents page, in mobile mode, the ids for "Incident details" are not duplicate.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
