### PR TITLE
Adds cloudflare cache purging on prepub sync toggle

### DIFF
--- a/cloudflare/tests/test_cache_tag_purge.py
+++ b/cloudflare/tests/test_cache_tag_purge.py
@@ -4,7 +4,11 @@ from django.test import TestCase, override_settings
 
 from requests.exceptions import HTTPError, InvalidURL
 
-from cloudflare.utils import purge_all_from_cache, purge_tags_from_cache
+from cloudflare.utils import (
+    purge_all_from_cache,
+    purge_tags_from_cache,
+    purge_urls_from_cache,
+)
 
 
 WAGTAILFRONTENDCACHE_SETTINGS = {
@@ -47,6 +51,31 @@ class TestCacheTags(TestCase):
         requests_delete.assert_called_with(
             "https://api.cloudflare.com/client/v4/zones/CLOUDFLARE_FAKE_ZONE/purge_cache",
             json={},
+            headers={
+                "X-Auth-Email": "CLOUDFLARE_FAKE_EMAIL",
+                "Content-Type": "application/json",
+                "X-Auth-Key": "CLOUDFLARE_FAKE_TOKEN",
+            },
+            timeout=5,
+        )
+
+
+@override_settings(WAGTAILFRONTENDCACHE=WAGTAILFRONTENDCACHE_SETTINGS)
+class TestCacheURLs(TestCase):
+    @patch("cloudflare.utils.requests.delete")
+    def test_cache_url_purge(self, requests_delete):
+        """
+        Should fire an appropriate looking HTTP request to Cloudflare's
+        purge API endpoint
+        """
+        purge_urls_from_cache(
+            ["http://example.com/path-1/", "http://example.com/path-2/"]
+        )
+        requests_delete.assert_called_with(
+            "https://api.cloudflare.com/client/v4/zones/CLOUDFLARE_FAKE_ZONE/purge_cache",
+            json={
+                "files": ["http://example.com/path-1/", "http://example.com/path-2/"]
+            },
             headers={
                 "X-Auth-Email": "CLOUDFLARE_FAKE_EMAIL",
                 "Content-Type": "application/json",

--- a/cloudflare/utils.py
+++ b/cloudflare/utils.py
@@ -8,7 +8,7 @@ import requests
 import structlog
 
 
-__all__ = ["purge_all_from_cache", "purge_tags_from_cache"]
+__all__ = ["purge_all_from_cache", "purge_tags_from_cache", "purge_urls_from_cache"]
 
 
 logger = structlog.get_logger("wagtail.frontendcache")
@@ -93,6 +93,12 @@ def purge(backend: CloudflareBackend, data=None) -> None:
 def purge_tags_from_cache(tags: Iterable, backend: CloudflareBackend) -> None:
     "Purge tags by list. Requires an enterprise Cloudflare subscription"
     purge(backend=backend, data={"tags": tags})
+
+
+@for_every_cloudflare_backend
+def purge_urls_from_cache(urls: Iterable, backend: CloudflareBackend) -> None:
+    "Purge urls by list. Requires an enterprise Cloudflare subscription"
+    purge(backend=backend, data={"files": urls})
 
 
 @for_every_cloudflare_backend

--- a/incident/signals.py
+++ b/incident/signals.py
@@ -1,13 +1,23 @@
-from django.db.models.signals import post_delete
+from urllib.parse import urljoin
+
+from django.db.models.signals import post_delete, post_save, pre_save
+from django.dispatch import receiver
+from django.urls import reverse
 
 from wagtail.contrib.frontend_cache.utils import purge_page_from_cache
+from wagtail.models import Site
 from wagtail.signals import page_published
 
 import structlog
 
-from cloudflare.utils import purge_tags_from_cache
+from cloudflare.utils import purge_tags_from_cache, purge_urls_from_cache
 from common.models import CategoryPage
-from incident.models import IncidentIndexPage, IncidentPage
+from home.models import HomePage
+from incident.models import (
+    IncidentIndexPage,
+    IncidentPage,
+    PrepublicationSettings,
+)
 
 
 logger = structlog.get_logger("wagtail.frontendcache")
@@ -37,6 +47,36 @@ def purge_incident_index_from_frontend_cache(**kwargs):
             f"Purged page IncidentIndexPage with title: {incident_index_page.title} and slug: {incident_index_page.slug}"
         )
     purge_tags_from_cache(tags)
+
+
+@receiver(pre_save, sender=PrepublicationSettings)
+def stash_prepub_enabled_state(instance=None, **kwargs):
+    if instance.pk is None:
+        previous = PrepublicationSettings._meta.get_field("is_enabled").get_default()
+    else:
+        previous = (
+            PrepublicationSettings.objects.filter(pk=instance.pk)
+            .values_list("is_enabled", flat=True)
+            .first()
+        )
+    instance._previously_enabled = previous
+
+
+@receiver(post_save, sender=PrepublicationSettings)
+def purge_prepub_list_homepage_from_frontend_cache(instance=None, **kwargs):
+    previously_enabled = getattr(instance, "_previously_enabled", None)
+    if previously_enabled == instance.is_enabled:
+        return
+
+    # Purge prepub list page
+    path = reverse("prepub_list")
+    urls = [urljoin(site.root_url, path) for site in Site.objects.all()]
+    purge_urls_from_cache(urls)
+    logger.info(f"Purged URLs from cache: {urls}")
+
+    # Purge homepage
+    for home_page in HomePage.objects.live():
+        purge_page_from_cache(home_page)
 
 
 # IncidentPage cache

--- a/incident/tests/test_frontend_cache_purge.py
+++ b/incident/tests/test_frontend_cache_purge.py
@@ -1,11 +1,14 @@
 from unittest.mock import patch
+from urllib.parse import urljoin
 
 from django.test import Client, TestCase
+from django.urls import reverse
 
 from wagtail.models import Site
 
 from common.tests.factories import CategoryPageFactory
-from incident.models import IncidentCategorization
+from home.tests.factories import HomePageFactory
+from incident.models import IncidentCategorization, PrepublicationSettings
 from incident.tests.factories import (
     IncidentIndexPageFactory,
     IncidentPageFactory,
@@ -108,3 +111,34 @@ class TestIncidentPageCachePurge(TestCase):
         incident1.save_revision().publish()  # Should not trigger purge on incident2
 
         assert_never_called_with(purge_page_from_cache, incident2)
+
+
+@patch("incident.signals.purge_page_from_cache")
+@patch("incident.signals.purge_urls_from_cache")
+class TestPrepublicationSettingsCachePurge(TestCase):
+    def setUp(self):
+        self.prepub_list_url = urljoin(
+            Site.objects.get().root_url, reverse("prepub_list")
+        )
+        self.home_page = HomePageFactory()
+
+    def test_cache_purged_when_feature_enabled(
+        self, purge_urls_from_cache, purge_page_from_cache
+    ):
+        "Should purge the unconfirmed incidents URL when the feature is enabled"
+        PrepublicationSettings.objects.create(is_enabled=True)
+
+        purge_urls_from_cache.assert_called_once_with([self.prepub_list_url])
+        purge_page_from_cache.assert_called_once_with(self.home_page)
+
+    def test_cache_purged_when_feature_toggled(
+        self, purge_urls_from_cache, purge_page_from_cache
+    ):
+        "Should purge the unconfirmed incidents when the feature is toggled"
+        prepub_settings = PrepublicationSettings.objects.create()
+        self.assertFalse(purge_urls_from_cache.called)
+
+        prepub_settings.is_enabled = True
+        prepub_settings.save()
+        purge_urls_from_cache.assert_called_once_with([self.prepub_list_url])
+        purge_page_from_cache.assert_called_once_with(self.home_page)


### PR DESCRIPTION
## Description

<!-- If this is a deploy PR, please append `?template=deploy.md` to the current URL -->

Fixes #2553.

Changes proposed in this pull request:
On toggling is_enabled in settings for Prepub sync, a cache purge is trigger for the URL of prepub list page, and the HomePage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Vulnerabilities update
- [ ] Config changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires an admin update after deploy
- [ ] Includes a database migration removing or renaming a field

## Testing

How should the reviewer test this PR?
Write out any special testing steps here.

## Checklist

### General checks

- [x] Linting and tests pass locally
- [x] The website and the changes are functional in Tor Browser
- [x] There is no conflicting migrations
- [x] Any CSP related changes required has been updated (check at least both firefox & chrome)
- [x] The changes are accessible using keyboard and screenreader
